### PR TITLE
Fix staticmethods interfering with dep resolution

### DIFF
--- a/mountaineer/__tests__/dependencies/test_base.py
+++ b/mountaineer/__tests__/dependencies/test_base.py
@@ -1,0 +1,46 @@
+import pytest
+from fastapi import Depends
+
+from mountaineer.dependencies.base import DependenciesBase, get_function_dependencies
+
+
+async def dep_1():
+    return 1
+
+
+async def dep_2(
+    dep_1: int = Depends(dep_1),
+):
+    return 2 + dep_1
+
+
+def dep_3(dep_2: int = Depends(dep_2)):
+    return dep_2 + 3
+
+
+class ExampleDependencies(DependenciesBase):
+    dep_1 = dep_1
+    dep_2 = dep_2
+    dep_3 = dep_3
+
+
+@pytest.mark.asyncio
+async def test_get_function_dependencies_recursive():
+    dep_fn = ExampleDependencies.dep_3
+
+    async with get_function_dependencies(callable=dep_fn) as values:
+        result = dep_fn(**values)
+        assert result == 6
+
+
+def test_incorrect_static_method():
+    """
+    Ensure static methods will throw an error on init
+
+    """
+    with pytest.raises(TypeError):
+
+        class ExampleIncorrectDependency(DependenciesBase):
+            @staticmethod
+            async def dep_1():
+                return 1

--- a/mountaineer/config.py
+++ b/mountaineer/config.py
@@ -22,7 +22,7 @@ APP_CONFIG: ConfigBase | None = None
 def register_config(config: ConfigBase):
     global APP_CONFIG
 
-    if APP_CONFIG is not None:
+    if APP_CONFIG is not None and APP_CONFIG != config:
         raise ValueError("Config already registered")
 
     APP_CONFIG = config

--- a/mountaineer/database/dependencies.py
+++ b/mountaineer/database/dependencies.py
@@ -2,30 +2,33 @@ from fastapi import Depends
 from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker, create_async_engine
 
 from mountaineer.database.config import DatabaseConfig
-from mountaineer.dependencies import CoreDependencies
+from mountaineer.dependencies import CoreDependencies, DependenciesBase
 
 
-class DatabaseDependencies:
+def get_db(
+    config: DatabaseConfig = Depends(
+        CoreDependencies.get_config_with_type(DatabaseConfig)
+    ),
+):
+    if not config.SQLALCHEMY_DATABASE_URI:
+        raise RuntimeError("No SQLALCHEMY_DATABASE_URI set")
+
+    return create_async_engine(str(config.SQLALCHEMY_DATABASE_URI))
+
+
+async def get_db_session(
+    engine: AsyncEngine = Depends(get_db),
+):
+    session_maker = async_sessionmaker(engine, expire_on_commit=False)
+    async with session_maker() as session:
+        yield session
+
+
+class DatabaseDependencies(DependenciesBase):
     """
     Dependencies for use in API endpoint routes.
 
     """
 
-    @staticmethod
-    def get_db(
-        config: DatabaseConfig = Depends(
-            CoreDependencies.get_config_with_type(DatabaseConfig)
-        ),
-    ):
-        if not config.SQLALCHEMY_DATABASE_URI:
-            raise RuntimeError("No SQLALCHEMY_DATABASE_URI set")
-
-        return create_async_engine(str(config.SQLALCHEMY_DATABASE_URI))
-
-    @staticmethod
-    async def get_db_session(
-        engine: AsyncEngine = Depends(get_db),
-    ):
-        session_maker = async_sessionmaker(engine, expire_on_commit=False)
-        async with session_maker() as session:
-            yield session
+    get_db = get_db
+    get_db_session = get_db_session

--- a/mountaineer/dependencies/__init__.py
+++ b/mountaineer/dependencies/__init__.py
@@ -1,0 +1,2 @@
+from .base import DependenciesBase, get_function_dependencies  # noqa: F401
+from .core import CoreDependencies  # noqa: F401

--- a/mountaineer/dependencies/core.py
+++ b/mountaineer/dependencies/core.py
@@ -1,0 +1,24 @@
+from typing import Type, TypeVar
+
+from pydantic_settings import BaseSettings
+
+from mountaineer.config import get_config
+from mountaineer.dependencies.base import DependenciesBase
+
+T = TypeVar("T", bound=BaseSettings)
+
+
+def get_config_with_type(required_type: Type[T]):
+    def internal_dependency() -> T:
+        config = get_config()
+        if not isinstance(config, required_type):
+            raise TypeError(
+                f"Expected config to inherit from {required_type}, {type(config)} is not a valid subclass"
+            )
+        return config
+
+    return internal_dependency
+
+
+class CoreDependencies(DependenciesBase):
+    get_config_with_type = get_config_with_type

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,4 +1,4 @@
 {
-  "venv": "filzl-8UmcSDDX-py3.11",
+  "venv": "mountaineer-WHAdwfD0-py3.11",
   "venvPath": "/Users/piercefreeman/Library/Caches/pypoetry/virtualenvs"
 }


### PR DESCRIPTION
Our previous approach to defining core dependencies looked like this:

```python
class CoreDependencies:
  @staticmethod
  async def dep_1():
    pass

  @staticmethod
  def dep_2(dep_1: int = Depends(dep_1)):
    pass
```

The class container was just intended for convenience, so all related dependencies could be located from one place. However, when referencing another dependency in the same file (Depends(dep_1)) we will actually be passing the full staticmethod(func) decorated function, versus the original function itself.

FastAPI's dependency resolution layer recursively resolves dependencies referenced from other dependencies. It supports sync and async dependencies, which it does via `inspect` utilities to figure out what object we're dealing with. Staticmethods break the async inspection since staticmethod() is a shortcut for a regular function, not a coroutine. As such we will fail to resolve nested async dependencies with the @staticmethod definition approach.

This PR:
- Switches the convention to assign the functions to the class after they're already defined in a global namespace, which removes the need to use @staticmethod
- Adds a new metaclass to validate that there are no static methods defined within each dependency class