### PR TITLE
Resolve package/filename caps mismatch

### DIFF
--- a/mountaineer/__tests__/test_watch.py
+++ b/mountaineer/__tests__/test_watch.py
@@ -1,4 +1,6 @@
+from json import dumps as json_dumps
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -52,3 +54,64 @@ def test_merge_paths(paths: list[str], expected_paths: list[str]):
     assert set(handler.merge_paths(paths)) == {
         str(Path(path).absolute()) for path in expected_paths
     }
+
+
+@pytest.mark.parametrize(
+    "package_name, filename",
+    [
+        ("my-awesome-project", "my_awesome_project.pth"),
+        ("MyAwesomeProject", "myawesomeproject.pth"),
+    ],
+)
+def test_resolve_symbolic_links(package_name: str, filename: str, tmpdir: str):
+    # pth files are in txt format and have an explicit link
+    # to the real file
+    tmp_root = Path(tmpdir)
+    (tmp_root / filename).write_text("/path/to/realfile")
+
+    watchdog = PackageWatchdog("mountaineer", [])
+    with patch("importlib.metadata.Distribution") as mock_distribution:
+        mock_distribution.name = package_name
+        mock_distribution.files = [
+            tmp_root / filename,
+            tmp_root / "other_file",
+        ]
+        mock_distribution.locate_file.side_effect = lambda x: x
+
+        assert watchdog.resolve_package_path(mock_distribution) == "/path/to/realfile"
+
+
+@pytest.mark.parametrize(
+    "package_name, egg_info_name",
+    [
+        (
+            "my-awesome-project",
+            "my_awesome_project-0.1.0.dist-info",
+        ),
+        (
+            "MyAwesomeProject",
+            "MyAwesomeProject-0.1.0.dist-info",
+        ),
+    ],
+)
+def test_resolve_dist_links(tmpdir: str, package_name: str, egg_info_name: str):
+    # direct_url.json files are located within the application's egginfo
+    # directory within a local venv
+    tmp_root = Path(tmpdir)
+    egg_info_path = tmp_root / egg_info_name
+    egg_info_path.mkdir(exist_ok=True)
+
+    (egg_info_path / "direct_url.json").write_text(
+        json_dumps({"dir_info": {"editable": True}, "url": "file:///path/to/realfile"})
+    )
+
+    watchdog = PackageWatchdog("mountaineer", [])
+    with patch("importlib.metadata.Distribution") as mock_distribution:
+        mock_distribution.name = package_name
+        mock_distribution.files = [
+            egg_info_path / "direct_url.json",
+            tmp_root / "other_file",
+        ]
+        mock_distribution.locate_file.side_effect = lambda x: x
+
+        assert watchdog.resolve_package_path(mock_distribution) == "/path/to/realfile"

--- a/mountaineer/watch.py
+++ b/mountaineer/watch.py
@@ -191,20 +191,24 @@ class PackageWatchdog:
         # https://the-hitchhikers-guide-to-packaging.readthedocs.io/en/latest/introduction.html
         # "Path configuration files have an extension of .pth, and each line must
         # contain a single path that will be appended to sys.path."
-        package_name = dist.name.replace("-", "_")
+        package_name = dist.name.replace("-", "_").lower()
         symbolic_links = [
-            path for path in (dist.files or []) if path.name == f"{package_name}.pth"
+            path
+            for path in (dist.files or [])
+            if path.name.lower() == f"{package_name}.pth"
         ]
         dist_links = [
             path
             for path in (dist.files or [])
             if path.name == "direct_url.json"
-            and re_search(package_name + r"-[0-9-.]+\.dist-info", path.parent.name)
+            and re_search(
+                package_name + r"-[0-9-.]+\.dist-info", path.parent.name.lower()
+            )
         ]
         explicit_links = [
             path
             for path in (dist.files or [])
-            if path.parent.name == package_name
+            if path.parent.name.lower() == package_name
             and (
                 # Sanity check that the parent is the high level project directory
                 # by looking for common base files


### PR DESCRIPTION
Different package managers have different conventions when it comes to symlinking the current project into the `site-packages` folder. Poetry relies on lowercase `.pth` files, vanilla venvs relies on mirroring the case of the parent project in the dist-info directory, etc.

In this PR we make our watcher a bit more flexible to resolve package names regardless of the case. We also add test coverage for symbolic links and dist links, based on our observation of the local paths installed after we run `create-mountaineer-app` with different configurations.

Addresses: https://github.com/piercefreeman/mountaineer/issues/40