### PR TITLE
Support enums in client-side useServer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ test-create-mountaineer-app-integrations:
 
 define test-common
 	echo "Running tests for $(2)..."
-	@(cd $(1) && poetry run pytest -W error $(2))
+	@(cd $(1) && poetry run pytest -W error $(test-args) $(2))
 endef
 
 define test-rust-common

--- a/mountaineer/client_builder/build_schemas.py
+++ b/mountaineer/client_builder/build_schemas.py
@@ -184,15 +184,15 @@ class OpenAPIToTypescriptSchemaConverter:
 
         for enum_value in model.enum:
             # If the enum is an integer, we need to escape it
-            enum_key: TSLiteral
+            enum_key: str
             if isinstance(enum_value, (int, float)):
-                enum_key = TSLiteral(f"VALUE_{enum_value}")
+                enum_key = f"Value__{enum_value}"
             elif isinstance(enum_value, str):
-                enum_key = TSLiteral(enum_value.upper())
+                enum_key = camelize(enum_value, uppercase_first_letter=True)
             else:
                 raise ValueError(f"Invalid enum value: {enum_value}")
 
-            fields[enum_key] = enum_value
+            fields[TSLiteral(enum_key)] = enum_value
 
         # Enums use an equal assignment syntax
         interface_body = python_payload_to_typescript(fields).replace(":", " =")

--- a/mountaineer/client_builder/build_schemas.py
+++ b/mountaineer/client_builder/build_schemas.py
@@ -1,7 +1,7 @@
 """
 Generator for TypeScript interfaces from OpenAPI specifications.
 """
-from typing import Dict, Iterator, Type, get_args, get_origin
+from typing import Any, Dict, Iterator, Type, get_args, get_origin
 
 from inflection import camelize
 from pydantic import BaseModel, create_model
@@ -12,7 +12,11 @@ from mountaineer.client_builder.openapi import (
     OpenAPISchema,
     OpenAPISchemaType,
 )
-from mountaineer.client_builder.typescript import map_openapi_type_to_ts
+from mountaineer.client_builder.typescript import (
+    TSLiteral,
+    map_openapi_type_to_ts,
+    python_payload_to_typescript,
+)
 
 
 class OpenAPIToTypescriptSchemaConverter:
@@ -55,9 +59,6 @@ class OpenAPIToTypescriptSchemaConverter:
         return synthetic_model.model_json_schema()
 
     def convert_to_typescript(self, parsed_spec: OpenAPISchema):
-        # components = parsed_spec.get('components', {})
-        # schemas = components.get('schemas', {})
-
         # Fetch all the dependent models
         all_models = list(self.gather_all_models(parsed_spec))
 
@@ -76,7 +77,10 @@ class OpenAPIToTypescriptSchemaConverter:
         """
 
         def walk_models(property: OpenAPIProperty) -> Iterator[OpenAPIProperty]:
-            if property.variable_type == OpenAPISchemaType.OBJECT:
+            if (
+                property.variable_type == OpenAPISchemaType.OBJECT
+                or property.enum is not None
+            ):
                 yield property
             if property.ref is not None:
                 yield from walk_models(self.resolve_ref(property.ref, base))
@@ -115,6 +119,14 @@ class OpenAPIToTypescriptSchemaConverter:
         return current_obj
 
     def convert_schema_to_interface(self, model: OpenAPIProperty, base: BaseModel):
+        if model.variable_type == OpenAPISchemaType.OBJECT:
+            return self._convert_object_to_interface(model, base)
+        elif model.enum is not None:
+            return self._convert_enum_to_interface(model)
+        else:
+            raise ValueError(f"Unknown model type: {model}")
+
+    def _convert_object_to_interface(self, model: OpenAPIProperty, base: BaseModel):
         fields = []
 
         # We have to support arrays with one and multiple values
@@ -158,6 +170,35 @@ class OpenAPIToTypescriptSchemaConverter:
 
         interface_body = "\n".join(fields)
         interface_full = f"interface {self.get_typescript_interface_name(model)} {{\n{interface_body}\n}}"
+
+        if self.export_interface:
+            interface_full = f"export {interface_full}"
+
+        return interface_full
+
+    def _convert_enum_to_interface(self, model: OpenAPIProperty):
+        fields: dict[str, Any] = {}
+
+        if not model.enum:
+            raise ValueError(f"Model {model} is not an enum")
+
+        for enum_value in model.enum:
+            # If the enum is an integer, we need to escape it
+            enum_key: TSLiteral
+            if isinstance(enum_value, (int, float)):
+                enum_key = TSLiteral(f"VALUE_{enum_value}")
+            elif isinstance(enum_value, str):
+                enum_key = TSLiteral(enum_value.upper())
+            else:
+                raise ValueError(f"Invalid enum value: {enum_value}")
+
+            fields[enum_key] = enum_value
+
+        # Enums use an equal assignment syntax
+        interface_body = python_payload_to_typescript(fields).replace(":", " =")
+        interface_full = (
+            f"enum {self.get_typescript_interface_name(model)} {interface_body}"
+        )
 
         if self.export_interface:
             interface_full = f"export {interface_full}"

--- a/mountaineer/client_builder/builder.py
+++ b/mountaineer/client_builder/builder.py
@@ -102,7 +102,7 @@ class ClientBuilder:
             ).items():
                 schemas[schema_name] = component
 
-            # Convert the sideeffect routes
+            # Convert all the other models defined in sideeffect routes
             for schema_name, component in base.components.schemas.items():
                 schemas[
                     schema_name

--- a/mountaineer/client_builder/openapi.py
+++ b/mountaineer/client_builder/openapi.py
@@ -61,6 +61,9 @@ class OpenAPIProperty(BaseModel):
     ref: str | None = Field(alias="$ref", default=None)
     # Array of another type
     items: Optional["OpenAPIProperty"] = None
+    # Enum type
+    enum: list[Any] | None = None
+
     # Pointer to multiple possible subtypes
     anyOf: list["OpenAPIProperty"] = []
 
@@ -69,8 +72,10 @@ class OpenAPIProperty(BaseModel):
     # Validator to ensure that one of the optional values is set
     @model_validator(mode="after")
     def check_provided_value(self) -> "OpenAPIProperty":
-        if not any([self.variable_type, self.ref, self.items, self.anyOf]):
-            raise ValueError("One of variable_type, $ref, anyOf, or items must be set")
+        if not any([self.variable_type, self.ref, self.items, self.anyOf, self.enum]):
+            raise ValueError(
+                "One of variable_type, $ref, anyOf, enum, or items must be set"
+            )
         return self
 
     def __hash__(self):


### PR DESCRIPTION
Add support for passing enums from the server to the client views.

### OpenAPI Definition

When Pydantic models contain enums, they are converted to an OpenAPI property with a list of `enum` values. These values can be a single type or mixed types. When there is a single property type, the property takes on the common type. When mixed type, the enum values are specified without an prevailing type. In this example `MyEnum` is a Python `Enum` and the others inherit from `IntEnum` and `StrEnum` respectively.

```json
{
    "$defs": {
        "MyEnum": {
            "enum": [
                "value_1",
                5
            ],
            "title": "MyEnum"
        },
        "MyIntEnum": {
            "enum": [
                1,
                2
            ],
            "title": "MyIntEnum",
            "type": "integer"
        },
        "MyStrEnum": {
            "enum": [
                "value_1",
                "value_2"
            ],
            "title": "MyStrEnum",
            "type": "string"
        }
    },
    "properties": {
        "a": {
            "$ref": "#/$defs/MyStrEnum"
        },
        "b": {
            "$ref": "#/$defs/MyIntEnum"
        },
        "c": {
            "$ref": "#/$defs/MyEnum"
        }
    },
    "required": [
        "a",
        "b",
        "c"
    ],
    "title": "MyModel",
    "type": "object"
}
```

This PR adds new handling for enum values, where we create a TypeScript enum definition within `/models.ts` if a definition is detected in the component layer. This builds on top of our existing `convert_schema_to_interface` logic to create an enum where ever we are traversing the schema for objects.

### Enum Keys

The OpenAPI schema provides less information than our Pydantic model, however, since we are only given the enum values but not the original enum names. To maintain our Pydantic->OpenAPI->Typescript conversion logic, we make the decision to auto-generate the enum key names from the openapi values.

For string values this conversion is trivial, since we can just use the string values as the keys themselves. For integers we need to generate a non-integer key (since integers themselves can't be key values). We standardize on the `Value__{val}` convention. In both cases, we use PascalCase formatted enum values since this is the convention in TypeScript.

### Final Result

The final result looks like:

```typescript
export enum StrEnum {
Value1 = 'value_1',
Value2 = 'value_2',
}

export enum IntEnum {
Value__1 = 1,
Value__2 = 2,
}
```
