### PR TITLE
Update types to be compatible with pyright

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 ci_webapp/**/* linguist-detectable=false
-project_template/**/* linguist-detectable=false
+create_mountaineer_app/**/* linguist-detectable=false

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
+name = "anstream"
+version = "0.6.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+dependencies = [
+ "anstyle",
+ "windows-sys",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -113,6 +161,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
 name = "criterion"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -186,16 +240,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
-name = "env_logger"
-version = "0.9.3"
+name = "env_filter"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
+checksum = "a009aa4810eb158359dda09d0c87378e4bbb89b5a801f016885a4707ba24f7ea"
 dependencies = [
- "atty",
- "humantime",
  "log",
  "regex",
- "termcolor",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c012a26a7f605efc424dd53697843a72be7dc86ad2d01f7814337794a12231d"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "humantime",
+ "log",
 ]
 
 [[package]]
@@ -682,15 +746,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69758bda2e78f098e4ccb393021a0963bb3442eac05f135c30f61b7370bbafae"
 
 [[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "textwrap"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -717,6 +772,12 @@ name = "unindent"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7de7d73e1754487cb58364ee906a499937a0dfabd86bcb980fa99ec8c8fa2ce"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "v8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ v8 = "0.82.0"
 lazy_static = "1.4.0"
 pyo3 = { version = "0.20", features = ["extension-module"] }
 log = "0.4"
-env_logger = "0.9"
+env_logger = "0.11"
 
 # Thread cancellation needs OS bindings
 libc = "0.2"

--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,10 @@ define lint-common
 	echo "Running linting for $(2)..."
 	@(cd $(1) && poetry run ruff format $(2))
 	@(cd $(1) && poetry run ruff check --fix $(2))
+	echo "Running mypy for $(2)..."
 	@(cd $(1) && poetry run mypy $(2))
+	echo "Running pyright for $(2)..."
+	@(cd $(1) && poetry run pyright $(2))
 endef
 
 define lint-validation-common

--- a/ci_webapp/ci_webapp/cli.py
+++ b/ci_webapp/ci_webapp/cli.py
@@ -9,7 +9,7 @@ def runserver():
         webservice="ci_webapp.main:app",
         webcontroller="ci_webapp.app:controller",
         port=5006,
-        subscribe_to_fizl=True,
+        subscribe_to_mountaineer=True,
     )
 
 
@@ -18,5 +18,5 @@ def watch():
     handle_watch(
         package="ci_webapp",
         webcontroller="ci_webapp.app:controller",
-        subscribe_to_fizl=True,
+        subscribe_to_mountaineer=True,
     )

--- a/ci_webapp/ci_webapp/controllers/home.py
+++ b/ci_webapp/ci_webapp/controllers/home.py
@@ -1,9 +1,7 @@
 from uuid import UUID, uuid4
 
 from fastapi import Request
-from mountaineer.actions import passthrough, sideeffect
-from mountaineer.controller import ControllerBase
-from mountaineer.render import Metadata, RenderBase
+from mountaineer import ControllerBase, Metadata, RenderBase, passthrough, sideeffect
 from pydantic import BaseModel
 
 

--- a/ci_webapp/poetry.lock
+++ b/ci_webapp/poetry.lock
@@ -380,6 +380,20 @@ files = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.8.0"
+description = "Node.js virtual environment builder"
+optional = false
+python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*"
+files = [
+    {file = "nodeenv-1.8.0-py2.py3-none-any.whl", hash = "sha256:df865724bb3c3adc86b3876fa209771517b0cfe596beff01a92700e0e8be4cec"},
+    {file = "nodeenv-1.8.0.tar.gz", hash = "sha256:d51e0c37e64fbf47d017feac3145cdbb58836d7eee8c6f6d3b6880c5456227d2"},
+]
+
+[package.dependencies]
+setuptools = "*"
+
+[[package]]
 name = "packaging"
 version = "23.2"
 description = "Core utilities for Python packages"
@@ -520,6 +534,24 @@ toml = ["tomli (>=2.0.1)"]
 yaml = ["pyyaml (>=6.0.1)"]
 
 [[package]]
+name = "pyright"
+version = "1.1.352"
+description = "Command line wrapper for pyright"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pyright-1.1.352-py3-none-any.whl", hash = "sha256:0040cf173c6a60704e553bfd129dfe54de59cc76d0b2b80f77cfab4f50701d64"},
+    {file = "pyright-1.1.352.tar.gz", hash = "sha256:a621c0dfbcf1291b3610641a07380fefaa1d0e182890a1b2a7f13b446e8109a9"},
+]
+
+[package.dependencies]
+nodeenv = ">=1.6.0"
+
+[package.extras]
+all = ["twine (>=3.4.1)"]
+dev = ["twine (>=3.4.1)"]
+
+[[package]]
 name = "python-dotenv"
 version = "1.0.1"
 description = "Read key-value pairs from a .env file and set them as environment variables"
@@ -617,6 +649,22 @@ files = [
     {file = "ruff-0.1.15-py3-none-win_arm64.whl", hash = "sha256:9a933dfb1c14ec7a33cceb1e49ec4a16b51ce3c20fd42663198746efc0427360"},
     {file = "ruff-0.1.15.tar.gz", hash = "sha256:f6dfa8c1b21c913c326919056c390966648b680966febcb796cc9d1aaab8564e"},
 ]
+
+[[package]]
+name = "setuptools"
+version = "69.1.1"
+description = "Easily download, build, install, upgrade, and uninstall Python packages"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "setuptools-69.1.1-py3-none-any.whl", hash = "sha256:02fa291a0471b3a18b2b2481ed902af520c69e8ae0919c13da936542754b4c56"},
+    {file = "setuptools-69.1.1.tar.gz", hash = "sha256:5c0806c7d9af348e6dd3777b4f4dbb42c7ad85b190104837488eab9a7c945cf8"},
+]
+
+[package.extras]
+docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (<7.2.5)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
+testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "packaging (>=23.2)", "pip (>=19.1)", "pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-home (>=0.5)", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-ruff (>=0.2.1)", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
+testing-integration = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "packaging (>=23.2)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
 
 [[package]]
 name = "sniffio"
@@ -1069,4 +1117,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "ff258894569cce8f85f4c9980fd632edc0a5fdbf14dc1d2c75d8157c5524eef6"
+content-hash = "2460bcc69a01ebc2d976aacd914fd30c03ce939befc5892647242589156ff8b4"

--- a/ci_webapp/pyproject.toml
+++ b/ci_webapp/pyproject.toml
@@ -19,6 +19,7 @@ watch = "ci_webapp.cli:watch"
 types-setuptools = "^69.0.0.20240125"
 mypy = "^1.8.0"
 ruff = "^0.1.14"
+pyright = "^1.1.352"
 
 [build-system]
 requires = ["poetry-core"]

--- a/create_mountaineer_app/poetry.lock
+++ b/create_mountaineer_app/poetry.lock
@@ -326,6 +326,20 @@ files = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.8.0"
+description = "Node.js virtual environment builder"
+optional = false
+python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*"
+files = [
+    {file = "nodeenv-1.8.0-py2.py3-none-any.whl", hash = "sha256:df865724bb3c3adc86b3876fa209771517b0cfe596beff01a92700e0e8be4cec"},
+    {file = "nodeenv-1.8.0.tar.gz", hash = "sha256:d51e0c37e64fbf47d017feac3145cdbb58836d7eee8c6f6d3b6880c5456227d2"},
+]
+
+[package.dependencies]
+setuptools = "*"
+
+[[package]]
 name = "packaging"
 version = "23.2"
 description = "Core utilities for Python packages"
@@ -498,6 +512,24 @@ files = [
 typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
 
 [[package]]
+name = "pyright"
+version = "1.1.352"
+description = "Command line wrapper for pyright"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pyright-1.1.352-py3-none-any.whl", hash = "sha256:0040cf173c6a60704e553bfd129dfe54de59cc76d0b2b80f77cfab4f50701d64"},
+    {file = "pyright-1.1.352.tar.gz", hash = "sha256:a621c0dfbcf1291b3610641a07380fefaa1d0e182890a1b2a7f13b446e8109a9"},
+]
+
+[package.dependencies]
+nodeenv = ">=1.6.0"
+
+[package.extras]
+all = ["twine (>=3.4.1)"]
+dev = ["twine (>=3.4.1)"]
+
+[[package]]
 name = "pytest"
 version = "8.0.0"
 description = "pytest: simple powerful testing with Python"
@@ -617,6 +649,22 @@ files = [
 ]
 
 [[package]]
+name = "setuptools"
+version = "69.1.1"
+description = "Easily download, build, install, upgrade, and uninstall Python packages"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "setuptools-69.1.1-py3-none-any.whl", hash = "sha256:02fa291a0471b3a18b2b2481ed902af520c69e8ae0919c13da936542754b4c56"},
+    {file = "setuptools-69.1.1.tar.gz", hash = "sha256:5c0806c7d9af348e6dd3777b4f4dbb42c7ad85b190104837488eab9a7c945cf8"},
+]
+
+[package.extras]
+docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (<7.2.5)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
+testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "packaging (>=23.2)", "pip (>=19.1)", "pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-home (>=0.5)", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-ruff (>=0.2.1)", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
+testing-integration = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "packaging (>=23.2)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
+
+[[package]]
 name = "types-psycopg2"
 version = "2.9.21.20240218"
 description = "Typing stubs for psycopg2"
@@ -683,4 +731,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "5e803306ba6c24c26f2b6a1288266479956b2b09b6c8f0a3250143f579058621"
+content-hash = "3976fc6245285320fd07f6ade039dbc20bb222fc64ff71c522761cc168b810df"

--- a/create_mountaineer_app/pyproject.toml
+++ b/create_mountaineer_app/pyproject.toml
@@ -37,6 +37,9 @@ exclude = ".*/templates/.*"
 [tool.ruff]
 exclude = ["**/templates/**"]
 
+[tool.pyright]
+exclude = ["**/templates"]
+
 [tool.ruff.lint]
 # Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
 # Disable print statements

--- a/create_mountaineer_app/pyproject.toml
+++ b/create_mountaineer_app/pyproject.toml
@@ -25,6 +25,7 @@ pytest-asyncio = "^0.23.4"
 pytest-xdist = "^3.5.0"
 psycopg2 = "^2.9.9"
 types-psycopg2 = "^2.9.21.20240218"
+pyright = "^1.1.352"
 
 [build-system]
 requires = ["poetry-core"]

--- a/mountaineer/__init__.py
+++ b/mountaineer/__init__.py
@@ -20,6 +20,9 @@ from mountaineer.render import (
     RenderBase as RenderBase,
 )
 from mountaineer.render import (
+    ScriptAttribute as ScriptAttribute,
+)
+from mountaineer.render import (
     ThemeColorMeta as ThemeColorMeta,
 )
 from mountaineer.render import (

--- a/mountaineer/__init__.py
+++ b/mountaineer/__init__.py
@@ -1,16 +1,27 @@
-from mountaineer.actions import passthrough, sideeffect  # noqa: F401
-from mountaineer.app import AppController  # noqa: F401
-from mountaineer.config import ConfigBase  # noqa: F401
-from mountaineer.controller import ControllerBase  # noqa: F401
-from mountaineer.dependencies import CoreDependencies  # noqa: F401
-from mountaineer.exceptions import APIException  # noqa: F401
-from mountaineer.js_compiler.postcss import PostCSSBundler  # noqa: F401
-from mountaineer.paths import ManagedViewPath  # noqa: F401
+from mountaineer.actions import passthrough as passthrough
+from mountaineer.actions import sideeffect as sideeffect
+from mountaineer.app import AppController as AppController
+from mountaineer.config import ConfigBase as ConfigBase
+from mountaineer.controller import ControllerBase as ControllerBase
+from mountaineer.dependencies import CoreDependencies as CoreDependencies
+from mountaineer.exceptions import APIException as APIException
+from mountaineer.js_compiler.postcss import PostCSSBundler as PostCSSBundler
+from mountaineer.paths import ManagedViewPath as ManagedViewPath
 from mountaineer.render import (
-    LinkAttribute,  # noqa: F401
-    MetaAttribute,  # noqa: F401
-    Metadata,  # noqa: F401
-    RenderBase,  # noqa: F401
-    ThemeColorMeta,  # noqa: F401
-    ViewportMeta,  # noqa: F401
+    LinkAttribute as LinkAttribute,
+)
+from mountaineer.render import (
+    MetaAttribute as MetaAttribute,
+)
+from mountaineer.render import (
+    Metadata as Metadata,
+)
+from mountaineer.render import (
+    RenderBase as RenderBase,
+)
+from mountaineer.render import (
+    ThemeColorMeta as ThemeColorMeta,
+)
+from mountaineer.render import (
+    ViewportMeta as ViewportMeta,
 )

--- a/mountaineer/__tests__/client_builder/test_build_actions.py
+++ b/mountaineer/__tests__/client_builder/test_build_actions.py
@@ -59,15 +59,17 @@ def test_convert():
 
 EXAMPLE_REQUEST_BODY = ContentBodyDefinition(
     content_type="application/json",
-    content_schema=ContentDefinition(
-        schema_ref=ContentDefinition.Reference(ref="#/components/schemas/ExampleModel")
+    content_schema=ContentDefinition.from_meta(
+        schema_ref=ContentDefinition.Reference.from_meta(
+            ref="#/components/schemas/ExampleModel"
+        )
     ),
 )
 
 EXAMPLE_RESPONSE_200 = ContentBodyDefinition(
     content_type="application/json",
-    content_schema=ContentDefinition(
-        schema_ref=ContentDefinition.Reference(
+    content_schema=ContentDefinition.from_meta(
+        schema_ref=ContentDefinition.Reference.from_meta(
             ref="#/components/schemas/ExampleResponseModel"
         )
     ),
@@ -75,8 +77,8 @@ EXAMPLE_RESPONSE_200 = ContentBodyDefinition(
 
 EXAMPLE_RESPONSE_400 = ContentBodyDefinition(
     content_type="application/json",
-    content_schema=ContentDefinition(
-        schema_ref=ContentDefinition.Reference(
+    content_schema=ContentDefinition.from_meta(
+        schema_ref=ContentDefinition.Reference.from_meta(
             ref="#/components/schemas/HTTPValidationError"
         )
     ),
@@ -136,9 +138,9 @@ EXAMPLE_RESPONSE_400 = ContentBodyDefinition(
                 },
                 parameters=[
                     # All path parameters are required
-                    URLParameterDefinition(
+                    URLParameterDefinition.from_meta(
                         name="item_id",
-                        schema_ref=OpenAPIProperty(
+                        schema_ref=OpenAPIProperty.from_meta(
                             title="",
                             variable_type=OpenAPISchemaType.STRING,
                         ),
@@ -146,9 +148,9 @@ EXAMPLE_RESPONSE_400 = ContentBodyDefinition(
                         required=True,
                     ),
                     # Required query parameter
-                    URLParameterDefinition(
+                    URLParameterDefinition.from_meta(
                         name="query_param_required_id",
-                        schema_ref=OpenAPIProperty(
+                        schema_ref=OpenAPIProperty.from_meta(
                             title="",
                             variable_type=OpenAPISchemaType.STRING,
                         ),
@@ -156,9 +158,9 @@ EXAMPLE_RESPONSE_400 = ContentBodyDefinition(
                         required=True,
                     ),
                     # Optional query parameter
-                    URLParameterDefinition(
+                    URLParameterDefinition.from_meta(
                         name="query_param_optional_id",
-                        schema_ref=OpenAPIProperty(
+                        schema_ref=OpenAPIProperty.from_meta(
                             title="",
                             variable_type=OpenAPISchemaType.STRING,
                         ),

--- a/mountaineer/__tests__/client_builder/test_typescript.py
+++ b/mountaineer/__tests__/client_builder/test_typescript.py
@@ -105,10 +105,10 @@ def test_collapse_repeated_literals(
     "url_parameter, expected_ts_key, expected_ts_type",
     [
         (
-            URLParameterDefinition(
+            URLParameterDefinition.from_meta(
                 name="test",
                 required=True,
-                schema_ref=OpenAPIProperty(
+                schema_ref=OpenAPIProperty.from_meta(
                     format="uuid",
                     variable_type=OpenAPISchemaType.STRING,
                 ),
@@ -125,10 +125,10 @@ def test_collapse_repeated_literals(
                     anyOf=[
                         OpenAPIProperty(
                             format="uuid",
-                            variable_type=OpenAPISchemaType.STRING,
+                            variable_type=OpenAPISchemaType.STRING,  # pyright: ignore
                         ),
                         OpenAPIProperty(
-                            variable_type=OpenAPISchemaType.INTEGER,
+                            variable_type=OpenAPISchemaType.INTEGER,  # pyright: ignore
                         ),
                     ]
                 ),

--- a/mountaineer/__tests__/client_builder/test_typescript.py
+++ b/mountaineer/__tests__/client_builder/test_typescript.py
@@ -118,17 +118,17 @@ def test_collapse_repeated_literals(
             "string",
         ),
         (
-            URLParameterDefinition(
+            URLParameterDefinition.from_meta(
                 name="test",
                 required=True,
                 schema_ref=OpenAPIProperty(
                     anyOf=[
-                        OpenAPIProperty(
+                        OpenAPIProperty.from_meta(
                             format="uuid",
-                            variable_type=OpenAPISchemaType.STRING,  # pyright: ignore
+                            variable_type=OpenAPISchemaType.STRING,
                         ),
-                        OpenAPIProperty(
-                            variable_type=OpenAPISchemaType.INTEGER,  # pyright: ignore
+                        OpenAPIProperty.from_meta(
+                            variable_type=OpenAPISchemaType.INTEGER,
                         ),
                     ]
                 ),

--- a/mountaineer/__tests__/test_config.py
+++ b/mountaineer/__tests__/test_config.py
@@ -1,0 +1,24 @@
+from pydantic_settings import BaseSettings
+
+from mountaineer.config import ConfigBase
+
+
+def test_merge_configs():
+    """
+    Ensure that we can merge two configurations together, both
+    during type checking and during runtime.
+
+    """
+
+    class Settings1(BaseSettings):
+        ABC: str
+
+    class Settings2(BaseSettings):
+        DEF: str
+
+    class Config(ConfigBase, Settings1, Settings2):
+        pass
+
+    config = Config(ABC="abc", DEF="def")
+    assert config.ABC == "abc"
+    assert config.DEF == "def"

--- a/mountaineer/actions/__init__.py
+++ b/mountaineer/actions/__init__.py
@@ -1,9 +1,17 @@
 from .fields import (
-    FunctionActionType,  # noqa
-    FunctionMetadata,  # noqa
-    fuse_metadata_to_response_typehint,  # noqa
-    get_function_metadata,  # noqa
-    init_function_metadata,  # noqa
+    FunctionActionType as FunctionActionType,
 )
-from .passthrough import passthrough  # noqa
-from .sideeffect import sideeffect  # noqa
+from .fields import (
+    FunctionMetadata as FunctionMetadata,
+)
+from .fields import (
+    fuse_metadata_to_response_typehint as fuse_metadata_to_response_typehint,
+)
+from .fields import (
+    get_function_metadata as get_function_metadata,
+)
+from .fields import (
+    init_function_metadata as init_function_metadata,
+)
+from .passthrough import passthrough as passthrough
+from .sideeffect import sideeffect as sideeffect

--- a/mountaineer/actions/fields.py
+++ b/mountaineer/actions/fields.py
@@ -42,7 +42,9 @@ class FunctionMetadata(BaseModel):
 
     # Render type, defines the data model that is returned by the render typehint
     # If "None", the user has explicitly stated that no render model is returned
-    render_model: Type[RenderBase] | MountaineerUnsetValue = MountaineerUnsetValue()
+    render_model: Type[
+        RenderBase
+    ] | None | MountaineerUnsetValue = MountaineerUnsetValue()
 
     # Inserted by the render decorator
     url: str | MountaineerUnsetValue = MountaineerUnsetValue()
@@ -64,7 +66,7 @@ class FunctionMetadata(BaseModel):
             raise ValueError("Reload states not set")
         return self.reload_states
 
-    def get_render_model(self) -> Type[RenderBase]:
+    def get_render_model(self) -> Type[RenderBase] | None:
         if isinstance(self.render_model, MountaineerUnsetValue):
             raise ValueError("Render model not set")
         return self.render_model or RenderNull
@@ -132,7 +134,7 @@ def annotation_is_metadata(annotation: type | None):
 
 def fuse_metadata_to_response_typehint(
     metadata: FunctionMetadata,
-    render_model: Type[RenderBase],
+    render_model: Type[RenderBase] | None,
 ) -> Type[BaseModel]:
     """
     Functions can either be marked up with side effects, explicit responses, or both.
@@ -146,7 +148,7 @@ def fuse_metadata_to_response_typehint(
     ):
         passthrough_fields = {**metadata.passthrough_model.model_fields}
 
-    if metadata.action_type == FunctionActionType.SIDEEFFECT:
+    if metadata.action_type == FunctionActionType.SIDEEFFECT and render_model:
         # By default, reload all fields
         sideeffect_fields = {**render_model.model_fields}
 

--- a/mountaineer/actions/passthrough.py
+++ b/mountaineer/actions/passthrough.py
@@ -1,6 +1,6 @@
 from functools import wraps
 from inspect import isawaitable
-from typing import TYPE_CHECKING, Callable, Type, overload
+from typing import TYPE_CHECKING, Callable, ParamSpec, Type, overload
 
 from pydantic import BaseModel
 
@@ -13,6 +13,8 @@ from mountaineer.exceptions import APIException
 
 if TYPE_CHECKING:
     from mountaineer.controller import ControllerBase
+
+PassthroughInputs = ParamSpec("PassthroughInputs")
 
 
 @overload
@@ -29,7 +31,7 @@ def passthrough(func: Callable) -> Callable:
     ...
 
 
-def passthrough(*args, **kwargs):
+def passthrough(*args, **kwargs):  # type: ignore
     """
     By default, we mask out function return values to avoid leaking any unintended data to client applications. This
     decorator marks a function .

--- a/mountaineer/actions/sideeffect.py
+++ b/mountaineer/actions/sideeffect.py
@@ -41,7 +41,7 @@ def sideeffect(func: Callable) -> Callable:
     ...
 
 
-def sideeffect(*args, **kwargs):
+def sideeffect(*args, **kwargs):  # type: ignore
     """
     Mark a function as causing a sideeffect to the data. This will force a reload of the full (or partial) server state
     and sync these changes down to the client page.

--- a/mountaineer/app.py
+++ b/mountaineer/app.py
@@ -24,7 +24,7 @@ from mountaineer.js_compiler.base import ClientBuilderBase
 from mountaineer.js_compiler.bundler import JavascriptBundler
 from mountaineer.logging import LOGGER
 from mountaineer.paths import ManagedViewPath
-from mountaineer.render import Metadata
+from mountaineer.render import Metadata, RenderBase
 
 
 class ControllerDefinition(BaseModel):
@@ -161,7 +161,7 @@ class AppController:
         # Validate the return model is actually a RenderBase or explicitly marked up as None
         if not (
             return_model is None
-            or (isclass(return_model) and issubclass(return_model, BaseModel))
+            or (isclass(return_model) and issubclass(return_model, RenderBase))
         ):
             raise ValueError(
                 "Controller render() return type annotation is not a RenderBase"

--- a/mountaineer/client_builder/builder.py
+++ b/mountaineer/client_builder/builder.py
@@ -97,10 +97,12 @@ class ClientBuilder:
 
             # Convert the render model
             render_metadata = get_function_metadata(controller.render)
-            for schema_name, component in self.openapi_schema_converter.convert(
-                render_metadata.get_render_model()
-            ).items():
-                schemas[schema_name] = component
+            render_model = render_metadata.get_render_model()
+            if render_model:
+                for schema_name, component in self.openapi_schema_converter.convert(
+                    render_model
+                ).items():
+                    schemas[schema_name] = component
 
             # Convert all the other models defined in sideeffect routes
             for schema_name, component in base.components.schemas.items():
@@ -492,7 +494,14 @@ class ClientBuilder:
         :returns ReturnModel
         """
         render_metadata = get_function_metadata(controller.render)
-        return camelize(render_metadata.get_render_model().__name__)
+        render_model = render_metadata.get_render_model()
+
+        if not render_model:
+            raise ValueError(
+                f"Controller {controller} does not have a render model defined"
+            )
+
+        return camelize(render_model.__name__)
 
     def openapi_from_controller(self, controller_definition: ControllerDefinition):
         """

--- a/mountaineer/config.py
+++ b/mountaineer/config.py
@@ -1,9 +1,12 @@
 from contextlib import contextmanager
 
 from pydantic._internal._model_construction import ModelMetaclass
+from pydantic.fields import Field
 from pydantic_settings import BaseSettings
+from typing_extensions import dataclass_transform
 
 
+@dataclass_transform(kw_only_default=True, field_specifiers=(Field,))
 class ConfigMeta(ModelMetaclass):
     def __call__(cls, *args, **kwargs):
         instance = super().__call__(*args, **kwargs)

--- a/mountaineer/controller.py
+++ b/mountaineer/controller.py
@@ -3,7 +3,7 @@ from inspect import getmembers, isawaitable, ismethod
 from pathlib import Path
 from re import compile as re_compile
 from time import time
-from typing import Any, Callable, Coroutine, Iterable, Mapping
+from typing import Any, Callable, Coroutine, Generic, Iterable, Mapping, ParamSpec
 
 from fastapi.responses import HTMLResponse
 from inflection import underscore
@@ -26,8 +26,10 @@ from mountaineer.render import (
 )
 from mountaineer.ssr import V8RuntimeError, render_ssr
 
+RenderInput = ParamSpec("RenderInput")
 
-class ControllerBase(ABC):
+
+class ControllerBase(ABC, Generic[RenderInput]):
     url: str
     # Typically, view paths should be a relative path to the local
     # Paths are only used if you need to specify an absolute path to another
@@ -58,7 +60,7 @@ class ControllerBase(ABC):
 
     @abstractmethod
     def render(
-        self, *args, **kwargs
+        self, *args: RenderInput.args, **kwargs: RenderInput.kwargs
     ) -> RenderBase | None | Coroutine[Any, Any, RenderBase]:
         """
         Client implementations must override render() to define the data that will

--- a/mountaineer/cropper.py
+++ b/mountaineer/cropper.py
@@ -195,8 +195,8 @@ class ASTReducer(ast.NodeTransformer):
             isinstance(stmt.value, ast.Call)
             and hasattr(stmt.value.func, "id")
             and (
-                stmt.value.func.id == "dict"
-                or stmt.value.func.id in self.known_pydantic_models
+                stmt.value.func.id == "dict"  # type: ignore
+                or stmt.value.func.id in self.known_pydantic_models  # type: ignore
             )
         ):
             for key, value in zip(

--- a/mountaineer/database/__init__.py
+++ b/mountaineer/database/__init__.py
@@ -1,4 +1,7 @@
-from mountaineer.database.config import DatabaseConfig  # noqa: F401
-from mountaineer.database.dependencies import DatabaseDependencies  # noqa: F401
-from mountaineer.database.sqlmodel import Field, SQLModel  # noqa: F401
-from mountaineer.database.validator import DatabaseValidator  # noqa: F401
+from mountaineer.database import (
+    dependencies as DatabaseDependencies,  # noqa: F401
+)
+from mountaineer.database.config import DatabaseConfig as DatabaseConfig
+from mountaineer.database.sqlmodel import Field as Field
+from mountaineer.database.sqlmodel import SQLModel as SQLModel
+from mountaineer.database.validator import DatabaseValidator as DatabaseValidator

--- a/mountaineer/database/cli.py
+++ b/mountaineer/database/cli.py
@@ -6,8 +6,7 @@ from fastapi import Depends
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncEngine
 
-from mountaineer.database.dependencies import DatabaseDependencies
-from mountaineer.database.sqlmodel import SQLModel
+from mountaineer.database import DatabaseDependencies, SQLModel
 from mountaineer.dependencies import get_function_dependencies
 
 

--- a/mountaineer/database/config.py
+++ b/mountaineer/database/config.py
@@ -15,7 +15,7 @@ class DatabaseConfig(BaseSettings):
     @model_validator(mode="before")
     def build_db_connection(cls, values: Any) -> Any:
         if not values.get("SQLALCHEMY_DATABASE_URI"):
-            values["SQLALCHEMY_DATABASE_URI"] = PostgresDsn.build(
+            values["SQLALCHEMY_DATABASE_URI"] = PostgresDsn.build(  # type: ignore
                 scheme="postgresql+asyncpg",
                 username=values["POSTGRES_USER"],
                 password=values["POSTGRES_PASSWORD"],

--- a/mountaineer/database/dependencies/__init__.py
+++ b/mountaineer/database/dependencies/__init__.py
@@ -1,0 +1,7 @@
+"""
+Dependencies for use in API endpoint routes.
+
+"""
+
+from .core import get_db as get_db
+from .core import get_db_session as get_db_session

--- a/mountaineer/database/dependencies/core.py
+++ b/mountaineer/database/dependencies/core.py
@@ -2,7 +2,7 @@ from fastapi import Depends
 from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker, create_async_engine
 
 from mountaineer.database.config import DatabaseConfig
-from mountaineer.dependencies import CoreDependencies, DependenciesBase
+from mountaineer.dependencies import CoreDependencies
 
 
 def get_db(
@@ -22,13 +22,3 @@ async def get_db_session(
     session_maker = async_sessionmaker(engine, expire_on_commit=False)
     async with session_maker() as session:
         yield session
-
-
-class DatabaseDependencies(DependenciesBase):
-    """
-    Dependencies for use in API endpoint routes.
-
-    """
-
-    get_db = get_db
-    get_db_session = get_db_session

--- a/mountaineer/database/sqlmodel.py
+++ b/mountaineer/database/sqlmodel.py
@@ -31,6 +31,7 @@ from sqlmodel.main import (
 from sqlmodel.main import (
     SQLModelMetaclass as SQLModelMetaclassBase,
 )
+from typing_extensions import dataclass_transform
 
 
 def Field(
@@ -125,6 +126,7 @@ def Field(
     return field_info
 
 
+@dataclass_transform(kw_only_default=True, field_specifiers=(Field, FieldInfo))
 class GenericSQLModelMetaclass(SQLModelMetaclassBase):
     def __new__(
         cls,

--- a/mountaineer/database/sqlmodel.py
+++ b/mountaineer/database/sqlmodel.py
@@ -13,15 +13,17 @@ from typing import (
 
 from pydantic import BaseModel
 from pydantic._internal._model_construction import ModelMetaclass
-from sqlmodel.main import (
-    Column,
-    FieldInfo,
-    NoArgAnyCallable,
-    Undefined,
-    UndefinedType,
+from pydantic_core import PydanticUndefined as Undefined
+from pydantic_core import PydanticUndefinedType as UndefinedType
+from sqlalchemy import Column
+from sqlmodel._compat import (
     finish_init,
     post_init_field_info,
     sqlmodel_init,
+)
+from sqlmodel.main import (
+    FieldInfo,
+    NoArgAnyCallable,
 )
 from sqlmodel.main import (
     SQLModel as SQLModelBase,

--- a/mountaineer/dependencies/__init__.py
+++ b/mountaineer/dependencies/__init__.py
@@ -1,2 +1,7 @@
-from .base import DependenciesBase, get_function_dependencies  # noqa: F401
-from .core import CoreDependencies  # noqa: F401
+from . import core as CoreDependencies  # noqa: F401
+from .base import (
+    DependenciesBase as DependenciesBase,
+)
+from .base import (
+    get_function_dependencies as get_function_dependencies,
+)

--- a/mountaineer/dependencies/base.py
+++ b/mountaineer/dependencies/base.py
@@ -5,6 +5,8 @@ from typing import Callable
 from fastapi import Request
 from fastapi.dependencies.utils import get_dependant, solve_dependencies
 
+from mountaineer.logging import LOGGER
+
 
 class DependenciesBaseMeta(type):
     """
@@ -23,6 +25,9 @@ class DependenciesBaseMeta(type):
     """
 
     def __new__(cls, name, bases, namespace, **kwargs):
+        # Flag this as deprecated
+        LOGGER.warning("DependenciesBase is deprecated")
+
         for attr_name, attr_value in namespace.items():
             if isinstance(attr_value, staticmethod):
                 raise TypeError(

--- a/mountaineer/dependencies/core/__init__.py
+++ b/mountaineer/dependencies/core/__init__.py
@@ -1,0 +1,5 @@
+"""
+Core dependencies for Mountaineer projects.
+
+"""
+from .core import get_config_with_type as get_config_with_type

--- a/mountaineer/dependencies/core/core.py
+++ b/mountaineer/dependencies/core/core.py
@@ -3,7 +3,6 @@ from typing import Type, TypeVar
 from pydantic_settings import BaseSettings
 
 from mountaineer.config import get_config
-from mountaineer.dependencies.base import DependenciesBase
 
 T = TypeVar("T", bound=BaseSettings)
 
@@ -18,7 +17,3 @@ def get_config_with_type(required_type: Type[T]):
         return config
 
     return internal_dependency
-
-
-class CoreDependencies(DependenciesBase):
-    get_config_with_type = get_config_with_type

--- a/mountaineer/js_compiler/base.py
+++ b/mountaineer/js_compiler/base.py
@@ -20,9 +20,9 @@ class ClientBuilderBase(ABC):
     """
 
     @abstractmethod
-    def handle_file(
+    async def handle_file(
         self,
-        current_path: ManagedViewPath,
+        file_path: ManagedViewPath,
         controller: ControllerBase | None,
         metadata: ClientBundleMetadata,
     ) -> None | Coroutine[Any, Any, None]:

--- a/mountaineer/js_compiler/postcss.py
+++ b/mountaineer/js_compiler/postcss.py
@@ -24,19 +24,18 @@ class PostCSSBundler(ClientBuilderBase):
 
     async def handle_file(
         self,
-        current_path: ManagedViewPath,
+        file_path: ManagedViewPath,
         controller: ControllerBase | None,
         metadata: ClientBundleMetadata,
     ):
         # If this is a CSS file we try to process it
-        if current_path.suffix not in {".css", ".scss"}:
+        if file_path.suffix not in {".css", ".scss"}:
             return
 
-        root_path = current_path.get_package_root_link()
-        built_css = await self.process_css(current_path)
+        root_path = file_path.get_package_root_link()
+        built_css = await self.process_css(file_path)
         (
-            root_path.get_managed_static_dir()
-            / self.get_style_output_name(current_path)
+            root_path.get_managed_static_dir() / self.get_style_output_name(file_path)
         ).write_text(built_css)
 
     async def process_css(self, css_path: ManagedViewPath) -> str:

--- a/mountaineer/watch.py
+++ b/mountaineer/watch.py
@@ -246,7 +246,7 @@ class PackageWatchdog:
         dist = importlib.metadata.distribution(self.main_package)
         package_path = self.resolve_package_path(dist)
 
-        lock_path = (Path(package_path) / ".watchdog.lock").absolute()
+        lock_path = (Path(str(package_path)) / ".watchdog.lock").absolute()
         if lock_path.exists():
             raise WatchdogLockError(lock_path=lock_path)
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -446,6 +446,20 @@ files = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.8.0"
+description = "Node.js virtual environment builder"
+optional = false
+python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*"
+files = [
+    {file = "nodeenv-1.8.0-py2.py3-none-any.whl", hash = "sha256:df865724bb3c3adc86b3876fa209771517b0cfe596beff01a92700e0e8be4cec"},
+    {file = "nodeenv-1.8.0.tar.gz", hash = "sha256:d51e0c37e64fbf47d017feac3145cdbb58836d7eee8c6f6d3b6880c5456227d2"},
+]
+
+[package.dependencies]
+setuptools = "*"
+
+[[package]]
 name = "packaging"
 version = "23.2"
 description = "Core utilities for Python packages"
@@ -673,6 +687,24 @@ test = ["flaky", "greenlet (>=3.0.0a1)", "ipython", "pytest", "pytest-asyncio (=
 types = ["typing-extensions"]
 
 [[package]]
+name = "pyright"
+version = "1.1.352"
+description = "Command line wrapper for pyright"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pyright-1.1.352-py3-none-any.whl", hash = "sha256:0040cf173c6a60704e553bfd129dfe54de59cc76d0b2b80f77cfab4f50701d64"},
+    {file = "pyright-1.1.352.tar.gz", hash = "sha256:a621c0dfbcf1291b3610641a07380fefaa1d0e182890a1b2a7f13b446e8109a9"},
+]
+
+[package.dependencies]
+nodeenv = ">=1.6.0"
+
+[package.extras]
+all = ["twine (>=3.4.1)"]
+dev = ["twine (>=3.4.1)"]
+
+[[package]]
 name = "pytest"
 version = "7.4.4"
 description = "pytest: simple powerful testing with Python"
@@ -808,6 +840,22 @@ files = [
     {file = "ruff-0.1.15-py3-none-win_arm64.whl", hash = "sha256:9a933dfb1c14ec7a33cceb1e49ec4a16b51ce3c20fd42663198746efc0427360"},
     {file = "ruff-0.1.15.tar.gz", hash = "sha256:f6dfa8c1b21c913c326919056c390966648b680966febcb796cc9d1aaab8564e"},
 ]
+
+[[package]]
+name = "setuptools"
+version = "69.1.1"
+description = "Easily download, build, install, upgrade, and uninstall Python packages"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "setuptools-69.1.1-py3-none-any.whl", hash = "sha256:02fa291a0471b3a18b2b2481ed902af520c69e8ae0919c13da936542754b4c56"},
+    {file = "setuptools-69.1.1.tar.gz", hash = "sha256:5c0806c7d9af348e6dd3777b4f4dbb42c7ad85b190104837488eab9a7c945cf8"},
+]
+
+[package.extras]
+docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (<7.2.5)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
+testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "packaging (>=23.2)", "pip (>=19.1)", "pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-home (>=0.5)", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-ruff (>=0.2.1)", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
+testing-integration = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "packaging (>=23.2)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
 
 [[package]]
 name = "sniffio"
@@ -1274,4 +1322,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "0f2c8373831ba32f6e7e4f91b7a25953873ad46f91b1f0c5e113b7c7840dcb85"
+content-hash = "1768d2abd6200c84acb44f74065786bb031ea54f8bf028eaa729046d6e43b149"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ pytest-asyncio = "^0.23.4"
 pyinstrument = "^4.6.2"
 httpx = "^0.27.0"
 types-psycopg2 = "^2.9.21.20240218"
+pyright = "^1.1.352"
 
 [build-system]
 requires = ["maturin>=1.3.0"]

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,4 +1,0 @@
-{
-  "venv": "mountaineer-WHAdwfD0-py3.11",
-  "venvPath": "/Users/piercefreeman/Library/Caches/pypoetry/virtualenvs"
-}


### PR DESCRIPTION
We previously only validated function signatures with mypy. Since pyright is gaining popularity (and seems to be the default choice in most IDE language server implementations), we add this validation to our `make lint` configuration.

We're able to mostly make the Mountaineer core project compatible with pyright by adding additional typehints. The more fundamental changes that required some code restructuring are flagged below.