### PR TITLE
Add rollup import for _server

### DIFF
--- a/.github/workflows/test_create_mountaineer_app.yml
+++ b/.github/workflows/test_create_mountaineer_app.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Run integration tests
         if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'Full Build')
-        run: make test-create-mountaineer-app-integrations
+        run: make test-create-mountaineer-app-integrations test-args="-vv"
 
   build:
     if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'Full Build')

--- a/README.md
+++ b/README.md
@@ -194,12 +194,10 @@ from mountaineer.app import AppController
 from mountaineer.js_compiler.postcss import PostCSSBundler
 from mountaineer.render import LinkAttribute, Metadata
 
-from my_webapp.views import get_view_path
 from my_webapp.config import AppConfig
 from my_webapp.controllers.home import HomeController
 
 controller = AppController(
-    view_root=get_view_path(""),
     config=AppConfig(),
     global_metadata=Metadata(
         links=[LinkAttribute(rel="stylesheet", href="/static/app_main.css")]
@@ -223,8 +221,13 @@ import { useServer, ServerState } from "./_server/useServer";
 const CreateTodo = ({ serverState }: { serverState: ServerState }) => {
   return (
     <div className="flex gap-x-4">
-      <input type="text" className="grow rounded border-2 border-gray-200 px-4 py-2" />
-      <button className="rounded bg-blue-500 px-4 py-2 font-bold text-white hover:bg-blue-700">Create</button>
+      <input
+        type="text"
+        className="grow rounded border-2 border-gray-200 px-4 py-2"
+      />
+      <button className="rounded bg-blue-500 px-4 py-2 font-bold text-white hover:bg-blue-700">
+        Create
+      </button>
     </div>
   );
 };
@@ -235,7 +238,8 @@ const Home = () => {
   return (
     <div className="mx-auto max-w-2xl space-y-8 p-8 text-2xl">
       <p>
-        Hello {serverState.client_ip}, you have {serverState.todos.length} todo items.
+        Hello {serverState.client_ip}, you have {serverState.todos.length} todo
+        items.
       </p>
       <CreateTodo serverState={serverState} />
       {

--- a/ci_webapp/ci_webapp/app.py
+++ b/ci_webapp/ci_webapp/app.py
@@ -1,21 +1,22 @@
-from mountaineer.app import AppController
+from mountaineer import AppController, LinkAttribute, Metadata
 from mountaineer.js_compiler.postcss import PostCSSBundler
-from mountaineer.render import LinkAttribute, Metadata
 
+from ci_webapp.config import AppConfig
 from ci_webapp.controllers.complex import ComplexController
 from ci_webapp.controllers.detail import DetailController
 from ci_webapp.controllers.home import HomeController
-from ci_webapp.views import get_view_path
+from ci_webapp.controllers.stream import StreamController
 
 controller = AppController(
-    view_root=get_view_path(""),
     global_metadata=Metadata(
         links=[LinkAttribute(rel="stylesheet", href="/static/app_main.css")]
     ),
     custom_builders=[
         PostCSSBundler(),
     ],
+    config=AppConfig(),
 )
 controller.register(HomeController())
 controller.register(DetailController())
 controller.register(ComplexController())
+controller.register(StreamController())

--- a/ci_webapp/ci_webapp/config.py
+++ b/ci_webapp/ci_webapp/config.py
@@ -1,0 +1,5 @@
+from mountaineer.config import ConfigBase
+
+
+class AppConfig(ConfigBase):
+    PACKAGE: str | None = "ci_webapp"

--- a/ci_webapp/ci_webapp/controllers/complex.py
+++ b/ci_webapp/ci_webapp/controllers/complex.py
@@ -1,8 +1,7 @@
 from uuid import UUID, uuid4
 
 from fastapi import Request
-from mountaineer.controller import ControllerBase
-from mountaineer.render import Metadata, RenderBase
+from mountaineer import ControllerBase, Metadata, RenderBase
 
 
 class ComplexRender(RenderBase):

--- a/ci_webapp/ci_webapp/controllers/detail.py
+++ b/ci_webapp/ci_webapp/controllers/detail.py
@@ -1,8 +1,7 @@
 from uuid import UUID
 
 from fastapi import Request
-from mountaineer.controller import ControllerBase
-from mountaineer.render import Metadata, RenderBase
+from mountaineer import ControllerBase, Metadata, RenderBase
 
 
 class DetailRender(RenderBase):

--- a/ci_webapp/ci_webapp/controllers/stream.py
+++ b/ci_webapp/ci_webapp/controllers/stream.py
@@ -1,0 +1,23 @@
+import asyncio
+from typing import AsyncIterator
+
+from mountaineer import ControllerBase, passthrough
+from pydantic import BaseModel
+
+
+class StreamActionResponse(BaseModel):
+    value: str
+
+
+class StreamController(ControllerBase):
+    url = "/stream"
+    view_path = "/app/stream/page.tsx"
+
+    async def render(self) -> None:
+        pass
+
+    @passthrough
+    async def stream_action(self) -> AsyncIterator[StreamActionResponse]:
+        for i in range(10):
+            yield StreamActionResponse(value=f"streaming {i}\n")
+            await asyncio.sleep(1)

--- a/ci_webapp/ci_webapp/views/app/complex/page.tsx
+++ b/ci_webapp/ci_webapp/views/app/complex/page.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { useServer } from "./_server/useServer";
+import { useServer } from "./_server";
 
 function isPrime(num: number) {
   if (num <= 1) return false;

--- a/ci_webapp/ci_webapp/views/app/detail/page.tsx
+++ b/ci_webapp/ci_webapp/views/app/detail/page.tsx
@@ -1,6 +1,5 @@
-import * as React from "react";
-import { useEffect } from "react";
-import { useServer } from "./_server/useServer";
+import React from "react";
+import { useServer } from "./_server";
 
 const Page = () => {
   const serverState = useServer();

--- a/ci_webapp/ci_webapp/views/app/home/page.tsx
+++ b/ci_webapp/ci_webapp/views/app/home/page.tsx
@@ -1,6 +1,5 @@
 import React from "react";
-import { useServer } from "./_server/useServer";
-import { HTTPValidationErrorException } from "./_server/actions";
+import { useServer, HTTPValidationErrorException } from "./_server";
 
 const Home = () => {
   const serverState = useServer();
@@ -32,6 +31,14 @@ const Home = () => {
           })}
         >
           Test Complex Link
+        </a>
+      </p>
+      <p>
+        <a
+          className="font-medium text-blue-500"
+          href={serverState.linkGenerator.streamController({})}
+        >
+          Stream Link
         </a>
       </p>
       <div className="flex gap-x-4">

--- a/ci_webapp/ci_webapp/views/app/stream/page.tsx
+++ b/ci_webapp/ci_webapp/views/app/stream/page.tsx
@@ -1,0 +1,28 @@
+import React, { useState } from "react";
+import { useServer } from "./_server";
+
+const Page = () => {
+  const serverState = useServer();
+  const [currentStream, setCurrentStream] = useState("");
+
+  return (
+    <div>
+      <div>Current Stream: {currentStream}</div>
+      <div>
+        <button
+          className="rounded-md bg-blue-500 p-2 text-white"
+          onClick={async () => {
+            const responseStream = await serverState.stream_action();
+            for await (const response of responseStream) {
+              setCurrentStream(response.passthrough.value);
+            }
+          }}
+        >
+          Start Stream
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default Page;

--- a/create_mountaineer_app/create_mountaineer_app/templates/project/[project_name]/app.py
+++ b/create_mountaineer_app/create_mountaineer_app/templates/project/[project_name]/app.py
@@ -6,11 +6,9 @@ from mountaineer.render import LinkAttribute, Metadata
 from {{project_name}}.controllers.detail import DetailController
 from {{project_name}}.controllers.home import HomeController
 {% endif %}
-from {{project_name}}.views import get_view_path
 from {{project_name}}.config import AppConfig
 
 controller = AppController(
-    view_root=get_view_path(""),
     config=AppConfig(),
     {% if use_tailwind %}
     global_metadata=Metadata(

--- a/create_mountaineer_app/create_mountaineer_app/templates/project/[project_name]/config.py
+++ b/create_mountaineer_app/create_mountaineer_app/templates/project/[project_name]/config.py
@@ -3,5 +3,6 @@ from mountaineer.database import DatabaseConfig
 from pydantic_settings import SettingsConfigDict
 
 class AppConfig(ConfigBase, DatabaseConfig):
+    PACKAGE: str | None = "{{project_name}}"
 
     model_config = SettingsConfigDict(env_file=(".env",))

--- a/create_mountaineer_app/create_mountaineer_app/templates/project/[project_name]/views/__init__.py
+++ b/create_mountaineer_app/create_mountaineer_app/templates/project/[project_name]/views/__init__.py
@@ -1,7 +1,0 @@
-from importlib.resources import as_file, files
-from pathlib import Path
-
-
-def get_view_path(asset_name: str) -> Path:
-    with as_file(files(__name__).joinpath(asset_name)) as path:
-        return Path(path)

--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -75,7 +75,6 @@ For metadata that you know should appear on every page (like stylesheets or glob
 
 ```python
 controller = AppController(
-    view_root=get_view_path(""),
     global_metadata=Metadata(
         links=[LinkAttribute(rel="stylesheet", href="/static/main.css")]
     ),

--- a/docs/postcss.md
+++ b/docs/postcss.md
@@ -8,7 +8,6 @@ PostCSS support is handled as a buildtime plugin with mountaineer. It's disabled
 from mountaineer.js_compiler.postcss import PostCSSBundler
 
 controller = AppController(
-    view_root=get_view_path(""),
     custom_builders=[
         PostCSSBundler(),
     ],

--- a/mountaineer/__tests__/client_builder/test_builder.py
+++ b/mountaineer/__tests__/client_builder/test_builder.py
@@ -67,3 +67,7 @@ def test_generate_link_aggregator(builder: ClientBuilder):
 
 def test_generate_view_servers(builder: ClientBuilder):
     builder.generate_view_servers()
+
+
+def test_generate_index_file(builder: ClientBuilder):
+    builder.generate_index_file()

--- a/mountaineer/__tests__/conftest.py
+++ b/mountaineer/__tests__/conftest.py
@@ -2,9 +2,16 @@ from warnings import filterwarnings
 
 import pytest
 
+from mountaineer.config import unregister_config
+
 
 @pytest.fixture(autouse=True)
 def ignore_httpx_deprecation_warnings():
     # Ignore httpx deprecation warnings until fastapi updates its internal test constructor
     # https://github.com/encode/httpx/blame/master/httpx/_client.py#L678
     filterwarnings("ignore", category=DeprecationWarning, module="httpx.*")
+
+
+@pytest.fixture(autouse=True)
+def clear_config_cache():
+    unregister_config()

--- a/mountaineer/__tests__/test_config.py
+++ b/mountaineer/__tests__/test_config.py
@@ -3,22 +3,24 @@ from pydantic_settings import BaseSettings
 from mountaineer.config import ConfigBase
 
 
+class Settings1(BaseSettings):
+    ABC: str
+
+
+class Settings2(BaseSettings):
+    DEF: str
+
+
+class Config(ConfigBase, Settings1, Settings2):
+    pass
+
+
 def test_merge_configs():
     """
     Ensure that we can merge two configurations together, both
     during type checking and during runtime.
 
     """
-
-    class Settings1(BaseSettings):
-        ABC: str
-
-    class Settings2(BaseSettings):
-        DEF: str
-
-    class Config(ConfigBase, Settings1, Settings2):
-        pass
-
     config = Config(ABC="abc", DEF="def")
     assert config.ABC == "abc"
     assert config.DEF == "def"

--- a/mountaineer/__tests__/test_watch.py
+++ b/mountaineer/__tests__/test_watch.py
@@ -1,6 +1,4 @@
-from json import dumps as json_dumps
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 
@@ -54,64 +52,3 @@ def test_merge_paths(paths: list[str], expected_paths: list[str]):
     assert set(handler.merge_paths(paths)) == {
         str(Path(path).absolute()) for path in expected_paths
     }
-
-
-@pytest.mark.parametrize(
-    "package_name, filename",
-    [
-        ("my-awesome-project", "my_awesome_project.pth"),
-        ("MyAwesomeProject", "myawesomeproject.pth"),
-    ],
-)
-def test_resolve_symbolic_links(package_name: str, filename: str, tmpdir: str):
-    # pth files are in txt format and have an explicit link
-    # to the real file
-    tmp_root = Path(tmpdir)
-    (tmp_root / filename).write_text("/path/to/realfile")
-
-    watchdog = PackageWatchdog("mountaineer", [])
-    with patch("importlib.metadata.Distribution") as mock_distribution:
-        mock_distribution.name = package_name
-        mock_distribution.files = [
-            tmp_root / filename,
-            tmp_root / "other_file",
-        ]
-        mock_distribution.locate_file.side_effect = lambda x: x
-
-        assert watchdog.resolve_package_path(mock_distribution) == "/path/to/realfile"
-
-
-@pytest.mark.parametrize(
-    "package_name, egg_info_name",
-    [
-        (
-            "my-awesome-project",
-            "my_awesome_project-0.1.0.dist-info",
-        ),
-        (
-            "MyAwesomeProject",
-            "MyAwesomeProject-0.1.0.dist-info",
-        ),
-    ],
-)
-def test_resolve_dist_links(tmpdir: str, package_name: str, egg_info_name: str):
-    # direct_url.json files are located within the application's egginfo
-    # directory within a local venv
-    tmp_root = Path(tmpdir)
-    egg_info_path = tmp_root / egg_info_name
-    egg_info_path.mkdir(exist_ok=True)
-
-    (egg_info_path / "direct_url.json").write_text(
-        json_dumps({"dir_info": {"editable": True}, "url": "file:///path/to/realfile"})
-    )
-
-    watchdog = PackageWatchdog("mountaineer", [])
-    with patch("importlib.metadata.Distribution") as mock_distribution:
-        mock_distribution.name = package_name
-        mock_distribution.files = [
-            egg_info_path / "direct_url.json",
-            tmp_root / "other_file",
-        ]
-        mock_distribution.locate_file.side_effect = lambda x: x
-
-        assert watchdog.resolve_package_path(mock_distribution) == "/path/to/realfile"

--- a/mountaineer/client_builder/builder.py
+++ b/mountaineer/client_builder/builder.py
@@ -72,7 +72,7 @@ class ClientBuilder:
         # Update the cached paths attached to the app
         for controller_definition in self.app.controllers:
             controller = controller_definition.controller
-            controller.resolve_paths(self.view_root)
+            controller.resolve_paths(self.view_root, force=True)
 
     def generate_static_files(self):
         """

--- a/mountaineer/client_builder/builder.py
+++ b/mountaineer/client_builder/builder.py
@@ -65,6 +65,7 @@ class ClientBuilder:
         self.generate_link_shortcuts()
         self.generate_link_aggregator()
         self.generate_view_servers()
+        self.generate_index_file()
 
         await self.build_javascript_chunks()
 
@@ -352,6 +353,22 @@ class ClientBuilder:
             )
 
             (controller_model_path / "useServer.ts").write_text("\n\n".join(chunks))
+
+    def generate_index_file(self):
+        for controller_definition in self.app.controllers:
+            controller = controller_definition.controller
+            controller_code_dir = self.view_root.get_controller_view_path(
+                controller
+            ).get_managed_code_dir()
+
+            chunks: list[str] = []
+
+            chunks.append("export * from './actions';")
+            chunks.append("export * from './links';")
+            chunks.append("export * from './models';")
+            chunks.append("export * from './useServer';")
+
+            (controller_code_dir / "index.ts").write_text("\n".join(chunks))
 
     async def build_javascript_chunks(self, max_concurrency: int = 25):
         """

--- a/mountaineer/config.py
+++ b/mountaineer/config.py
@@ -6,7 +6,6 @@ from pydantic_settings import BaseSettings
 from typing_extensions import dataclass_transform
 
 
-@dataclass_transform(kw_only_default=True, field_specifiers=(Field,))
 class ConfigMeta(ModelMetaclass):
     def __call__(cls, *args, **kwargs):
         instance = super().__call__(*args, **kwargs)
@@ -14,7 +13,11 @@ class ConfigMeta(ModelMetaclass):
         return instance
 
 
+@dataclass_transform(kw_only_default=True, field_specifiers=(Field,))
 class ConfigBase(BaseSettings, metaclass=ConfigMeta):
+    # Name of the python package
+    PACKAGE: str | None = None
+
     model_config = {"frozen": True}
 
 

--- a/mountaineer/controller.py
+++ b/mountaineer/controller.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from importlib.metadata import PackageNotFoundError
 from inspect import getmembers, isawaitable, ismethod
 from pathlib import Path
 from re import compile as re_compile
@@ -275,7 +276,7 @@ class ControllerBase(ABC, Generic[RenderInput]):
                 config = get_config()
                 if config.PACKAGE:
                     view_base = Path(resolve_package_path(config.PACKAGE)) / "views"
-            except ValueError:
+            except (ValueError, PackageNotFoundError):
                 # Config isn't registered yet
                 pass
 

--- a/mountaineer/paths.py
+++ b/mountaineer/paths.py
@@ -1,7 +1,10 @@
+import importlib.metadata
 import sys
+from json import loads as json_loads
 from os import PathLike
 from os.path import relpath
 from pathlib import Path
+from re import search as re_search
 from typing import TYPE_CHECKING, Optional
 
 from mountaineer.annotation_helpers import MountaineerUnsetValue
@@ -245,3 +248,80 @@ def generate_relative_import(
                 relative_path = relative_path.removesuffix(js_extensions)
 
     return relative_path
+
+
+def resolve_package_path(package_name: str):
+    """
+    Given a package distribution, returns the local file directory where the code
+    is located. This is resolved to the original reference if installed with `-e`
+    otherwise is a copy of the package.
+
+    """
+    dist = importlib.metadata.distribution(package_name)
+
+    def normalize_package(package: str):
+        return package.replace("-", "_").lower()
+
+    # Recent versions of poetry install development packages (-e .) as direct URLs
+    # https://the-hitchhikers-guide-to-packaging.readthedocs.io/en/latest/introduction.html
+    # "Path configuration files have an extension of .pth, and each line must
+    # contain a single path that will be appended to sys.path."
+    package_name = normalize_package(dist.name)
+    symbolic_links = [
+        path
+        for path in (dist.files or [])
+        if path.name.lower() == f"{package_name}.pth"
+    ]
+    dist_links = [
+        path
+        for path in (dist.files or [])
+        if path.name == "direct_url.json"
+        and re_search(package_name + r"-[0-9-.]+\.dist-info", path.parent.name.lower())
+    ]
+    explicit_links = [
+        path
+        for path in (dist.files or [])
+        if path.parent.name.lower() == package_name
+        and (
+            # Sanity check that the parent is the high level project directory
+            # by looking for common base files
+            path.name == "__init__.py"
+        )
+    ]
+
+    # The user installed code as an absolute package (ie. with pip install .) instead of
+    # as a reference. There's no need to sniff for the additional package path since
+    # we've already found it
+    if explicit_links:
+        # Right now we have a file pointer to __init__.py. Go up one level
+        # to the main package directory to return a directory
+        explicit_link = explicit_links[0]
+        return Path(str(dist.locate_file(explicit_link.parent)))
+
+    # Raw path will capture the path to the pyproject.toml file directory,
+    # not the actual package code directory
+    # Find the root, then resolve the package directory
+    raw_path: Path | None = None
+
+    if symbolic_links:
+        direct_url_path = symbolic_links[0]
+        raw_path = Path(str(dist.locate_file(direct_url_path.read_text().strip())))
+    elif dist_links:
+        dist_link = dist_links[0]
+        direct_metadata = json_loads(dist_link.read_text())
+        package_path = "/" + direct_metadata["url"].lstrip("file://").lstrip("/")
+        raw_path = Path(str(dist.locate_file(package_path)))
+
+    if not raw_path:
+        raise ValueError(
+            f"Could not find a valid path for package {dist.name}, found files: {dist.files}"
+        )
+
+    # Sniff for the presence of the code directory
+    for path in raw_path.iterdir():
+        if path.is_dir() and normalize_package(path.name) == package_name:
+            return path
+
+    raise ValueError(
+        f"No matching package found in root path: {raw_path} {list(raw_path.iterdir())}"
+    )


### PR DESCRIPTION
## _server index

Our client-code generation pipeline creates a series of typescript files for use in client projects. These are all placed within the `_server` folders embedded within the application views. To access interfaces and helper functions, clients might need to import from multiple of these sub-files.

```tsx
import { useServer } from './_server/useServer';
import { MyModel } from './_server/models';
```

The specific names of these files are an implementation detail. For convenience, this PR adds a `index.ts` file that aggregates and re-exports all of these client objects from the component files. This allows a single import statement to collect all of the objects that the given view will need:

```tsx
import { useServer, MyModel } from './_server';
```

More details: https://github.com/piercefreeman/mountaineer/issues/59

## Auto-find views directory

By convention, Mountaineer apps have a `views` folder that hosts the React frontend. Clients previously had to specify this folder when creating the `AppController` via `view_path`. While we still support this explicit instantiation (mostly for our own test harness usage) we switch the default behavior to auto-find the `views` directory given the current project package. Just specify `PACKAGE` and controllers will identify the right path at runtime:

```python
class AppConfig(ConfigBase):
    PACKAGE: str | None = "my_package"
```

This approach has the benefit of letting controllers auto-find their associated view dependencies, so clients can more easily use controllers outside of a builder context. It also simplifies client configurations by consolidating more of the app-specific logic into the universal Config.