### PR TITLE
Allow passthroughs to return raw responses

### DIFF
--- a/ci_webapp/ci_webapp/controllers/home.py
+++ b/ci_webapp/ci_webapp/controllers/home.py
@@ -36,11 +36,11 @@ class HomeController(ControllerBase):
         self.global_count += payload.count
 
     @passthrough(response_model=GetExternalDataResponse)
-    def get_external_data(self):
+    def get_external_data(self) -> GetExternalDataResponse:
         # Execute a server action without automatically reloading the server state
         # Typically side-effects are the recommended way to get static data to the client
         # but sometimes you need to get data from a third-party API or gated resource
-        return dict(
+        return GetExternalDataResponse(
             first_name="John",
         )
 

--- a/mountaineer/__tests__/actions/test_passthrough.py
+++ b/mountaineer/__tests__/actions/test_passthrough.py
@@ -1,6 +1,9 @@
+from inspect import getsource
 from pathlib import Path
+from textwrap import dedent
 from typing import Any, AsyncIterator, Iterator, cast
 
+import mypy.api
 import pytest
 from fastapi.responses import JSONResponse, StreamingResponse
 from fastapi.testclient import TestClient
@@ -13,6 +16,7 @@ from mountaineer.actions.passthrough import (
 from mountaineer.annotation_helpers import MountaineerUnsetValue
 from mountaineer.app import AppController
 from mountaineer.controller import ControllerBase
+from mountaineer.logging import LOGGER
 from mountaineer.render import RenderBase
 
 
@@ -211,3 +215,88 @@ async def test_raw_response():
     )
     # No "passthrough" wrapping
     assert response.json() == {"raw_value": "success"}
+
+
+@pytest.mark.parametrize(
+    "passthrough_value, return_typehint, return_value, is_valid",
+    [
+        # Normal return type
+        ("@passthrough", "InputModel", "return InputModel()", True),
+        (
+            "@passthrough(exception_models=[])",
+            "InputModel",
+            "return InputModel()",
+            True,
+        ),
+        # Raw responses have to be fastapi.Response models or subclasses
+        ("@passthrough(raw_response=True)", "InputModel", "return InputModel()", False),
+        (
+            "@passthrough(raw_response=True)",
+            "JSONResponse",
+            "return JSONResponse(content={})",
+            True,
+        ),
+        (
+            "@passthrough(raw_response=True)",
+            "HTMLResponse",
+            'return HTMLResponse(content="TEST")',
+            True,
+        ),
+        # We can return JSONResponse is normal passthrough functions as well, because they'll be wrapped
+        # in a passthrough response
+        # We can't return other fastapi.Response models, however
+        ("@passthrough", "JSONResponse", "return JSONResponse(content={})", True),
+        ("@passthrough", "HTMLResponse", 'return HTMLResponse(content="TEST")', False),
+        # Iterator types are only allowed if they're async
+        ("@passthrough", "AsyncIterator[InputModel]", "yield InputModel()", True),
+    ],
+)
+def test_passthrough_typechecking(
+    passthrough_value: str,
+    return_typehint: str,
+    return_value: str,
+    is_valid: bool,
+    tmp_path: Path,
+):
+    """
+    Ensure that mypy will catch type errors in passthrough signatures
+
+    """
+
+    def run_function():
+        from typing import AsyncIterator  # noqa: F401
+
+        from fastapi.responses import HTMLResponse, JSONResponse  # noqa: F401
+        from pydantic import BaseModel  # noqa: F401
+
+        from mountaineer import ControllerBase, passthrough  # noqa: F401
+
+        class InputModel(BaseModel):
+            pass
+
+        class TestController:
+            @passthrough  # type: ignore
+            async def get_external_data(self) -> str:
+                return "{output_value}"
+
+    # Ignore the "run_function()" function header itself
+    function_lines = getsource(run_function).split("\n")[1:]
+    value = dedent("\n".join(function_lines))
+
+    value = value.replace("@passthrough", passthrough_value)
+    value = value.replace("-> str", f"-> {return_typehint}")
+    value = value.replace('return "{output_value}"', return_value)
+    value = value.replace("# type: ignore", "")
+
+    LOGGER.debug(f"Input value:\n{value}")
+
+    module_path = tmp_path / "test.py"
+    module_path.write_text(value)
+
+    result = mypy.api.run([str(module_path)])
+    LOGGER.debug(f"mypy result: {result}")
+
+    if is_valid:
+        assert "Success" in result[0]
+    else:
+        assert "error" in result[0]

--- a/mountaineer/__tests__/actions/test_sideeffect.py
+++ b/mountaineer/__tests__/actions/test_sideeffect.py
@@ -93,12 +93,12 @@ async def call_sideeffect_common(controller: ControllerCommon):
         # by the function injected by the sideeffect decorator.
         return_value_sync = await controller.call_sideeffect(
             {},
-            request=Request({"type": "http"}),
+            request=Request({"type": "http"}),  # type: ignore
         )
 
         return_value_async = await controller.call_sideeffect_async(
             {},
-            request=Request({"type": "http"}),
+            request=Request({"type": "http"}),  # type: ignore
         )
 
         # The response payload should be the same both both sync and async endpoints

--- a/mountaineer/__tests__/client_builder/test_build_actions.py
+++ b/mountaineer/__tests__/client_builder/test_build_actions.py
@@ -280,10 +280,67 @@ def test_build_server_side_event_action(
 ):
     builder = OpenAPIToTypescriptActionConverter()
     built_function, build_imports = builder.build_action(url, definition, method_name)
-
-    # Exact match for function contents
     assert re_sub(r"\s+", "", built_function) == re_sub(r"\s+", "", expected_function)
+    assert set(build_imports) == set(expected_imports)
 
-    # Order doesn't matter in the imports. We assume they're all coming from the locally defined
-    # /models.ts source file.
+
+@pytest.mark.parametrize(
+    "method_name,url,definition,expected_function,expected_imports",
+    [
+        (
+            "my_method_fn",
+            "/testing/url",
+            ActionDefinition(
+                action_type=ActionType.POST,
+                summary="",
+                operationId="",
+                requestBody=EXAMPLE_REQUEST_BODY,
+                responses={
+                    "200": ContentBodyDefinition(
+                        content_type="application/json",
+                        content_schema=ContentDefinition.from_meta(
+                            schema_ref=ContentDefinition.Reference.from_meta(
+                                # We won't have a response_model for raw responses
+                                ref=""
+                            )
+                        ),
+                    ),
+                    "422": EXAMPLE_RESPONSE_400,
+                },
+                is_raw_response=True,
+            ),
+            (
+                """
+                export const my_method_fn = (
+                    {requestBody}: {requestBody: ExampleModel}
+                ): Promise<Response> => {
+                    return __request({
+                        'method': 'POST',
+                        'url': '/testing/url',
+                        'errors': {
+                            422: HTTPValidationErrorException
+                        },
+                        'body': requestBody,
+                        'mediaType': 'application/json',
+                        'outputFormat': 'raw'
+                    });
+                }
+                """
+            ),
+            [
+                "ExampleModel",
+            ],
+        ),
+    ],
+)
+def test_build_raw_response_action(
+    url: str,
+    method_name: str,
+    definition: ActionDefinition,
+    expected_function: str,
+    expected_imports: list[str],
+):
+    builder = OpenAPIToTypescriptActionConverter()
+    built_function, build_imports = builder.build_action(url, definition, method_name)
+    assert re_sub(r"\s+", "", built_function) == re_sub(r"\s+", "", expected_function)
     assert set(build_imports) == set(expected_imports)

--- a/mountaineer/actions/passthrough.py
+++ b/mountaineer/actions/passthrough.py
@@ -19,7 +19,7 @@ from typing import (
     overload,
 )
 
-from fastapi.responses import Response, StreamingResponse
+from fastapi.responses import JSONResponse, Response, StreamingResponse
 from pydantic import BaseModel
 
 from mountaineer.actions.fields import (
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
     from mountaineer.controller import ControllerBase
 
 P = ParamSpec("P")
-R = TypeVar("R", bound=BaseModel | AsyncIterator[BaseModel] | None)
+R = TypeVar("R", bound=BaseModel | AsyncIterator[BaseModel] | JSONResponse | None)
 
 RawResponseR = TypeVar("RawResponseR", bound=Response)
 

--- a/mountaineer/actions/sideeffect.py
+++ b/mountaineer/actions/sideeffect.py
@@ -1,7 +1,17 @@
 from contextlib import asynccontextmanager
 from functools import partial, wraps
 from inspect import Parameter, isawaitable, signature
-from typing import TYPE_CHECKING, Any, Callable, Type, overload
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Awaitable,
+    Callable,
+    Coroutine,
+    ParamSpec,
+    Type,
+    TypeVar,
+    overload,
+)
 from urllib.parse import urlparse
 
 from fastapi import Request
@@ -24,22 +34,28 @@ from mountaineer.render import FieldClassDefinition
 if TYPE_CHECKING:
     from mountaineer.controller import ControllerBase
 
+# TypedResponseType = TypeVar("TypedResponseType", bound=Callable[..., RenderBase | None])
+
+
+P = ParamSpec("P")
+R = TypeVar("R", bound=BaseModel | None)
+
 
 @overload
 def sideeffect(
     *,
-    # We need to typehint reload to be Any, because during typechecking our Model.attribute will just
-    # yield whatever the typehint of that field is. Only at runtime does it become a FieldClassDefinition
     reload: tuple[Any, ...] | None = None,
     response_model: Type[BaseModel] | None = None,
     exception_models: list[Type[APIException]] | None = None,
     experimental_render_reload: bool | None = None,
-) -> Callable[[Callable], Callable]:
+) -> Callable[[Callable[P, R | Coroutine[Any, Any, R]]], Callable[P, Awaitable[R]]]:
     ...
 
 
 @overload
-def sideeffect(func: Callable) -> Callable:
+def sideeffect(
+    func: Callable[P, R | Coroutine[Any, Any, R]],
+) -> Callable[P, Awaitable[R]]:
     ...
 
 

--- a/mountaineer/actions/sideeffect.py
+++ b/mountaineer/actions/sideeffect.py
@@ -15,6 +15,7 @@ from typing import (
 from urllib.parse import urlparse
 
 from fastapi import Request
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 from starlette.routing import Match
 
@@ -34,11 +35,8 @@ from mountaineer.render import FieldClassDefinition
 if TYPE_CHECKING:
     from mountaineer.controller import ControllerBase
 
-# TypedResponseType = TypeVar("TypedResponseType", bound=Callable[..., RenderBase | None])
-
-
 P = ParamSpec("P")
-R = TypeVar("R", bound=BaseModel | None)
+R = TypeVar("R", bound=BaseModel | JSONResponse | None)
 
 
 @overload

--- a/mountaineer/app.py
+++ b/mountaineer/app.py
@@ -198,7 +198,9 @@ class AppController:
             f"{self.internal_api_prefix}/{underscore(controller.__class__.__name__)}"
         )
         for _, fn, metadata in controller._get_client_functions():
-            openapi_extra: dict[str, Any] = {}
+            openapi_extra: dict[str, Any] = {
+                "is_raw_response": metadata.get_is_raw_response()
+            }
 
             if not metadata.get_is_raw_response():
                 # We need to delay adding the typehint for each function until we are here, adding the view. Since

--- a/mountaineer/app.py
+++ b/mountaineer/app.py
@@ -198,30 +198,32 @@ class AppController:
             f"{self.internal_api_prefix}/{underscore(controller.__class__.__name__)}"
         )
         for _, fn, metadata in controller._get_client_functions():
-            # We need to delay adding the typehint for each function until we are here, adding the view. Since
-            # decorators run before the class is actually mounted, they're isolated from the larger class/controller
-            # context that the action function is being defined within. Here since we have a global view
-            # of the controller (render function + actions) this becomes trivial
-            metadata.return_model = fuse_metadata_to_response_typehint(
-                metadata, render_metadata.get_render_model()
-            )
+            openapi_extra: dict[str, Any] = {}
 
-            # Update the signature of the internal function, which fastapi will sniff for the return declaration
-            # https://github.com/tiangolo/fastapi/blob/a235d93002b925b0d2d7aa650b7ab6d7bb4b24dd/fastapi/dependencies/utils.py#L207
-            method_function: Callable = fn.__func__  # type: ignore
-            method_function.__signature__ = signature(method_function).replace(  # type: ignore
-                return_annotation=metadata.return_model
-            )
+            if not metadata.get_is_raw_response():
+                # We need to delay adding the typehint for each function until we are here, adding the view. Since
+                # decorators run before the class is actually mounted, they're isolated from the larger class/controller
+                # context that the action function is being defined within. Here since we have a global view
+                # of the controller (render function + actions) this becomes trivial
+                metadata.return_model = fuse_metadata_to_response_typehint(
+                    metadata, render_metadata.get_render_model()
+                )
+
+                # Update the signature of the internal function, which fastapi will sniff for the return declaration
+                # https://github.com/tiangolo/fastapi/blob/a235d93002b925b0d2d7aa650b7ab6d7bb4b24dd/fastapi/dependencies/utils.py#L207
+                method_function: Callable = fn.__func__  # type: ignore
+                method_function.__signature__ = signature(method_function).replace(  # type: ignore
+                    return_annotation=metadata.return_model
+                )
+
+                # Pass along relevant tags in the OpenAPI meta struct
+                # This will appear in the root key of the API route, at the same level of "summary" and "parameters"
+                if metadata.get_media_type():
+                    openapi_extra["media_type"] = metadata.get_media_type()
 
             metadata.url = (
                 f"{controller_url_prefix}/{metadata.function_name.strip('/')}"
             )
-
-            # Pass along relevant tags in the OpenAPI meta struct
-            # This will appear in the root key of the API route, at the same level of "summary" and "parameters"
-            openapi_extra: dict[str, Any] = {}
-            if metadata.get_media_type():
-                openapi_extra["media_type"] = metadata.get_media_type()
 
             controller_api.post(
                 f"/{metadata.function_name}", openapi_extra=openapi_extra

--- a/mountaineer/client_builder/openapi.py
+++ b/mountaineer/client_builder/openapi.py
@@ -224,6 +224,7 @@ class ActionDefinition(BaseModel):
     # Custom Mountaineer event types specified in the OpenAPI schema
     # These should all have defaults since they're optional
     media_type: str | None = None
+    is_raw_response: bool = False
 
 
 class EndpointDefinition(BaseModel):

--- a/mountaineer/static/api.ts
+++ b/mountaineer/static/api.ts
@@ -26,13 +26,15 @@ interface FetchParams {
   >;
   body?: Record<string, any>;
   mediaType?: string;
-  outputFormat?: "json" | "text";
+  outputFormat?: "json" | "text" | "raw";
   eventStreamResponse?: boolean;
 }
 
 const handleOutputFormat = async (response: Response, format?: string) => {
   if (format === "text") {
     return await response.text();
+  } else if (format == "raw") {
+    return response;
   } else {
     // Assume JSON if not specified
     return await response.json();

--- a/mountaineer/static/ssr_polyfills.js
+++ b/mountaineer/static/ssr_polyfills.js
@@ -9,3 +9,5 @@ class TextEncoder {
     return str;
   }
 }
+
+Intl.Locale = undefined;


### PR DESCRIPTION
`@passthrough` functions provide some syntactic sugar over standard POST API endpoints, since most endpoints want to return objects for use on the client side.

Previous PRs added:
- Object streaming support via [async generators](https://github.com/piercefreeman/mountaineer/pull/57)
- Returning [JSONResponse](https://github.com/piercefreeman/mountaineer/commit/803dd21c5b79a7348fac4f91807f45f58598d035), to provide additional headers during passthroughs and sideeffects

This PR adds stronger typehinting to define which endpoints support which kind of return functions, so mypy/pyright should throw an error early if you try to use an incompatible function signature. We also add support for returning arbitrary starlette Response objects in `passthrough` functions:

```python
@passthrough(raw_response=True)
async def my_passthrough(self):
    return HTMLResponse(content=...)
```

This will still generate client-side actions for users, but will return the vanilla fetch() Response. We will still perform our default Exception checking for raw responses. The definition stubs will look like this:

```typescript
export const my_method_fn = (
    {requestBody}: {requestBody: ExampleModel}
): Promise<Response> => {
    return __request({
        'method': 'POST',
        'url': '/testing/url',
        'errors': {
            422: HTTPValidationErrorException
        },
        'body': requestBody,
        'mediaType': 'application/json',
        'outputFormat': 'raw'
    });
}
```

This offers an escape hatch for situations where users really need to return raw responses that don't conform to native Mountaineer conventions, without having to interface with the fastapi `app` directly.