### PR TITLE
Partial JS Builds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,7 +88,7 @@ jobs:
           make clean-poetry-lock
           make install-deps-lib
 
-      - name: Python tests
+      - name: Tests
         run: make test-lib
         env:
           GOROOT: ${{ env.GOROOT }}

--- a/mountaineer/__tests__/client_builder/test_build_schemas.py
+++ b/mountaineer/__tests__/client_builder/test_build_schemas.py
@@ -8,6 +8,7 @@ from mountaineer.client_builder.build_schemas import (
     OpenAPISchema,
     OpenAPIToTypescriptSchemaConverter,
 )
+from mountaineer.client_builder.openapi import OpenAPIProperty, OpenAPISchemaType
 
 
 class SubModel1(BaseModel):
@@ -224,3 +225,25 @@ def test_defaults_are_required(defaults_are_required: bool):
         else:
             assert "a: string" not in js_interfaces[model_name]
             assert "a?: string" in js_interfaces[model_name]
+
+
+@pytest.mark.parametrize(
+    "model_title, expected_interface",
+    [
+        ("MyModel", "MyModel"),
+        # We've seen cases where sub-variables are converted to multiple words
+        ("My Model", "MyModel"),
+        ("My model", "MyModel"),
+    ],
+)
+def test_get_typescript_interface_name(model_title: str, expected_interface: str):
+    converter = OpenAPIToTypescriptSchemaConverter()
+    assert (
+        converter.get_typescript_interface_name(
+            OpenAPIProperty.from_meta(
+                title=model_title,
+                variable_type=OpenAPISchemaType.OBJECT,
+            )
+        )
+        == expected_interface
+    )

--- a/mountaineer/__tests__/test_cli.py
+++ b/mountaineer/__tests__/test_cli.py
@@ -7,8 +7,8 @@ from fastapi.testclient import TestClient
 from pydantic import BaseModel
 
 from mountaineer.cli import (
+    IsolatedBuildConfig,
     IsolatedEnvProcess,
-    IsolatedWatchConfig,
     find_packages_with_prefix,
 )
 from mountaineer.controllers.exception_controller import ExceptionController
@@ -50,7 +50,7 @@ def test_dev_exception_on_get(tmpdir: str):
     # Install our exception handler hook. The rest of the env process is unused, we just
     # need it for the mounted controller.
     # This is a hack to avoid calling run(), which will trigger an actual build
-    env_process = IsolatedEnvProcess(IsolatedWatchConfig(webcontroller=""))
+    env_process = IsolatedEnvProcess(IsolatedBuildConfig(webcontroller=""))
     env_process.exception_controller = exception_controller
     app.exception_handler(Exception)(env_process.handle_dev_exception)
 

--- a/mountaineer/cache.py
+++ b/mountaineer/cache.py
@@ -1,7 +1,7 @@
 import functools
 from collections import OrderedDict
 from hashlib import sha256
-from json import dumps
+from json import dumps as json_dumps
 from typing import Any, Callable
 
 from pydantic import BaseModel
@@ -52,7 +52,7 @@ def serialize_args(args, kwargs):
             serialized.append((key, value.model_dump_json()))
         else:
             serialized.append((key, value))
-    return dumps(serialized, sort_keys=True)
+    return json_dumps(serialized, sort_keys=True)
 
 
 def extended_lru_cache(maxsize: int, max_size_mb: float | None = None):
@@ -85,7 +85,7 @@ def extended_lru_cache(maxsize: int, max_size_mb: float | None = None):
 
             # Serialize result to check size
             if use_cache:
-                serialized_result = dumps(result)
+                serialized_result = json_dumps(result)
                 size_bytes = len(serialized_result.encode("utf-8"))
                 cache.put(hash_key, result, size_bytes)
 

--- a/mountaineer/client_builder/build_schemas.py
+++ b/mountaineer/client_builder/build_schemas.py
@@ -234,7 +234,7 @@ class OpenAPIToTypescriptSchemaConverter:
             raise ValueError(
                 f"Model must have a title to retrieve its typescript name: {model}"
             )
-        return camelize(model.title)
+        return camelize(model.title.replace(" ", "_"))
 
     def validate_typescript_candidate(self, model: Type[BaseModel]):
         """

--- a/mountaineer/js_compiler/javascript.py
+++ b/mountaineer/js_compiler/javascript.py
@@ -361,6 +361,7 @@ class JavascriptBundler(ClientBuilderBase):
                     )
                 continue
 
+            # If the file exists, we assume it's to the correct path
             LOGGER.debug(f"Linking {file_name} to {temp_dir_path}")
             (temp_dir_path / file_name).unlink(missing_ok=True)
             (temp_dir_path / file_name).symlink_to(view_root_path / file_name)

--- a/mountaineer/test_utilities.py
+++ b/mountaineer/test_utilities.py
@@ -78,7 +78,7 @@ def benchmark_function(max_time_seconds: int | float):
                 if end is None:
                     raise Exception("Test function did not call end_timing")
 
-                LOGGER.info(f"Test function took: {end - start}")
+                LOGGER.info(f"Test function took: {(end - start) / 1e9}")
 
                 if (end - start) / 1e9 > max_time_seconds:
                     raise ExecutionTooLong()

--- a/mountaineer/watch.py
+++ b/mountaineer/watch.py
@@ -19,10 +19,12 @@ class CallbackType(Flag):
     MODIFIED = auto()
     DELETED = auto()
 
+
 @dataclass
 class CallbackEvent:
     action: CallbackType
     path: Path
+
 
 @dataclass
 class CallbackMetadata:
@@ -30,10 +32,12 @@ class CallbackMetadata:
     # in the batch.
     events: list[CallbackEvent]
 
+
 @dataclass
 class CallbackDefinition:
     action: CallbackType
     callback: Callable[[CallbackMetadata], None]
+
 
 class ChangeEventHandler(FileSystemEventHandler):
     def __init__(
@@ -71,7 +75,7 @@ class ChangeEventHandler(FileSystemEventHandler):
             return
         if not event.is_directory:
             secho(f"File created: {event.src_path}", fg="yellow")
-            self._debounce(CallbackType.CREATED, Path(event.src_path)
+            self._debounce(CallbackType.CREATED, Path(event.src_path))
 
     def on_deleted(self, event):
         super().on_deleted(event)
@@ -164,9 +168,7 @@ class PackageWatchdog:
         with self.acquire_watchdog_lock():
             if self.run_on_bootup:
                 for callback_definition in self.callbacks:
-                    callback_definition.callback(
-                        CallbackMetadata(events=[])
-                    )
+                    callback_definition.callback(CallbackMetadata(events=[]))
 
             event_handler = ChangeEventHandler(callbacks=self.callbacks)
             observer = Observer()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ use std::time::Duration;
 
 mod errors;
 mod lexers;
+mod logging;
 mod source_map;
 mod ssr;
 mod timeout;

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,0 +1,26 @@
+use std::io::{self, Write};
+use std::sync::{Arc, Mutex};
+
+pub struct StdoutWrapper(Arc<Mutex<dyn Write + Send + 'static>>);
+
+impl StdoutWrapper {
+    pub fn new() -> Self {
+        StdoutWrapper(Arc::new(Mutex::new(io::stdout())))
+    }
+
+    pub fn get_arc(&self) -> Arc<Mutex<dyn Write + Send + 'static>> {
+        self.0.clone()
+    }
+}
+
+impl Write for StdoutWrapper {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let mut writer = self.0.lock().expect("Failed to lock mutex");
+        writer.write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        let mut writer = self.0.lock().expect("Failed to lock mutex");
+        writer.flush()
+    }
+}

--- a/src/ssr.rs
+++ b/src/ssr.rs
@@ -27,7 +27,10 @@
 // DEALINGS IN THE SOFTWARE.
 
 use crate::errors::AppError;
+use crate::logging::StdoutWrapper;
 use std::collections::HashMap;
+use std::io::Write;
+use std::sync::{Arc, Mutex};
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct Ssr<'a> {
@@ -35,6 +38,14 @@ pub struct Ssr<'a> {
     source: String,
     entry_point: &'a str,
 }
+
+struct LoggerData {
+    console_type: String,
+    stdout: Arc<Mutex<dyn Write + 'static>>,
+}
+
+// Ensure that LoggerData can be sent safely across threads.
+unsafe impl Send for LoggerData {}
 
 impl<'a> Ssr<'a> {
     /// Create an instance of the Ssr struct instanciate the v8 platform as well.
@@ -63,10 +74,20 @@ impl<'a> Ssr<'a> {
     /// Evaluates the JS source code instanciate in the Ssr struct
     /// "enrty_point" is the variable name set from the frontend bundler used. <a href="https://github.com/Valerioageno/ssr-rs/blob/main/client/webpack.ssr.js" target="_blank">Here</a> an example from webpack.
     pub fn render_to_string(&self, params: Option<&str>) -> Result<String, AppError> {
-        Self::render(self.source.clone(), self.entry_point, params)
+        Self::render(
+            self.source.clone(),
+            self.entry_point,
+            params,
+            StdoutWrapper::new().get_arc(),
+        )
     }
 
-    fn render(source: String, entry_point: &str, params: Option<&str>) -> Result<String, AppError> {
+    fn render(
+        source: String,
+        entry_point: &str,
+        params: Option<&str>,
+        stdout: Arc<Mutex<dyn Write + 'static>>,
+    ) -> Result<String, AppError> {
         /*
          * Main entrypoint for rendering, takes a source string (containing one or many functions) and
          * an entry point (ie. function name to execute) and returns the result of the execution as
@@ -79,7 +100,7 @@ impl<'a> Ssr<'a> {
         let scope = &mut v8::ContextScope::new(handle_scope, context);
 
         // Add logging support
-        Self::inject_logger(&mut context, scope);
+        Self::inject_logger(&mut context, scope, stdout);
 
         // Encapsulate all V8 operations that might throw exceptions within this TryCatch block
         let try_catch = &mut v8::TryCatch::new(scope);
@@ -155,6 +176,7 @@ impl<'a> Ssr<'a> {
     fn inject_logger(
         context: &mut v8::Local<'_, v8::Context>,
         scope: &mut v8::ContextScope<'_, v8::HandleScope<'_>>,
+        stdout: Arc<Mutex<dyn Write + 'static>>,
     ) {
         let console_types = vec!["log", "warn", "info", "debug", "error"];
         let global = context.global(scope);
@@ -170,12 +192,12 @@ impl<'a> Ssr<'a> {
             });
 
         for console_type in console_types {
-            // Convert to native types which can be stored in the C++ engine
-            let console_type_v8_str = v8::String::new(scope, console_type).unwrap();
-            let console_type_data = v8::External::new(
-                scope,
-                Box::into_raw(Box::new(console_type_v8_str)) as *mut _,
-            );
+            let logger_data = LoggerData {
+                console_type: console_type.to_string(),
+                stdout: stdout.clone(),
+            };
+            let logger_data_external =
+                v8::External::new(scope, Box::into_raw(Box::new(logger_data)) as *mut _);
 
             // Normally, we'd just use a closure to pass the console data into our handler function.
             // However, the Function() syntax in V8 relies on us passing a raw function _pointer_ into
@@ -189,32 +211,36 @@ impl<'a> Ssr<'a> {
                       args: v8::FunctionCallbackArguments,
                       mut ret_val: v8::ReturnValue| {
                     let data = args.data();
-                    // We expect our data to external, but we should check it to be safe.
-                    if data.is_external() {
+                    let logger_data = if data.is_external() {
                         let external = unsafe { v8::Local::<v8::External>::cast(data) };
-                        let console_type_ptr = external.value();
-                        let console_type = unsafe { &*(console_type_ptr as *const String) };
-
-                        let log_message = (0..args.length())
-                            .map(|i| {
-                                args.get(i)
-                                    .to_string(scope)
-                                    .unwrap()
-                                    .to_rust_string_lossy(scope)
-                            })
-                            .collect::<Vec<String>>()
-                            .join(" ");
-
-                        println!("ssr console [{}]: {}", console_type, log_message);
+                        let logger_data_ptr = external.value();
+                        unsafe { &*(logger_data_ptr as *const LoggerData) }
                     } else {
-                        // Handle the unexpected case where data is not an external.
-                        println!("Error: Expected external data not found.");
-                    }
+                        panic!("Expected logger data to be passed as external data");
+                    };
+
+                    let log_message = (0..args.length())
+                        .map(|i| {
+                            args.get(i)
+                                .to_string(scope)
+                                .unwrap()
+                                .to_rust_string_lossy(scope)
+                        })
+                        .collect::<Vec<String>>()
+                        .join(" ");
+
+                    let mut stdout_lock = logger_data.stdout.lock().unwrap();
+                    writeln!(
+                        stdout_lock,
+                        "ssr console [{}]: {}",
+                        logger_data.console_type, log_message
+                    )
+                    .expect("Failed to write to stdout");
 
                     ret_val.set_undefined();
                 },
             )
-            .data(console_type_data.into())
+            .data(logger_data_external.into())
             .build(scope)
             .unwrap();
 
@@ -333,5 +359,34 @@ mod tests {
         let result = js.render_to_string(None);
 
         assert_eq!(result, Ok("<html></html>".to_string()))
+    }
+
+    #[test]
+    fn test_log_to_stdout() {
+        // Create a synthetic stdout that we can inspect
+        let stdout = Arc::new(Mutex::new(Vec::new()));
+
+        Ssr::init_platform();
+        let result = Ssr::render(
+            r##"
+                var SSR = {
+                    x: () => {
+                        console.log('test log');
+                        return "<html></html>"
+                    }
+                };"##
+                .to_string(),
+            "SSR",
+            None,
+            stdout.clone(),
+        );
+
+        let result_vector = stdout.lock().unwrap();
+
+        assert_eq!(result, Ok("<html></html>".to_string()));
+        assert_eq!(
+            String::from_utf8_lossy(&*result_vector),
+            "ssr console [log]: test log\n"
+        );
     }
 }


### PR DESCRIPTION
## Javascript only builds

We modify our watch logic to keep track of what files were actually modified. We bundle up this change log so the builder can determine the type of changes that were made. This speeds up builds by letting us do the minimum computation for each change type. More specifically:

If a _view_ file has changed but the _server_ has not, there's no reason to restart the python runtime and server codebase. We will keep the server running in our isolated watch process and just perform a rebuild of the client files.

If the server has updated but the _API_ has not changed, there's no reason to rebuild the `useServer` client hooks. Since our file building process is deterministic given the input OpenAPI schema, this will just result in the same files that were generated previously. At the moment we still rebuild the view files to make sure that we have all the latest changes, but in theory this too could be delayed if we detect that no view files have changed.

## console.log in SSR

Our V8 engine performs all server side rendering in an isolated environment, so we don't pass through any of the stdout/stderr pipes like normally happens in Node. This necessarily means that logging is swallowed, which sometimes makes it harder to debug server-side-rendering behavior.

As part of this PR we also add `console.log` support for the SSR engine, which will route to being logged as normal in Rust.