### PR TITLE
Optional passthrough of custom fastapi args

### DIFF
--- a/mountaineer/app.py
+++ b/mountaineer/app.py
@@ -59,6 +59,7 @@ class AppController:
         global_metadata: Metadata | None = None,
         custom_builders: list[ClientBuilderBase] | None = None,
         config: ConfigBase | None = None,
+        fastapi_args: dict[str, Any] | None = None,
     ):
         """
         :param global_metadata: Script and meta will be applied to every
@@ -67,7 +68,7 @@ class AppController:
         :param config: Application global configuration.
 
         """
-        self.app = FastAPI(title=name, version=version)
+        self.app = FastAPI(title=name, version=version, **(fastapi_args or {}))
         self.controllers: list[ControllerDefinition] = []
         self.name = name
         self.version = version


### PR DESCRIPTION
Some FastAPI arguments are only available at init time and can't be overridden after the fact. `lifespan` is one of these, which allows you to install custom hooks at the beginning and termination of your webapp process. To support these init arguments in a generic way, we add a new `fastapi_args` parameter to the AppController. At runtime we will pass these through as-declared so you can override any default argument that FastAPI supports now and in the future.