### PR TITLE
Improve APIException processing and inheritance

### DIFF
--- a/mountaineer/__tests__/actions/test_passthrough.py
+++ b/mountaineer/__tests__/actions/test_passthrough.py
@@ -43,7 +43,6 @@ def test_markup_passthrough():
     assert isinstance(metadata.reload_states, MountaineerUnsetValue)
     assert isinstance(metadata.render_model, MountaineerUnsetValue)
     assert isinstance(metadata.return_model, MountaineerUnsetValue)
-    assert isinstance(metadata.render_router, MountaineerUnsetValue)
 
 
 class ExampleRenderModel(RenderBase):

--- a/mountaineer/__tests__/actions/test_passthrough.py
+++ b/mountaineer/__tests__/actions/test_passthrough.py
@@ -42,7 +42,6 @@ def test_markup_passthrough():
     assert metadata.function_name == "get_external_data"
     assert isinstance(metadata.reload_states, MountaineerUnsetValue)
     assert isinstance(metadata.render_model, MountaineerUnsetValue)
-    assert isinstance(metadata.url, MountaineerUnsetValue)
     assert isinstance(metadata.return_model, MountaineerUnsetValue)
     assert isinstance(metadata.render_router, MountaineerUnsetValue)
 
@@ -171,7 +170,10 @@ async def test_can_call_iterable():
     assert isinstance(return_value_sync, StreamingResponse)
 
     # StreamingResponses are intended to be read by an ASGI server, so we'll use the TestClient to simulate one instead of calling directly
-    passthrough_url = get_function_metadata(controller.get_data).get_url()
+    controller_definition = app.definition_for_controller(controller)
+    passthrough_url = controller_definition.get_url_for_metadata(
+        get_function_metadata(controller.get_data)
+    )
 
     client = TestClient(app.app)
     lines: list[str] = []
@@ -208,9 +210,13 @@ async def test_raw_response():
     controller = TestController()
     app.register(controller)
 
+    controller_definition = app.definition_for_controller(controller)
+
     client = TestClient(app.app)
     response = client.post(
-        get_function_metadata(controller.call_passthrough).get_url(),
+        controller_definition.get_url_for_metadata(
+            get_function_metadata(controller.call_passthrough)
+        ),
         json={},
     )
     # No "passthrough" wrapping

--- a/mountaineer/__tests__/actions/test_sideeffect.py
+++ b/mountaineer/__tests__/actions/test_sideeffect.py
@@ -51,7 +51,6 @@ def test_markup_sideeffect():
     assert metadata.reload_states == tuple([ExampleRenderModel.value_a])
     assert isinstance(metadata.render_model, MountaineerUnsetValue)
     assert isinstance(metadata.return_model, MountaineerUnsetValue)
-    assert isinstance(metadata.render_router, MountaineerUnsetValue)
 
 
 class ControllerCommon(ControllerBase):

--- a/mountaineer/__tests__/actions/test_sideeffect.py
+++ b/mountaineer/__tests__/actions/test_sideeffect.py
@@ -50,7 +50,6 @@ def test_markup_sideeffect():
     assert metadata.function_name == "sideeffect_and_return_data"
     assert metadata.reload_states == tuple([ExampleRenderModel.value_a])
     assert isinstance(metadata.render_model, MountaineerUnsetValue)
-    assert isinstance(metadata.url, MountaineerUnsetValue)
     assert isinstance(metadata.return_model, MountaineerUnsetValue)
     assert isinstance(metadata.render_router, MountaineerUnsetValue)
 
@@ -261,7 +260,10 @@ def test_limit_codepath_experimental(
     controller = ExampleController()
     app.register(controller)
 
-    sideeffect_url = get_function_metadata(ExampleController.call_sideeffect).get_url()
+    controller_definition = app.definition_for_controller(controller)
+    sideeffect_url = controller_definition.get_url_for_metadata(
+        get_function_metadata(ExampleController.call_sideeffect)
+    )
 
     client = TestClient(app.app)
     start = monotonic_ns()

--- a/mountaineer/__tests__/client_builder/test_build_actions.py
+++ b/mountaineer/__tests__/client_builder/test_build_actions.py
@@ -158,6 +158,16 @@ EXAMPLE_RESPONSE_400 = ContentBodyDefinition(
                         in_location=ParameterLocationType.QUERY,
                         required=True,
                     ),
+                    # Cookies should be skipped
+                    URLParameterDefinition.from_meta(
+                        name="auth_cookie",
+                        schema_ref=OpenAPIProperty.from_meta(
+                            title="",
+                            variable_type=OpenAPISchemaType.STRING,
+                        ),
+                        in_location=ParameterLocationType.COOKIE,
+                        required=True,
+                    ),
                     # Optional query parameter
                     URLParameterDefinition.from_meta(
                         name="query_param_optional_id",

--- a/mountaineer/__tests__/client_builder/test_build_schemas.py
+++ b/mountaineer/__tests__/client_builder/test_build_schemas.py
@@ -129,7 +129,10 @@ def test_python_to_typescript_types(
 
     converter = OpenAPIToTypescriptSchemaConverter()
     interface_definition = converter.convert_schema_to_interface(
-        schema, base=schema, defaults_are_required=False
+        schema,
+        base=schema,
+        defaults_are_required=False,
+        all_fields_required=False,
     )
 
     for expected_str in expected_typescript_types:

--- a/mountaineer/actions/fields.py
+++ b/mountaineer/actions/fields.py
@@ -69,7 +69,6 @@ class FunctionMetadata(BaseModel):
     ] | None | MountaineerUnsetValue = MountaineerUnsetValue()
 
     # Inserted by the render decorator
-    url: str | MountaineerUnsetValue = MountaineerUnsetValue()
     return_model: Type[BaseModel] | MountaineerUnsetValue = MountaineerUnsetValue()
     render_router: APIRouter | MountaineerUnsetValue = MountaineerUnsetValue()
 
@@ -110,11 +109,6 @@ class FunctionMetadata(BaseModel):
 
     def get_is_raw_response(self) -> bool:
         return self.is_raw_response
-
-    def get_url(self) -> str:
-        if isinstance(self.url, MountaineerUnsetValue):
-            raise ValueError("URL not set")
-        return self.url
 
     def get_return_model(self) -> Type[BaseModel]:
         if isinstance(self.return_model, MountaineerUnsetValue):

--- a/mountaineer/actions/fields.py
+++ b/mountaineer/actions/fields.py
@@ -18,7 +18,6 @@ from typing import (
 )
 
 import starlette.responses
-from fastapi import APIRouter
 from fastapi.responses import JSONResponse
 from inflection import camelize
 from pydantic import BaseModel, create_model
@@ -70,7 +69,6 @@ class FunctionMetadata(BaseModel):
 
     # Inserted by the render decorator
     return_model: Type[BaseModel] | MountaineerUnsetValue = MountaineerUnsetValue()
-    render_router: APIRouter | MountaineerUnsetValue = MountaineerUnsetValue()
 
     model_config = {
         "arbitrary_types_allowed": True,
@@ -114,11 +112,6 @@ class FunctionMetadata(BaseModel):
         if isinstance(self.return_model, MountaineerUnsetValue):
             raise ValueError("Return model not set")
         return self.return_model
-
-    def get_render_router(self) -> APIRouter:
-        if isinstance(self.render_router, MountaineerUnsetValue):
-            raise ValueError("Render router not set")
-        return self.render_router
 
 
 METADATA_ATTRIBUTE = "_mountaineer_metadata"

--- a/mountaineer/actions/fields.py
+++ b/mountaineer/actions/fields.py
@@ -188,9 +188,16 @@ def fuse_metadata_to_response_typehint(
         ):
             # Make sure this class actually aligns to the response model
             # If not the user mis-specified the reload states
+            #
+            # We allow the reload state to be a subclass of the render model, in case the method
+            # was originally defined in the superclass. This will result in us sending a subset
+            # of the child controller's fields - but since our differential update is based on the
+            # original state and modified, this will resolve correctly for the client
             reload_classes = {field.root_model for field in metadata.reload_states}
             reload_keys = {field.key for field in metadata.reload_states}
-            if reload_classes != {render_model}:
+            if len(reload_classes) != 1 or not issubclass(
+                render_model, next(iter(reload_classes))
+            ):
                 raise ValueError(
                     f"Reload states {reload_classes} do not align to response model {render_model}"
                 )

--- a/mountaineer/client_builder/build_actions.py
+++ b/mountaineer/client_builder/build_actions.py
@@ -134,6 +134,8 @@ class OpenAPIToTypescriptActionConverter:
 
         for parameter in action.parameters:
             typehint_key, typehint_value = get_typehint_for_parameter(parameter)
+            if parameter.in_location == ParameterLocationType.COOKIE:
+                continue
             parameters_dict[parameter.name] = TSLiteral(parameter.name)
             typehint_dict[typehint_key] = typehint_value
 
@@ -180,6 +182,9 @@ class OpenAPIToTypescriptActionConverter:
                     common_params["path"][parameter.name] = TSLiteral(parameter.name)
                 elif parameter.in_location == ParameterLocationType.QUERY:
                     common_params["query"][parameter.name] = TSLiteral(parameter.name)
+                elif parameter.in_location == ParameterLocationType.COOKIE:
+                    # No-op, cookies will be sent automatically by fetch()
+                    continue
                 else:
                     raise NotImplementedError(
                         f"Parameter location {parameter.in_location} not supported"

--- a/mountaineer/client_builder/build_links.py
+++ b/mountaineer/client_builder/build_links.py
@@ -29,14 +29,19 @@ class OpenAPIToTypescriptLinkConverter:
             )
 
         # Extract metadata from this GET definition to fill our link generation
-        render_url, render_endpoint_definition = list(openapi_spec.paths.items())[0]
-        get_action = next(
-            (
-                endpoint
-                for endpoint in render_endpoint_definition.actions
-                if endpoint.action_type == ActionType.GET
+        # We require a single get action
+        render_payloads = [
+            (render_url, endpoint)
+            for render_url, render_endpoint_definition in openapi_spec.paths.items()
+            for endpoint in render_endpoint_definition.actions
+            if endpoint.action_type == ActionType.GET
+        ]
+        if len(render_payloads) != 1:
+            raise ValueError(
+                f"Expected exactly one GET action in render router, got {render_payloads}"
             )
-        )
+
+        render_url, get_action = render_payloads[0]
 
         input_parameters: dict[str, Any] = {}
         typehint_parameters: dict[str, Any] = {}

--- a/mountaineer/client_builder/builder.py
+++ b/mountaineer/client_builder/builder.py
@@ -227,7 +227,7 @@ class ClientBuilder:
             root_api_import_path = generate_relative_import(
                 controller_links_path, root_common_handler
             )
-            render_route = get_function_metadata(controller.render).get_render_router()
+            render_route = controller_definition.render_router
             render_openapi = self.app.generate_openapi(
                 routes=render_route.routes,
             )

--- a/mountaineer/client_builder/builder.py
+++ b/mountaineer/client_builder/builder.py
@@ -138,8 +138,8 @@ class ClientBuilder:
                 ) in self.openapi_schema_converter.convert_schema_to_typescript(
                     render_base,
                     # Render models are sent server -> client, so we know they'll provide all their
-                    # default values in the initial payload
-                    defaults_are_required=True,
+                    # values in the initial payload
+                    all_fields_required=True,
                 ).items():
                     schemas[schema_name] = component
 
@@ -158,6 +158,7 @@ class ClientBuilder:
                     # This is in contrast to the render() where we always know the response
                     # payloads should be force required.
                     defaults_are_required=False,
+                    all_fields_required=False,
                 )
 
             # We put in one big models.ts file to enable potentially cyclical dependencies

--- a/mountaineer/client_builder/openapi.py
+++ b/mountaineer/client_builder/openapi.py
@@ -24,6 +24,9 @@ class ParameterLocationType(StrEnum):
     PATH = "path"
     QUERY = "query"
 
+    # https://swagger.io/docs/specification/authentication/cookie-authentication/
+    COOKIE = "cookie"
+
 
 class ActionType(StrEnum):
     GET = "get"

--- a/mountaineer/controller.py
+++ b/mountaineer/controller.py
@@ -250,6 +250,7 @@ class ControllerBase(ABC, Generic[RenderInput]):
 
         """
         # Iterate over all the functions in this class and see which ones have a _metadata attribute
+        # We specifically traverse through the MRO, except the last one (object class)
         for name, func in getmembers(self, predicate=ismethod):
             try:
                 metadata = get_function_metadata(func)

--- a/mountaineer/controller.py
+++ b/mountaineer/controller.py
@@ -4,7 +4,18 @@ from inspect import getmembers, isawaitable, ismethod
 from pathlib import Path
 from re import compile as re_compile
 from time import monotonic_ns
-from typing import Any, Callable, Coroutine, Generic, Iterable, Mapping, ParamSpec, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Coroutine,
+    Generic,
+    Iterable,
+    Mapping,
+    Optional,
+    ParamSpec,
+    cast,
+)
 
 from fastapi.responses import HTMLResponse
 from inflection import underscore
@@ -28,6 +39,9 @@ from mountaineer.render import (
 )
 from mountaineer.ssr import V8RuntimeError, render_ssr
 
+if TYPE_CHECKING:
+    from mountaineer.app import ControllerDefinition
+
 RenderInput = ParamSpec("RenderInput")
 
 
@@ -39,6 +53,10 @@ class ControllerBase(ABC, Generic[RenderInput]):
     view_path: str | ManagedViewPath
 
     bundled_scripts: list[str]
+
+    # Upon registration, the AppController will mount a wrapper
+    # with state metadata
+    definition: Optional["ControllerDefinition"] = None
 
     def __init__(
         self, slow_ssr_threshold: float = 0.1, hard_ssr_timeout: float | None = 10.0

--- a/mountaineer/exceptions.py
+++ b/mountaineer/exceptions.py
@@ -46,6 +46,7 @@ class InternalModelMeta(type):
             __base__=APIExceptionInternalModelBase,
             **cast(Any, fields),
         )
+        cls.InternalModel.__module__ = cls.__module__
 
     def __call__(cls, *args, **kwargs):
         # Override the __call__ method to instantiate models like Pydantic does


### PR DESCRIPTION
This PR fixes some edge cases with OpenAPI schema construction and parsing for use in JS generation.

## Cookies

Cookies accessed by method signatures will be captured in the raw OpenAPI schema. The client application will pass through these automatically with the `fetch()` defaults, so we allow our action builder to parse them but skip over them during the JS function construction.

## Exceptions

We add stronger validation of user-provided APIExceptions:
- Ensure that only one status code is available for each action URL, since OpenAPI switches based on status code value.
- Allow multiple APIException subclasses that have the same name, as long as they're defined in separate files. In this case we fallback to naming the schema based on the module and class name to avoid conflicting schema definitions. The default behavior for unique exception names remains unchanged.

We also fix a bug that prevented ControllerBase inheritance from inheriting exceptions that were defined in parent classes.