### PR TITLE
Pin mountaineer to CMA version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,6 +166,7 @@ test-project
 
 # Include create-mountaineer-app env files, since these are part of the template
 !*/create_mountaineer_app/templates/project/.env
+!*/create_mountaineer_app/templates/editor_configs/zed/pyrightconfig.json
 
 # We don't commit our automatically managed files - you can in your project, but these
 # change so much we'd like to avoid them in code reviews.

--- a/create_mountaineer_app/create_mountaineer_app/__tests__/test_builder.py
+++ b/create_mountaineer_app/create_mountaineer_app/__tests__/test_builder.py
@@ -18,7 +18,7 @@ from create_mountaineer_app.builder import (
     environment_from_metadata,
     should_copy_path,
 )
-from create_mountaineer_app.generation import ProjectMetadata
+from create_mountaineer_app.generation import EditorType, ProjectMetadata
 from create_mountaineer_app.io import get_free_port
 from create_mountaineer_app.templates import get_template_path
 
@@ -63,7 +63,7 @@ def test_copy_path(root_path: Path, input_path: Path, expected_copy: bool):
             # Use tailwind
             [False, True],
             # Editor config
-            ["no", "vscode", "vim"],
+            [None, EditorType.VSCODE, EditorType.VIM, EditorType.ZED],
             # Create stub files
             [False, True],
         )
@@ -74,7 +74,7 @@ def test_valid_permutations(
     tmpdir: str,
     use_poetry: bool,
     use_tailwind: bool,
-    editor_config: str,
+    editor_config: EditorType | None,
     create_stub_files: bool,
 ):
     """

--- a/create_mountaineer_app/create_mountaineer_app/__tests__/test_cli.py
+++ b/create_mountaineer_app/create_mountaineer_app/__tests__/test_cli.py
@@ -1,0 +1,7 @@
+from create_mountaineer_app.cli import get_current_version_number
+
+
+def test_get_current_version_number():
+    # Before we release our package and bump the version in pyproject.toml, our version
+    # will be static during local development
+    assert get_current_version_number() == "0.1.0"

--- a/create_mountaineer_app/create_mountaineer_app/__tests__/test_generation.py
+++ b/create_mountaineer_app/create_mountaineer_app/__tests__/test_generation.py
@@ -10,9 +10,10 @@ def test_path_url_replacement():
         author_email="TEST_EMAIL",
         use_tailwind=True,
         use_poetry=True,
-        editor_config="no",
+        editor_config=None,
         create_stub_files=True,
         project_path=Path("fake-path"),
+        mountaineer_min_version="0.1.0",
         mountaineer_dev_path=None,
     )
     bundle = format_template("[project_name]/app.py", metadata)

--- a/create_mountaineer_app/create_mountaineer_app/__tests__/test_generation.py
+++ b/create_mountaineer_app/create_mountaineer_app/__tests__/test_generation.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 from create_mountaineer_app.generation import ProjectMetadata, format_template
+from create_mountaineer_app.templates import get_template_path
 
 
 def test_path_url_replacement():
@@ -16,5 +17,8 @@ def test_path_url_replacement():
         mountaineer_min_version="0.1.0",
         mountaineer_dev_path=None,
     )
-    bundle = format_template("[project_name]/app.py", metadata)
+    project_template_base = get_template_path("project")
+    bundle = format_template(
+        project_template_base / "[project_name]/app.py", project_template_base, metadata
+    )
     assert bundle.path == "TEST_PROJECT_NAME/app.py"

--- a/create_mountaineer_app/create_mountaineer_app/builder.py
+++ b/create_mountaineer_app/create_mountaineer_app/builder.py
@@ -28,8 +28,8 @@ def environment_from_metadata(metadata: ProjectMetadata) -> EnvironmentBase:
         return VEnvEnvironment()
 
 
-def editor_config_from_metadata(metadata: ProjectMetadata):
-    if metadata.editor_config == "no":
+def copy_editor_config(metadata: ProjectMetadata):
+    if not metadata.editor_config:
         return
 
     config_source = get_template_path("editor_configs") / metadata.editor_config
@@ -57,7 +57,7 @@ def should_copy_path(root_path: Path, path: Path):
     return True
 
 
-def build_project(metadata: ProjectMetadata):
+def build_project(metadata: ProjectMetadata, install_deps: bool = True):
     template_base = get_template_path("project")
     template_paths = list(template_base.glob("**/*"))
 
@@ -96,19 +96,20 @@ def build_project(metadata: ProjectMetadata):
 
     secho(f"Project created at {metadata.project_path}", fg="green")
 
-    environment = environment_from_metadata(metadata)
+    copy_editor_config(metadata)
 
-    try:
-        environment.install_project(metadata.project_path)
-    except Exception as e:
-        secho(f"Error installing python dependencies: {e}", fg="red")
+    if install_deps:
+        environment = environment_from_metadata(metadata)
 
-    if has_npm():
-        npm_install(metadata.project_path / metadata.project_name / "views")
-    else:
-        secho(
-            "npm is not installed and is required to install React dependencies.",
-            fg="red",
-        )
+        try:
+            environment.install_project(metadata.project_path)
+        except Exception as e:
+            secho(f"Error installing python dependencies: {e}", fg="red")
 
-    editor_config_from_metadata(metadata)
+        if has_npm():
+            npm_install(metadata.project_path / metadata.project_name / "views")
+        else:
+            secho(
+                "npm is not installed and is required to install React dependencies.",
+                fg="red",
+            )

--- a/create_mountaineer_app/create_mountaineer_app/cli.py
+++ b/create_mountaineer_app/create_mountaineer_app/cli.py
@@ -10,7 +10,7 @@ from create_mountaineer_app.environments.poetry import PoetryEnvironment
 from create_mountaineer_app.external import (
     get_git_user_info,
 )
-from create_mountaineer_app.generation import ProjectMetadata
+from create_mountaineer_app.generation import EditorType, ProjectMetadata
 
 
 def prompt_should_use_poetry():
@@ -106,7 +106,7 @@ def main(output_path: str | None, mountaineer_dev_path: str | None):
     ).unsafe_ask()
     input_editor_config = questionary.rawselect(
         "Add editor configuration? [vscode]",
-        choices=["vscode", "vim", "no"],
+        choices=["vscode", "vim", "zed", "no"],
         default="vscode",
     ).unsafe_ask()
 
@@ -121,7 +121,9 @@ def main(output_path: str | None, mountaineer_dev_path: str | None):
         author_email=input_author_email,
         use_poetry=input_use_poetry,
         use_tailwind=input_use_tailwind,
-        editor_config=input_editor_config if input_editor_config != "no" else None,
+        editor_config=EditorType(input_editor_config)
+        if input_editor_config != "no"
+        else None,
         project_path=project_path,
         create_stub_files=input_create_stub_files,
         mountaineer_min_version=get_current_version_number(),

--- a/create_mountaineer_app/create_mountaineer_app/cli.py
+++ b/create_mountaineer_app/create_mountaineer_app/cli.py
@@ -1,3 +1,4 @@
+from importlib.metadata import version
 from pathlib import Path
 from re import match as re_match
 
@@ -69,6 +70,17 @@ def prompt_author() -> tuple[str, str]:
         return matched_obj.group(1), matched_obj.group(2)
 
 
+def get_current_version_number():
+    """
+    Return the version of the mountaineer app that is linked to this particular
+    template project layout.
+
+    We assume the version numbers are tied, which they are deterministically in CI.
+
+    """
+    return version("create_mountaineer_app")
+
+
 @command()
 @option("--output-path", help="The output path for the bundled files.")
 @option("--mountaineer-dev-path", help="The path to the Mountaineer dev environment.")
@@ -109,9 +121,10 @@ def main(output_path: str | None, mountaineer_dev_path: str | None):
         author_email=input_author_email,
         use_poetry=input_use_poetry,
         use_tailwind=input_use_tailwind,
-        editor_config=input_editor_config,
+        editor_config=input_editor_config if input_editor_config != "no" else None,
         project_path=project_path,
         create_stub_files=input_create_stub_files,
+        mountaineer_min_version=get_current_version_number(),
         mountaineer_dev_path=Path(mountaineer_dev_path).resolve()
         if mountaineer_dev_path
         else None,

--- a/create_mountaineer_app/create_mountaineer_app/environments/base.py
+++ b/create_mountaineer_app/create_mountaineer_app/environments/base.py
@@ -44,3 +44,12 @@ class EnvironmentBase(ABC):
 
         """
         pass
+
+    @abstractmethod
+    def get_env_path(self, project_path: Path) -> str:
+        """
+        Get the environment path. Only valid after the installation
+        process has completed. Otherwise will raise an error.
+
+        """
+        pass

--- a/create_mountaineer_app/create_mountaineer_app/environments/poetry.py
+++ b/create_mountaineer_app/create_mountaineer_app/environments/poetry.py
@@ -53,15 +53,8 @@ class PoetryEnvironment(EnvironmentBase):
         )
 
         # Retrieve the location of the new virtualenv
-        result = subprocess.run(
-            ["poetry", "env", "info", "--path"],
-            check=True,
-            capture_output=True,
-            cwd=str(project_path),
-            env=self.limited_scope_env,
-        )
-
-        secho(f"Poetry venv created: {result.stdout.decode().strip()}", fg="green")
+        env_path = self.get_env_path(project_path)
+        secho(f"Poetry venv created: {env_path}", fg="green")
 
     def install_provider(self):
         """
@@ -129,3 +122,14 @@ class PoetryEnvironment(EnvironmentBase):
             cwd=path,
             env=self.limited_scope_env,
         )
+
+    def get_env_path(self, project_path: Path) -> str:
+        result = subprocess.run(
+            ["poetry", "env", "info", "--path"],
+            check=True,
+            capture_output=True,
+            cwd=str(project_path),
+            env=self.limited_scope_env,
+        )
+
+        return result.stdout.decode().strip()

--- a/create_mountaineer_app/create_mountaineer_app/environments/venv.py
+++ b/create_mountaineer_app/create_mountaineer_app/environments/venv.py
@@ -50,3 +50,10 @@ class VEnvEnvironment(EnvironmentBase):
             cwd=path,
             env={"PATH": f"{venv_path}/bin:{environ['PATH']}", **self.global_env},
         )
+
+    def get_env_path(self, project_path: Path) -> str:
+        venv_path = project_path / self.venv_name
+        if not venv_path.exists():
+            raise ValueError(f"Virtual environment not found at: {venv_path}")
+
+        return str(venv_path)

--- a/create_mountaineer_app/create_mountaineer_app/generation.py
+++ b/create_mountaineer_app/create_mountaineer_app/generation.py
@@ -12,13 +12,16 @@ class ProjectMetadata(BaseModel):
     author_email: str
     use_poetry: bool
     use_tailwind: bool
-    editor_config: str
+    editor_config: str | None
     project_path: Path
 
     postgres_password: str = "mysecretpassword"
     postgres_port: int = 5432
 
     create_stub_files: bool
+
+    # Current version of mountaineer tied to CMA version
+    mountaineer_min_version: str
 
     # If specified, will install mountaineer in development mode pointing to a local path
     # This is useful for testing changes to mountaineer itself

--- a/create_mountaineer_app/create_mountaineer_app/templates/editor_configs/vim/.vimrc
+++ b/create_mountaineer_app/create_mountaineer_app/templates/editor_configs/vim/.vimrc
@@ -1,6 +1,8 @@
+{% if editor_config == 'vim' %}
 set wildignore+=*/_server/*
 set wildignore+=*/_ssr/*
 set wildignore+=*/_static/*
 set path-=*/_server/**
 set path-=*/_ssr/**
 set path-=*/_static/**
+{% endif %}

--- a/create_mountaineer_app/create_mountaineer_app/templates/editor_configs/vscode/.vscode/settings.json
+++ b/create_mountaineer_app/create_mountaineer_app/templates/editor_configs/vscode/.vscode/settings.json
@@ -1,3 +1,4 @@
+{% if editor_config == 'vscode' %}
 {
   "files.exclude": {
     "_server/": true,
@@ -5,3 +6,4 @@
     "_static/": true
   }
 }
+{% endif %}

--- a/create_mountaineer_app/create_mountaineer_app/templates/editor_configs/zed/pyrightconfig.json
+++ b/create_mountaineer_app/create_mountaineer_app/templates/editor_configs/zed/pyrightconfig.json
@@ -1,0 +1,6 @@
+{% if editor_config == 'zed' %}
+{
+    "venv": "{{venv_name}}",
+    "venvPath": "{{venv_base}}"
+}
+{% endif %}

--- a/create_mountaineer_app/create_mountaineer_app/templates/project/pyproject.toml
+++ b/create_mountaineer_app/create_mountaineer_app/templates/project/pyproject.toml
@@ -14,7 +14,7 @@ python = "^3.11"
 {% if mountaineer_dev_path %}
 mountaineer = { path = "{{mountaineer_dev_path}}", develop = true }
 {% else %}
-mountaineer = "^0.2.0"
+mountaineer = "^{{ mountaineer_min_version }}"
 {% endif %}
 
 [build-system]
@@ -44,7 +44,7 @@ dependencies = [
     {% if mountaineer_dev_path %}
     "mountaineer @ file://{{ mountaineer_dev_path }}"
     {% else %}
-    "mountaineer"
+    "mountaineer=={{ mountaineer_min_version }}"
     {% endif %}
 ]
 


### PR DESCRIPTION
The templated project files in `create-mountaineer-app` are highly coupled to the active Mountaineer version that's within `main`. This PR removes the hard-coded Mountaineer version from the CMA templating logic, to avoid human errors where we don't bump the Mountaineer template to the appropriate version.

After this is merged and released, we will pull the same version of Mountaineer that is built concurrently with CMA. We can do this by checking the current CMA version, since they're released with equivalent feature numbers (see [here](https://github.com/piercefreeman/mountaineer/blob/9d210d61fc3f1c341470268bd4c58c267f01fd04/.github/workflows/test_create_mountaineer_app.yml#L99) for the current logic).

Fixes https://github.com/piercefreeman/mountaineer/issues/77.