### PR TITLE
Attempt mac wheel fixes if corrupt

### DIFF
--- a/.github/scripts/fix_mac_wheels.py
+++ b/.github/scripts/fix_mac_wheels.py
@@ -1,0 +1,54 @@
+import subprocess
+import sys
+from zipfile import ZipFile, BadZipFile
+from pathlib import Path
+
+def system_unzip_rezip(wheel_path: Path, extract_dir: Path):
+    """
+    Use system utilities to unzip and re-zip a .whl file.
+
+    """
+    # Unzip using system call
+    subprocess.run(["unzip", "-o", str(wheel_path), "-d", str(extract_dir)], check=True)
+
+    # Re-zip using system call
+    subprocess.run(["zip", "-r", str(wheel_path.with_suffix(".zip")), "."], cwd=extract_dir, check=True)
+    (wheel_path.with_suffix(".zip")).rename(wheel_path)
+
+    # Remove the hanging directory
+    subprocess.run(["rm", "-rf", str(extract_dir)], check=True)
+
+def try_unzip_wheel(wheel_path: Path):
+    """
+    Attempt to unzip a wheel file, falling back to system utilities on failure.
+    """
+    try:
+        # If we can read the file in python from the get-go, there's no need
+        # to fix it
+        print("Found wheel, attempting to fix:", wheel_path)
+        with ZipFile(wheel_path, 'r') as zip_ref:
+            zip_ref.extractall(wheel_path.parent / wheel_path.stem)
+        print("Wheel is already valid.")
+        raise BadZipFile
+    except BadZipFile:
+        print(f"BadZipFile caught for {wheel_path}, using system utilities to recreate.")
+        extract_dir = wheel_path.parent / wheel_path.stem
+        extract_dir.mkdir(exist_ok=True)
+        system_unzip_rezip(wheel_path, extract_dir)
+
+        # Verify fix
+        try:
+            with ZipFile(wheel_path, 'r') as zip_ref:
+                print(f"Successfully fixed and verified {wheel_path}.")
+        except BadZipFile:
+            raise ValueError(f"Failed to fix the wheel file {wheel_path} after using system utilities.")
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: python fix_mac_wheels.py <dist>")
+        sys.exit(1)
+    dist_path = Path(sys.argv[1]).expanduser().resolve()
+    print(f"Fixing wheels in {dist_path}")
+    for wheel_path in dist_path.glob("*.whl"):
+        try_unzip_wheel(wheel_path)
+    print("Done with wheel fixes.")

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -261,6 +261,14 @@ jobs:
 
       - run: ${{ (matrix.os == 'windows' && 'dir') || 'ls -lh' }} dist/
 
+      # There is an issue with some builds where the magic number of the wheel
+      # file can't be read in python, but can be read by the OS. We explicitly
+      # decompress the wheel files with the system level handler
+      # and then re-compress them with the python level handler
+      - name: Verify and fix wheels
+        if: ${{ matrix.os == 'macos' }}
+        run: python .github/scripts/fix_mac_wheels.py dist
+
       - run: twine check --strict dist/*
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -261,20 +261,31 @@ jobs:
 
       - run: ${{ (matrix.os == 'windows' && 'dir') || 'ls -lh' }} dist/
 
-      # There is an issue with some builds where the magic number of the wheel
-      # file can't be read in python, but can be read by the OS. We explicitly
-      # decompress the wheel files with the system level handler
-      # and then re-compress them with the python level handler
-      - name: Verify and fix wheels
-        if: ${{ matrix.os == 'macos' }}
-        run: python .github/scripts/fix_mac_wheels.py dist
-
       - run: twine check --strict dist/*
+
+      # Unzip wheel files to directories
+      - name: Unzip Wheels
+        shell: bash
+        run: |
+          mkdir unpacked_wheels
+          for wheel in dist/*.whl; do
+            unzip -d unpacked_wheels/"$(basename "$wheel" .whl)" "$wheel"
+          done
+          rm dist/*.whl # Remove original .whl files to avoid confusion
+
+      - name: List unpacked wheel directories
+        shell: bash
+        run: ls -lh unpacked_wheels/
 
       - uses: actions/upload-artifact@v4
         with:
           name: pypi_files-${{ matrix.os }}-${{ matrix.target }}
-          path: dist
+          path: unpacked_wheels/
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: pypi_files_sdist-${{ matrix.os }}-${{ matrix.target }}
+          path: dist/
 
   inspect-pypi-assets:
     needs: [build]
@@ -296,7 +307,19 @@ jobs:
         with:
           pattern: pypi_files-*
           merge-multiple: true
+          path: unpacked_wheels
+
+      - name: get dist artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: pypi_files_sdist-*
+          merge-multiple: true
           path: dist
+
+      - name: list unpacked files
+        run: |
+          ls -lh unpacked_wheels/
+          echo "`ls unpacked_wheels | wc -l` files"
 
       - name: list dist files
         run: |
@@ -309,10 +332,25 @@ jobs:
           tar -xvf dist/*.tar.gz -C sdist-files
           find sdist-files -print
 
-      - name: extract and list wheel file
+      # Unzip wheel files to directories
+      - name: Zip Wheels
         run: |
-          ls dist/*cp311-manylinux*x86_64.whl | head -n 1
-          python -m zipfile --list `ls dist/*cp311-manylinux*x86_64.whl | head -n 1`
+          for dir in unpacked_wheels/*; do
+              # Check if it's a directory
+              if [ -d "$dir" ]; then
+                  # Get the base name of the directory
+                  base_name=$(basename "$dir")
+                  # Zip the directory into a .whl file inside the dist directory
+                  zip -r "dist/${base_name}.whl" "$dir"
+              fi
+          done
+
+      # There is an issue with some builds where the magic number of the wheel
+      # file can't be read in python, but can be read by the OS. We explicitly
+      # decompress the wheel files with the system level handler
+      # and then re-compress them with the python level handler
+      - name: Verify and fix wheels
+        run: python .github/scripts/fix_mac_wheels.py dist
 
       - run: pip install twine
       - run: twine check dist/*
@@ -330,13 +368,42 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: get dist artifacts
+      - name: get unpacked_wheels artifacts
         uses: actions/download-artifact@v4
         with:
           pattern: pypi_files-*
           merge-multiple: true
+          path: unpacked_wheels
+
+      - name: get dist artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: pypi_files_sdist-*
+          merge-multiple: true
           path: dist
 
+      - run: ls -lh unpacked_wheels
+
       - run: ls -lh dist
+
+      # Unzip wheel files to directories
+      - name: Zip Wheels
+        run: |
+          for dir in unpacked_wheels/*; do
+              # Check if it's a directory
+              if [ -d "$dir" ]; then
+                  # Get the base name of the directory
+                  base_name=$(basename "$dir")
+                  # Zip the directory into a .whl file inside the dist directory
+                  zip -r "dist/${base_name}.whl" "$dir"
+              fi
+          done
+
+      # There is an issue with some builds where the magic number of the wheel
+      # file can't be read in python, but can be read by the OS. We explicitly
+      # decompress the wheel files with the system level handler
+      # and then re-compress them with the python level handler
+      - name: Verify and fix wheels
+        run: python .github/scripts/fix_mac_wheels.py dist
 
       - uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
We've seen periodic issues (like during the [last](https://github.com/piercefreeman/mountaineer/actions/runs/8439195911/job/23113769124) release) where wheel artifacts created on OSX can't be read by twine. This issue notably only affects OSX artifacts.

Switching to an OSX runner fixed the frequency of these issues (likely because the underlying system zip utilities are more compatible) but hasn't completely solved the problem. This PR tries another approach where we run a compatibility check for the OSX artifacts and then unzip->rezip them at the system level. We then try to read these newly rezipped files at the python layer so we can throw an early error during the building if we expect to have problems when twine reads the file contents.