### PR TITLE
Build wheels for older glibc

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -167,7 +167,7 @@ jobs:
           jobs: ${{ toJSON(needs) }}
 
   build:
-    name: build os=${{ matrix.os }} target=${{ matrix.target }} int=${{ matrix.interpreter || 'all' }} ml=${{ matrix.manylinux || 'auto' }}
+    name: build os=${{ matrix.os }} target=${{ matrix.target }} int=${{ matrix.interpreter || 'all' }} ml=${{ matrix.manylinux || 'auto' }} release=${{ matrix.release || 'latest' }}
     if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'Full Build')
     strategy:
       fail-fast: false
@@ -192,7 +192,7 @@ jobs:
           - os: windows
             target: x86_64
 
-    runs-on: ${{ (matrix.os == 'linux' && 'ubuntu') || matrix.os }}-latest
+    runs-on: ${{ (matrix.os == 'linux' && 'ubuntu') || matrix.os }}-${{ matrix.release || 'latest' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -222,12 +222,15 @@ jobs:
       # Before we start building, validate that the Rust code compiles
       # This helps to detect errors on different underlying architectures, since
       # these wheel builds are representative of our deployment platforms
-      - name: Rust tests
-        run: cargo test --all
+      # TODO: RESTORE
+      #- name: Rust tests
+      #  run: cargo test --all
 
       # Run basic benchmarks to make sure these still compile
-      - name: Rust benchmarks
-        run: cargo bench
+      # TODO: RESTORE
+      #- name: Rust benchmarks
+      #  run: cargo bench
+      #
 
       - name: Update version
         if: startsWith(github.ref, 'refs/tags/v')
@@ -247,13 +250,64 @@ jobs:
         with:
           target: ${{ matrix.target }}
           manylinux: ${{ matrix.manylinux || 'auto' }}
-          args: --release --out dist --interpreter ${{ matrix.interpreter || '3.11 3.12' }}
+          args: -vv --release --out dist --interpreter ${{ matrix.interpreter || '3.11 3.12' }}
           rust-toolchain: stable
-          docker-options: -e CI -e CI_TARGET=${{ matrix.target }} -e GOARCH=${{ matrix.target }} -e GOROOT=${{ env.GOROOT }} -v ${{ env.GOROOT }}:${{ env.GOROOT }}
-          command: build -vv
+          container: quay.io/pypa/manylinux2014_x86_64:latest
+          docker-options: -e CI -e CI_TARGET=${{ matrix.target }}
+          # Already defaults to build, but we make explicit here. Any arguments should
+          # be added to args above and not here - otherwise we will affect the switch()
+          # condition handling of maturin-action.
+          command: build
           before-script-linux: |
+            # Install go within the docker container - only used for manylinux builds
+            # since they need an isolated docker context. The other build pipelines
+            # just run within the host so use the global worker's go install.
+            # Determine the machine architecture
+            echo "Raw architecture: $(uname -m)"
+
+            # Log the current glibc version
+            ldd --version
+
+            # Centos: wget for golang downloading, clang for golang build
+            yum -y install wget
+            yum -y install centos-release-scl
+            yum -y install llvm-toolset-7
+
+            export PATH=/opt/rh/llvm-toolset-7/root/usr/bin:/opt/rh/llvm-toolset-7/root/usr/sbin:/opt/rh/devtoolset-10/root/usr/bin:$PATH
+            # found via:
+            # find / -name "libclang.so*"
+            export LIBCLANG_PATH=/opt/rh/llvm-toolset-7/root/usr/lib64/
+
+            clang --version
+
+            uname -a
+            cat /etc/os-release
+            cat /proc/version
+
+            case "${{ matrix.target }}" in
+              x86_64) export GOARCH="amd64";;
+              aarch64) export GOARCH="arm64";;
+              *) echo "Unsupported architecture: ${{ matrix.target }}"; exit 1;;
+            esac
+            echo "GOARCH=${GOARCH}"
+
+            GOVERSION="1.22.1"
+
+            # Must be explicitly specified for cross-compilation
+            export CGO_ENABLED=1
+
+            # Download and Install Go - we will always be running on a x86_64 runner
+            # despite the build architecture
+            wget -q https://go.dev/dl/go${GOVERSION}.linux-amd64.tar.gz
+            tar -C /usr/local -xzf go${GOVERSION}.linux-amd64.tar.gz
+            rm go${GOVERSION}.linux-amd64.tar.gz
+
+            # Set up Go environment variables
+            export GOROOT=/usr/local/go
             export PATH=$PATH:$GOROOT/bin
+
             go version
+            go tool dist list
         env:
           GOROOT: ${{ env.GOROOT }}
           GOPATH: ${{ env.GOPATH }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -280,9 +280,9 @@ jobs:
                 export LIBCLANG_PATH=/opt/rh/llvm-toolset-7/root/usr/lib64/
             elif [ "$DISTRO" = "ubuntu" ]; then
                 # Ubuntu specific package installation
+                # Clang is already installed as part of the base image
                 apt-get update
-                apt-get -y install wget clang
-                # For Ubuntu, the default location of libclang.so should be automatically detected
+                apt-get -y install wget
             else
                 echo "Unsupported distribution: $DISTRO"
                 exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -268,6 +268,11 @@ jobs:
             # Log the current glibc version
             ldd --version
 
+            # System configs
+            uname -a
+            cat /etc/os-release
+            cat /proc/version
+
             # Centos: wget for golang downloading, clang for golang build
             yum -y install wget
             yum -y install centos-release-scl
@@ -278,15 +283,37 @@ jobs:
             # find / -name "libclang.so*"
             export LIBCLANG_PATH=/opt/rh/llvm-toolset-7/root/usr/lib64/
 
-            clang --version
+            # Cross-compilation only available through EPEL release
+            # This should already be configured in the manylinux image
+            yum -y install gcc-aarch64-linux-gnu
 
-            uname -a
-            cat /etc/os-release
-            cat /proc/version
+            wget https://mirror.chpc.utah.edu/pub/centos-altarch/7/os/aarch64/Packages/glibc-devel-2.17-317.el7.aarch64.rpm -O /aarch64-devel.rpm
+            wget https://mirror.chpc.utah.edu/pub/centos-altarch/7/os/aarch64/Packages/glibc-common-2.17-317.el7.aarch64.rpm -O /aarch64-common.rpm
+            wget https://mirror.chpc.utah.edu/pub/centos-altarch/7/os/aarch64/Packages/glibc-headers-2.17-317.el7.aarch64.rpm -O /aarch64-headers.rpm
+            wget https://mirror.chpc.utah.edu/pub/centos-altarch/7/os/aarch64/Packages/kernel-headers-4.18.0-193.28.1.el7.aarch64.rpm -O /aarch64-kernel-headers.rpm
+
+            mkdir /usr/aarch64-glibc
+            rpm2cpio /aarch64-devel.rpm | (cd /usr/aarch64-glibc && cpio -idmv)
+            rpm2cpio /aarch64-common.rpm | (cd /usr/aarch64-glibc && cpio -idmv)
+            rpm2cpio /aarch64-headers.rpm | (cd /usr/aarch64-glibc && cpio -idmv)
+            rpm2cpio /aarch64-kernel-headers.rpm | (cd /usr/aarch64-glibc && cpio -idmv)
+
+            cp -r /usr/aarch64-glibc/usr/include /usr/aarch64-linux-gnu/include
+            cp -r /usr/aarch64-glibc/usr/lib64 /usr/aarch64-linux-gnu/lib64
+
+            clang --version
+            aarch64-linux-gnu-gcc --version
+
+            # log header search directories
+            export C_INCLUDE_PATH=$C_INCLUDE_PATH:/usr/aarch64-glibc/usr/include
+            export CPLUS_INCLUDE_PATH=$CPLUS_INCLUDE_PATH:/usr/aarch64-glibc/usr/include
 
             case "${{ matrix.target }}" in
               x86_64) export GOARCH="amd64";;
-              aarch64) export GOARCH="arm64";;
+              aarch64) export GOARCH="arm64";
+                export CC=aarch64-linux-gnu-gcc;
+                export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc;
+                export RUSTFLAGS="-C link-arg=-L/usr/aarch64-linux-gnu/lib64 -C link-args=-Wl,-v ${RUSTFLAGS}";;
               *) echo "Unsupported architecture: ${{ matrix.target }}"; exit 1;;
             esac
             echo "GOARCH=${GOARCH}"
@@ -300,11 +327,13 @@ jobs:
             # despite the build architecture
             wget -q https://go.dev/dl/go${GOVERSION}.linux-amd64.tar.gz
             tar -C /usr/local -xzf go${GOVERSION}.linux-amd64.tar.gz
-            rm go${GOVERSION}.linux-amd64.tar.gz
+            rm -f go${GOVERSION}.linux-amd64.tar.gz
 
             # Set up Go environment variables
             export GOROOT=/usr/local/go
             export PATH=$PATH:$GOROOT/bin
+
+            go env
 
             go version
             go tool dist list

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -222,15 +222,12 @@ jobs:
       # Before we start building, validate that the Rust code compiles
       # This helps to detect errors on different underlying architectures, since
       # these wheel builds are representative of our deployment platforms
-      # TODO: RESTORE
-      #- name: Rust tests
-      #  run: cargo test --all
+      - name: Rust tests
+        run: cargo test --all
 
       # Run basic benchmarks to make sure these still compile
-      # TODO: RESTORE
-      #- name: Rust benchmarks
-      #  run: cargo bench
-      #
+      - name: Rust benchmarks
+        run: cargo bench
 
       - name: Update version
         if: startsWith(github.ref, 'refs/tags/v')
@@ -252,7 +249,6 @@ jobs:
           manylinux: ${{ matrix.manylinux || 'auto' }}
           args: -vv --release --out dist --interpreter ${{ matrix.interpreter || '3.11 3.12' }}
           rust-toolchain: stable
-          container: quay.io/pypa/manylinux2014_x86_64:latest
           docker-options: -e CI -e CI_TARGET=${{ matrix.target }}
           # Already defaults to build, but we make explicit here. Any arguments should
           # be added to args above and not here - otherwise we will affect the switch()
@@ -273,47 +269,36 @@ jobs:
             cat /etc/os-release
             cat /proc/version
 
-            # Centos: wget for golang downloading, clang for golang build
-            yum -y install wget
-            yum -y install centos-release-scl
-            yum -y install llvm-toolset-7
+            # Determine distribution from /etc/os-release
+            DISTRO=$(grep ^ID= /etc/os-release | cut -d= -f2 | tr -d '"')
 
-            export PATH=/opt/rh/llvm-toolset-7/root/usr/bin:/opt/rh/llvm-toolset-7/root/usr/sbin:/opt/rh/devtoolset-10/root/usr/bin:$PATH
-            # found via:
-            # find / -name "libclang.so*"
-            export LIBCLANG_PATH=/opt/rh/llvm-toolset-7/root/usr/lib64/
-
-            # Cross-compilation only available through EPEL release
-            # This should already be configured in the manylinux image
-            yum -y install gcc-aarch64-linux-gnu
-
-            wget https://mirror.chpc.utah.edu/pub/centos-altarch/7/os/aarch64/Packages/glibc-devel-2.17-317.el7.aarch64.rpm -O /aarch64-devel.rpm
-            wget https://mirror.chpc.utah.edu/pub/centos-altarch/7/os/aarch64/Packages/glibc-common-2.17-317.el7.aarch64.rpm -O /aarch64-common.rpm
-            wget https://mirror.chpc.utah.edu/pub/centos-altarch/7/os/aarch64/Packages/glibc-headers-2.17-317.el7.aarch64.rpm -O /aarch64-headers.rpm
-            wget https://mirror.chpc.utah.edu/pub/centos-altarch/7/os/aarch64/Packages/kernel-headers-4.18.0-193.28.1.el7.aarch64.rpm -O /aarch64-kernel-headers.rpm
-
-            mkdir /usr/aarch64-glibc
-            rpm2cpio /aarch64-devel.rpm | (cd /usr/aarch64-glibc && cpio -idmv)
-            rpm2cpio /aarch64-common.rpm | (cd /usr/aarch64-glibc && cpio -idmv)
-            rpm2cpio /aarch64-headers.rpm | (cd /usr/aarch64-glibc && cpio -idmv)
-            rpm2cpio /aarch64-kernel-headers.rpm | (cd /usr/aarch64-glibc && cpio -idmv)
-
-            cp -r /usr/aarch64-glibc/usr/include /usr/aarch64-linux-gnu/include
-            cp -r /usr/aarch64-glibc/usr/lib64 /usr/aarch64-linux-gnu/lib64
+            # Install necessary packages based on the distribution
+            if [ "$DISTRO" = "centos" ]; then
+                # CentOS specific package installation
+                yum -y install wget llvm-toolset-7 centos-release-scl
+                export PATH=/opt/rh/llvm-toolset-7/root/usr/bin:/opt/rh/llvm-toolset-7/root/usr/sbin:/opt/rh/devtoolset-10/root/usr/bin:$PATH
+                export LIBCLANG_PATH=/opt/rh/llvm-toolset-7/root/usr/lib64/
+            elif [ "$DISTRO" = "ubuntu" ]; then
+                # Ubuntu specific package installation
+                apt-get update
+                apt-get -y install wget clang
+                # For Ubuntu, the default location of libclang.so should be automatically detected
+            else
+                echo "Unsupported distribution: $DISTRO"
+                exit 1
+            fi
 
             clang --version
-            aarch64-linux-gnu-gcc --version
 
-            # log header search directories
-            export C_INCLUDE_PATH=$C_INCLUDE_PATH:/usr/aarch64-glibc/usr/include
-            export CPLUS_INCLUDE_PATH=$CPLUS_INCLUDE_PATH:/usr/aarch64-glibc/usr/include
+            ls -ls /usr/bin
 
             case "${{ matrix.target }}" in
               x86_64) export GOARCH="amd64";;
-              aarch64) export GOARCH="arm64";
-                export CC=aarch64-linux-gnu-gcc;
-                export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc;
-                export RUSTFLAGS="-C link-arg=-L/usr/aarch64-linux-gnu/lib64 -C link-args=-Wl,-v ${RUSTFLAGS}";;
+              aarch64)
+              export GOARCH="arm64";
+              export PATH=$PATH:/usr/aarch64-unknown-linux-gnu/bin;
+              aarch64-unknown-linux-gnu-gcc --version;
+              export CC=aarch64-unknown-linux-gnu-gcc;;
               *) echo "Unsupported architecture: ${{ matrix.target }}"; exit 1;;
             esac
             echo "GOARCH=${GOARCH}"
@@ -321,6 +306,7 @@ jobs:
             GOVERSION="1.22.1"
 
             # Must be explicitly specified for cross-compilation
+            # Otherwise it causes the misleading "go: no Go source files" error
             export CGO_ENABLED=1
 
             # Download and Install Go - we will always be running on a x86_64 runner

--- a/src_go/build.rs
+++ b/src_go/build.rs
@@ -22,6 +22,9 @@ fn main() {
         env::current_dir().unwrap().display()
     );
 
+    // Print the $PATH
+    eprintln!("PATH: {}", env::var("PATH").unwrap());
+
     // Step 1: Compile the Go code into a static library.
     let status = Command::new("go")
         .args([
@@ -37,6 +40,8 @@ fn main() {
         .expect("Failed to execute go build");
 
     assert!(status.success(), "Go build failed");
+
+    eprintln!("Successful golang build");
 
     // Step 2: Generate Rust bindings using bindgen.
     let bindings = bindgen::Builder::default()

--- a/src_go/build.rs
+++ b/src_go/build.rs
@@ -16,6 +16,12 @@ fn main() {
         eprintln!("GOARCH is not set");
     }
 
+    // Print the current working directory
+    eprintln!(
+        "Current working directory: {}",
+        env::current_dir().unwrap().display()
+    );
+
     // Step 1: Compile the Go code into a static library.
     let status = Command::new("go")
         .args([


### PR DESCRIPTION
PR to support older glibc versions to maximize prebuilt wheel compatibility. First raised in https://github.com/piercefreeman/mountaineer/issues/81.

Our initial approach was just to use the 20.04 runners, install golang globally, and then share the golang install with the docker context. Since the 20.04 runner will likely be deprecated when the support window expires (Apr 2025) we instead use the provided docker image for compilation. This has the added benefit of allowing us to cross-compile for more architectures. aarch64 was previously enabled but removed during the golang builder migration.

This glib support goes back to 2.17.