### PR TITLE
Allow override of environment in config

### DIFF
--- a/mountaineer/app.py
+++ b/mountaineer/app.py
@@ -93,7 +93,11 @@ class AppController:
         self.global_metadata = global_metadata
         self.builders = [
             # Default builders
-            JavascriptBundler(),
+            JavascriptBundler(
+                environment=(
+                    config.ENVIRONMENT if config is not None else "development"
+                )
+            ),
             # Custom builders
             *(custom_builders if custom_builders else []),
         ]

--- a/mountaineer/config.py
+++ b/mountaineer/config.py
@@ -27,8 +27,13 @@ class ConfigBase(BaseSettings, metaclass=ConfigMeta):
 
     """
 
-    # Name of the python package
+    # Name of the python package. Will be used to sniff for the installed
+    # codebase in the current virtualenv.
     PACKAGE: str | None = None
+
+    # Environment flag. Set to anything you want. Only if set to "development" will
+    # we include frontend artifacts for the hot-reloading server.
+    ENVIRONMENT: str = "development"
 
     model_config = {"frozen": True}
 

--- a/mountaineer/js_compiler/javascript.py
+++ b/mountaineer/js_compiler/javascript.py
@@ -165,6 +165,8 @@ class JavascriptBundler(ClientBuilderBase):
             ssr_dir = root_path.get_managed_ssr_dir(tmp_build=True)
 
             # Client entrypoint config
+            # All these tuple arguments map to the input __init__ arguments
+            # for mountaineer_rs.BuildContextParams
             build_params.append(
                 (
                     str(payload.client_entrypoint_path),


### PR DESCRIPTION
Add a ConfigBase convention for specifying the environment that the Mountaineer app is running under. We've always supported this via the `JavascriptBuilder`, but overriding the default of `development` required an explicit instantiation. This approach makes it much easier to override the environment via a environment variable that you can toggle as you deploy into remote environments.

Specifically, this `ENVIRONMENT` python key will make its way into the javascript environment (both in SSR and in the client side app) via the `process.env.NODE_ENV` key. Only if this key is equal to `development` will we add the WebSocket reloading instance to the global state. This also allows users to add additional conditional frontend logic depending on the environment.