### PR TITLE
Add timestamp and tests for logger

### DIFF
--- a/mountaineer/__tests__/js_compiler/test_source_maps.py
+++ b/mountaineer/__tests__/js_compiler/test_source_maps.py
@@ -13,7 +13,7 @@ from mountaineer.test_utilities import benchmark_function
 
 
 @pytest.mark.asyncio
-@benchmark_function(0.2)
+@benchmark_function(0.2, time_budget_seconds=10)
 async def test_parse_source_map_parse(
     start_timing,
     end_timing,

--- a/mountaineer/__tests__/test_logging.py
+++ b/mountaineer/__tests__/test_logging.py
@@ -1,0 +1,55 @@
+import json
+import logging
+from contextlib import contextmanager, redirect_stderr, redirect_stdout
+from io import StringIO
+
+from mountaineer.logging import setup_logger
+
+
+@contextmanager
+def capture_logger_output(logger_func, *args, **kwargs):
+    new_stdout, new_stderr = StringIO(), StringIO()
+    with redirect_stdout(new_stdout), redirect_stderr(new_stderr):
+        logger = logger_func(*args, **kwargs)
+        yield logger, new_stdout, new_stderr
+
+
+def test_setup_logger_name_and_level():
+    logger_name = "test_logger"
+    log_level = logging.DEBUG
+    with capture_logger_output(setup_logger, logger_name, log_level) as (logger, _, _):
+        assert logger.name == logger_name
+        assert logger.level == log_level
+
+
+def test_log_message_output():
+    log_message = "Test message"
+    logger_name = "output_logger"
+    with capture_logger_output(setup_logger, logger_name) as (logger, stdout, _):
+        logger.info(log_message)
+        output = stdout.getvalue()
+    # Since actual output includes ANSI escape codes for colors, we validate the presence of the message and level
+    assert log_message in output
+    assert "INFO" in output
+
+
+def test_timestamp():
+    logger_name = "format_logger"
+    with capture_logger_output(setup_logger, logger_name) as (logger, stdout, _):
+        logger.warning("Warning test")
+        output = stdout.getvalue()
+    log_output = json.loads(output.strip())
+    assert "timestamp" in log_output
+
+
+def test_exception_logging():
+    logger_name = "exception_logger"
+    with capture_logger_output(setup_logger, logger_name) as (logger, stdout, _):
+        try:
+            raise ValueError("Test exception")
+        except ValueError:
+            logger.exception("This is an exception")
+        output = stdout.getvalue()
+        log_output = json.loads(output.strip())
+        assert "exception" in log_output
+        assert "Test exception" in log_output["exception"]

--- a/mountaineer/logging.py
+++ b/mountaineer/logging.py
@@ -12,6 +12,7 @@ class JsonFormatter(Formatter):
         log_record = {
             "level": record.levelname,
             "name": record.name,
+            "timestamp": self.formatTime(record, self.datefmt),
             "message": record.getMessage(),
         }
         if record.exc_info:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,3 +77,13 @@ dependencies = [
     "asyncpg",
     "sqlalchemy[asyncio]",
 ]
+
+# Excluded in sdist packaging
+exclude = [
+    "fixtures",
+    "ci_webapp",
+    "create_mountaineer_app",
+    "media",
+    "docs_website",
+    "benchmarking",
+]


### PR DESCRIPTION
When used in downstream client apps, it's helpful for the logger to also output the timestamp that warnings have occurred. We add a default formatter to the `mountaineer.logging` logger constructor.

We also hopefully improve function benchmarking stability by adding a time budget for runs in python.