### PR TITLE
More robust handling for complex schema types

### DIFF
--- a/mountaineer/__tests__/client_builder/test_build_schemas.py
+++ b/mountaineer/__tests__/client_builder/test_build_schemas.py
@@ -115,6 +115,14 @@ def test_model_gathering_enum_models():
         (list[str] | None, ["value: Array<string> | null"]),
         (list[str | int] | None, ["value: Array<number | string> | null"]),
         (list | None, ["value: Array<any> | null"]),
+        (
+            dict[str, str | None | int | float],
+            ["value: Record<string, null | number | string>"],
+        ),
+        (list[str | None] | None, ["value: Array<null | string> | null"]),
+        (tuple[str, str], ["value: [string, string]"]),
+        (tuple[str, int | None], ["value: [string, null | number]"]),
+        (list[tuple[str, int] | str], ["value: Array<[string, number] | string>"]),
     ],
 )
 def test_python_to_typescript_types(

--- a/mountaineer/__tests__/client_builder/test_build_schemas.py
+++ b/mountaineer/__tests__/client_builder/test_build_schemas.py
@@ -1,6 +1,6 @@
 from enum import Enum, IntEnum, StrEnum
 from json import dumps as json_dumps
-from typing import Generic, TypeVar
+from typing import Any, Generic, Literal, TypeVar
 
 import pytest
 from pydantic import BaseModel, Field, create_model
@@ -10,6 +10,7 @@ from mountaineer.client_builder.build_schemas import (
     OpenAPIToTypescriptSchemaConverter,
 )
 from mountaineer.client_builder.openapi import OpenAPIProperty, OpenAPISchemaType
+from mountaineer.logging import LOGGER
 
 T = TypeVar("T")
 
@@ -123,6 +124,18 @@ def test_model_gathering_enum_models():
         (tuple[str, str], ["value: [string, string]"]),
         (tuple[str, int | None], ["value: [string, null | number]"]),
         (list[tuple[str, int] | str], ["value: Array<[string, number] | string>"]),
+        (Literal["my_value"], ["value: 'my_value'"]),
+        (Literal["my_value"] | Literal[True], ["value: 'my_value' | true"]),  # type: ignore
+        (bool, ["value: boolean"]),
+        (float, ["value: number"]),
+        (Any, ["value: any"]),
+        # We don't consider types that would encompass other types, so right now
+        # we just parse separately
+        (Any | None, ["value: any | null"]),  # type: ignore
+        # OpenAPI doesn't support bytes, so it casts them as strings
+        (bytes, ["value: string"]),
+        # OpenAPI doesn't support sets, so it casts them as arrays
+        (set[str], ["value: Array<string>"]),
     ],
 )
 def test_python_to_typescript_types(
@@ -137,6 +150,7 @@ def test_python_to_typescript_types(
         value=(python_type, Field()),
     )
 
+    LOGGER.debug(f"Raw schema: {fake_model.model_json_schema()}")
     schema = OpenAPISchema(**fake_model.model_json_schema())
 
     converter = OpenAPIToTypescriptSchemaConverter()

--- a/mountaineer/__tests__/client_builder/test_build_schemas.py
+++ b/mountaineer/__tests__/client_builder/test_build_schemas.py
@@ -111,6 +111,10 @@ def test_model_gathering_enum_models():
         (MyStrEnum, ["value: MyStrEnum"]),
         (MyIntEnum, ["value: MyIntEnum"]),
         (MyEnum, ["value: MyEnum"]),
+        (str | None, ["value: null | string"]),
+        (list[str] | None, ["value: Array<string> | null"]),
+        (list[str | int] | None, ["value: Array<number | string> | null"]),
+        (list | None, ["value: Array<any> | null"]),
     ],
 )
 def test_python_to_typescript_types(

--- a/mountaineer/client_builder/build_schemas.py
+++ b/mountaineer/client_builder/build_schemas.py
@@ -18,6 +18,7 @@ from mountaineer.client_builder.typescript import (
     map_openapi_type_to_ts,
     python_payload_to_typescript,
 )
+from mountaineer.logging import LOGGER
 
 
 class OpenAPIToTypescriptSchemaConverter:
@@ -195,6 +196,10 @@ class OpenAPIToTypescriptSchemaConverter:
                 yield f"Record<{map_openapi_type_to_ts(OpenAPISchemaType.STRING)}, {sub_types}>"
             elif prop.variable_type:
                 yield map_openapi_type_to_ts(prop.variable_type)
+            elif prop.const:
+                yield python_payload_to_typescript(prop.const)
+            else:
+                LOGGER.warning(f"Unknown property type: {prop}")
 
         for prop_name, prop_details in model.properties.items():
             is_required = (

--- a/mountaineer/client_builder/openapi.py
+++ b/mountaineer/client_builder/openapi.py
@@ -18,6 +18,8 @@ class OpenAPISchemaType(StrEnum):
     ARRAY = "array"
     # Typically used to indicate an optional type within an anyOf statement
     NULL = "null"
+    # Used in some cases when endpoints can accept multiple number types (like integers and floats)
+    NUMBER = "number"
 
 
 class ParameterLocationType(StrEnum):
@@ -79,6 +81,10 @@ class OpenAPIProperty(BaseModel):
 
     # Pointer to multiple possible subtypes
     anyOf: list["OpenAPIProperty"] = []
+
+    # Supported by OpenAPI 3.1+, allows for definition of arrays that only accept
+    # certain quantity of item/type combinations (like a tuple)
+    prefixItems: list["OpenAPIProperty"] = []
 
     model_config = {"populate_by_name": True}
 

--- a/mountaineer/client_builder/typescript.py
+++ b/mountaineer/client_builder/typescript.py
@@ -81,8 +81,6 @@ def map_openapi_type_to_ts(openapi_type: OpenAPISchemaType):
         "number": "number",
         "boolean": "boolean",
         "null": "null",
-        "array": "Array<{types}>",
-        "object": "{types}",
     }
     return mapping[openapi_type]
 


### PR DESCRIPTION
As identified in https://github.com/piercefreeman/mountaineer/issues/91, there are some cases where python->javascript schema compilation can result in the wrong types without throwing any errors during the build process. We want to correct these wherever possible. This PR expands our test case coverage for complex types and makes our logic a bit more flexible to deal with nested complex types. We also add support for passing typed tuples through to Typescript.