### PR TITLE
Initial support for layout controllers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,6 +173,7 @@ test-project
 _server
 _ssr
 _static
+_metadata
 
 # Ignore template files that might be used locally for testing
 # but shouldn't be added to the downstream templates

--- a/ci_webapp/ci_webapp/app.py
+++ b/ci_webapp/ci_webapp/app.py
@@ -5,8 +5,8 @@ from ci_webapp.config import AppConfig
 from ci_webapp.controllers.complex import ComplexController
 from ci_webapp.controllers.detail import DetailController
 from ci_webapp.controllers.home import HomeController
-from ci_webapp.controllers.stream import StreamController
 from ci_webapp.controllers.root_layout import RootLayoutController
+from ci_webapp.controllers.stream import StreamController
 
 controller = AppController(
     global_metadata=Metadata(

--- a/ci_webapp/ci_webapp/app.py
+++ b/ci_webapp/ci_webapp/app.py
@@ -6,6 +6,7 @@ from ci_webapp.controllers.complex import ComplexController
 from ci_webapp.controllers.detail import DetailController
 from ci_webapp.controllers.home import HomeController
 from ci_webapp.controllers.stream import StreamController
+from ci_webapp.controllers.root_layout import RootLayoutController
 
 controller = AppController(
     global_metadata=Metadata(
@@ -20,3 +21,4 @@ controller.register(HomeController())
 controller.register(DetailController())
 controller.register(ComplexController())
 controller.register(StreamController())
+controller.register(RootLayoutController())

--- a/ci_webapp/ci_webapp/controllers/root_layout.py
+++ b/ci_webapp/ci_webapp/controllers/root_layout.py
@@ -5,7 +5,7 @@ from mountaineer import LayoutControllerBase, Metadata, RenderBase
 
 
 class RootLayoutRender(RenderBase):
-    client_ip: str
+    layout_value: int
 
 
 class RootLayoutController(LayoutControllerBase):
@@ -13,9 +13,9 @@ class RootLayoutController(LayoutControllerBase):
 
     def __init__(self):
         super().__init__()
+        self.layout_value = 0
 
-    def render(self, detail_id: UUID, request: Request) -> RootLayoutRender:
+    def render(self) -> RootLayoutRender:
         return RootLayoutRender(
-            client_ip=request.client.host if request.client else "unknown",
-            metadata=Metadata(title=f"Detail: {detail_id}"),
+            layout_value=self.layout_value,
         )

--- a/ci_webapp/ci_webapp/controllers/root_layout.py
+++ b/ci_webapp/ci_webapp/controllers/root_layout.py
@@ -1,0 +1,21 @@
+from uuid import UUID
+
+from fastapi import Request
+from mountaineer import LayoutControllerBase, Metadata, RenderBase
+
+
+class RootLayoutRender(RenderBase):
+    client_ip: str
+
+
+class RootLayoutController(LayoutControllerBase):
+    view_path = "/app/layout.tsx"
+
+    def __init__(self):
+        super().__init__()
+
+    def render(self, detail_id: UUID, request: Request) -> RootLayoutRender:
+        return RootLayoutRender(
+            client_ip=request.client.host if request.client else "unknown",
+            metadata=Metadata(title=f"Detail: {detail_id}"),
+        )

--- a/ci_webapp/ci_webapp/controllers/root_layout.py
+++ b/ci_webapp/ci_webapp/controllers/root_layout.py
@@ -2,6 +2,7 @@ from uuid import UUID
 
 from fastapi import Request
 from mountaineer import LayoutControllerBase, Metadata, RenderBase
+from mountaineer.actions import sideeffect
 
 
 class RootLayoutRender(RenderBase):
@@ -19,3 +20,7 @@ class RootLayoutController(LayoutControllerBase):
         return RootLayoutRender(
             layout_value=self.layout_value,
         )
+
+    @sideeffect
+    async def increment_layout_value(self) -> None:
+        self.layout_value += 1

--- a/ci_webapp/ci_webapp/controllers/root_layout.py
+++ b/ci_webapp/ci_webapp/controllers/root_layout.py
@@ -1,7 +1,4 @@
-from uuid import UUID
-
-from fastapi import Request
-from mountaineer import LayoutControllerBase, Metadata, RenderBase
+from mountaineer import LayoutControllerBase, RenderBase
 from mountaineer.actions import sideeffect
 
 

--- a/ci_webapp/ci_webapp/views/app/layout.tsx
+++ b/ci_webapp/ci_webapp/views/app/layout.tsx
@@ -6,7 +6,7 @@ const Layout = ({ children }: { children: ReactNode }) => {
 
   return (
     <div>
-      <h1>Layout State: {serverState.client_ip}</h1>
+      <h1>Layout State: {serverState.layout_value}</h1>
       <div>{children}</div>
     </div>
   );

--- a/ci_webapp/ci_webapp/views/app/layout.tsx
+++ b/ci_webapp/ci_webapp/views/app/layout.tsx
@@ -5,9 +5,19 @@ const Layout = ({ children }: { children: ReactNode }) => {
   const serverState = useServer();
 
   return (
-    <div>
+    <div className="p-6">
       <h1>Layout State: {serverState.layout_value}</h1>
       <div>{children}</div>
+      <div>
+        <button
+          className="rounded-md bg-indigo-500 p-2 text-white"
+          onClick={async () => {
+            await serverState.increment_layout_value();
+          }}
+        >
+          Layout increment
+        </button>
+      </div>
     </div>
   );
 };

--- a/ci_webapp/ci_webapp/views/app/layout.tsx
+++ b/ci_webapp/ci_webapp/views/app/layout.tsx
@@ -1,0 +1,15 @@
+import React, { ReactNode } from "react";
+import { useServer } from "./_server";
+
+const Layout = ({ children }: { children: ReactNode }) => {
+  const serverState = useServer();
+
+  return (
+    <div>
+      <h1>Layout State: {serverState.client_ip}</h1>
+      <div>{children}</div>
+    </div>
+  );
+};
+
+export default Layout;

--- a/create_mountaineer_app/create_mountaineer_app/templates/editor_configs/vim/.vimrc
+++ b/create_mountaineer_app/create_mountaineer_app/templates/editor_configs/vim/.vimrc
@@ -2,7 +2,9 @@
 set wildignore+=*/_server/*
 set wildignore+=*/_ssr/*
 set wildignore+=*/_static/*
+set wildignore+=*/_metadata/*
 set path-=*/_server/**
 set path-=*/_ssr/**
 set path-=*/_static/**
+set path-=*/_metadata/**
 {% endif %}

--- a/create_mountaineer_app/create_mountaineer_app/templates/editor_configs/vscode/.vscode/settings.json
+++ b/create_mountaineer_app/create_mountaineer_app/templates/editor_configs/vscode/.vscode/settings.json
@@ -3,6 +3,7 @@
   "files.exclude": {
     "_server/": true,
     "_ssr/": true,
+    "_metadata/": true,
     "_static/": true
   }
 }

--- a/create_mountaineer_app/create_mountaineer_app/templates/project/.gitignore
+++ b/create_mountaineer_app/create_mountaineer_app/templates/project/.gitignore
@@ -13,6 +13,7 @@ node_modules
 _server
 _ssr
 _static
+_metadata
 .watchdog.lock
 
 # General Python excludes

--- a/docs_website/docs/api/controller.md
+++ b/docs_website/docs/api/controller.md
@@ -1,3 +1,7 @@
 # View Controller
 
 ::: mountaineer.controller.ControllerBase
+
+# Layout Controller
+
+::: mountaineer.controller_layout.LayoutControllerBase

--- a/docs_website/docs/deploy.md
+++ b/docs_website/docs/deploy.md
@@ -11,6 +11,7 @@ First, add the following to your `.dockerignore` file. This will prevent Docker 
 **/_server
 **/_ssr
 **/_static
+**/_metadata
 ```
 
 ### Image 1: Frontend Dependencies

--- a/docs_website/docs/quickstart.md
+++ b/docs_website/docs/quickstart.md
@@ -294,9 +294,9 @@ export default Home;
 
 Go ahead and load it in your browser. If you open up your web tools, you can create a new Todo and see POST requests sending data to the backend and receiving the current server state. The actual data updates and merging happens internally by Mountaineer.
 
-![Getting Started Final TODO App](/media/final_todo_list.png){ height="400" }
+![Getting Started Final TODO App](media/final_todo_list.png){ height="400" }
 
-![Getting Started Final TODO App](/media/network_debug.png){ height="400" }
+![Getting Started Final TODO App](media/network_debug.png){ height="400" }
 
 You can use these serverState variables anywhere you'd use dynamic React state variables (useEffect, useCallback, etc). But unlike React state, these variables are automatically updated when a relevant sideeffect is triggered.
 

--- a/docs_website/docs/views.md
+++ b/docs_website/docs/views.md
@@ -1,4 +1,4 @@
-# Frontend Views
+# Frontend Views & Layouts
 
 Your React app should be initialized in the `/views` folder of your Mountaineer project. This is the directory where we look for package.json and tsconfig.json, and where esbuild looks for specific build-time overrides. In other words, the views folder should look just like your frontend application if you were building a Single-Page-App (SPA). It's just embedded within your larger Mountaineer project and rendered separately.
 
@@ -84,7 +84,82 @@ This allows you to chain layouts before rendering the final, most specific page:
     /layout.tsx
 ```
 
-When rendering `dashboard/home/page.tsx`, the view will be wrapped in the `app/dashboard/layout.tsx` layout alongside `app/layout.tsx`. These layouts should only provide styling. Since the use of `useServer` would be ambiguous for layouts that are rendered by multiple components, they should not contain any logic or data fetching.
+When rendering `dashboard/home/page.tsx`, the view will be wrapped in the `app/dashboard/layout.tsx` layout alongside `app/layout.tsx`. These layout files will be automatically found by Mountaineer during the build process. They don't require any explicit declaration in your Python backend if you're just using them for styling.
+
+If you need more server side power and want to define them in Python, you can add a LayoutController that backs the layout.
+
+## Layout Controllers
+
+Layouts support most of the same controller logic that regular pages do. They can specify their own actions, both sideeffects and passthroughs, which will re-render the layout as required.
+
+```python title="/controllers/root_layout.py"
+from mountaineer import LayoutControllerBase, RenderBase
+from mountaineer.actions import sideeffect
+
+class RootLayoutRender(RenderBase):
+    layout_value: int
+
+class RootLayoutController(LayoutControllerBase):
+    view_path = "/app/layout.tsx"
+
+    def __init__(self):
+        super().__init__()
+        self.layout_value = 0
+
+    def render(self) -> RootLayoutRender:
+        return RootLayoutRender(
+            layout_value=self.layout_value,
+        )
+
+    @sideeffect
+    async def increment_layout_value(self) -> None:
+        self.layout_value += 1
+```
+
+All these functions are now exposed to the frontend layout, including the link generator, state, and any actions specified.
+
+```typescript title="/views/app/layout.tsx"
+import React, { ReactNode } from "react";
+import { useServer } from "./_server";
+
+const Layout = ({ children }: { children: ReactNode }) => {
+  const serverState = useServer();
+
+  return (
+    <div className="p-6">
+      <h1>Layout State: {serverState.layout_value}</h1>
+      <div>{children}</div>
+      <div>
+        <button
+          className="rounded-md bg-indigo-500 p-2 text-white"
+          onClick={async () => {
+            await serverState.increment_layout_value();
+          }}
+        >
+          Increase Ticker
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default Layout;
+```
+
+Once your controller is declared, you'll need to mount your layout into the AppController like you do for regular pages.
+
+```python title="/app.py"
+app_controller = AppController(...)
+app_controller.register(RootLayoutController())
+```
+
+In general you can implement layout controllers just like you do for pages. But since they're shared across multiple pages there are a few important differences to keep in mind:
+
+- Layout controllers will be rendered in an isolated scope. Sideeffects in one layout controller won't affect the others.
+- Dependency injections are similarly isolated. They are run in an isolated, synthetic context and not with the same dependency injection parameters that the page uses.
+- Layout controllers don't modify the page signature. Query params on layouts won't be extracted, for instance.
+
+As long as you write your layout controllers without directly referencing the page that they might be wrapping, which is the case for most layouts, you should be good to go.
 
 ## Typescript Configuration
 

--- a/docs_website/pyproject.toml
+++ b/docs_website/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 description = ""
 authors = ["Pierce Freeman <pierce@freeman.vc>"]
 readme = "README.md"
+package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.11"

--- a/mountaineer/__init__.py
+++ b/mountaineer/__init__.py
@@ -6,6 +6,7 @@ from mountaineer.actions import passthrough as passthrough, sideeffect as sideef
 from mountaineer.app import AppController as AppController
 from mountaineer.config import ConfigBase as ConfigBase
 from mountaineer.controller import ControllerBase as ControllerBase
+from mountaineer.controller_layout import LayoutControllerBase as LayoutControllerBase
 from mountaineer.dependencies import CoreDependencies as CoreDependencies
 from mountaineer.exceptions import APIException as APIException
 from mountaineer.js_compiler.postcss import PostCSSBundler as PostCSSBundler

--- a/mountaineer/__tests__/actions/test_passthrough.py
+++ b/mountaineer/__tests__/actions/test_passthrough.py
@@ -100,9 +100,11 @@ async def test_can_call_passthrough():
 
     # The response payload should be the same both both sync and async endpoints
     expected_response = {
-        "passthrough": ExamplePassthroughModel(
-            status="success",
-        )
+        "TestController": {
+            "passthrough": ExamplePassthroughModel(
+                status="success",
+            )
+        }
     }
 
     assert return_value_sync == expected_response

--- a/mountaineer/__tests__/actions/test_sideeffect.py
+++ b/mountaineer/__tests__/actions/test_sideeffect.py
@@ -101,11 +101,13 @@ async def call_sideeffect_common(controller: ControllerCommon):
 
         # The response payload should be the same both both sync and async endpoints
         expected_response = {
-            "sideeffect": ExampleRenderModel(
-                value_a="Hello",
-                value_b="World",
-            ),
-            "passthrough": None,
+            controller.__class__.__name__: {
+                "sideeffect": ExampleRenderModel(
+                    value_a="Hello",
+                    value_b="World",
+                ),
+                "passthrough": None,
+            }
         }
 
         assert return_value_sync == expected_response
@@ -277,8 +279,10 @@ def test_limit_codepath_experimental(
     elapsed = (monotonic_ns() - start) / 1e9
     assert response.status_code == 200
     assert response.json() == {
-        "sideeffect": {
-            "value_a": "Hello 1229",
+        "ExampleController": {
+            "sideeffect": {
+                "value_a": "Hello 1229",
+            }
         }
     }
 

--- a/mountaineer/__tests__/test_app.py
+++ b/mountaineer/__tests__/test_app.py
@@ -12,6 +12,7 @@ from mountaineer.app import AppController
 from mountaineer.client_builder.openapi import OpenAPIDefinition
 from mountaineer.config import ConfigBase
 from mountaineer.controller import ControllerBase
+from mountaineer.controller_layout import LayoutControllerBase
 from mountaineer.exceptions import APIException
 
 
@@ -41,6 +42,26 @@ def test_requires_render_return_value():
         app.register(TestControllerWithoutRenderMarkup())
 
     app.register(TestControllerWithRenderMarkup())
+
+
+def test_validates_layouts_exclude_urls():
+    """
+    The app controller should reject the registration of layouts that specify
+    a url.
+
+    """
+
+    class TestLayoutController(LayoutControllerBase):
+        # Not allowed, but might typehint correctly because the ControllerBase
+        # superclass supports it.
+        url = "/layout_url"
+
+        async def render(self) -> None:
+            pass
+
+    app_controller = AppController(view_root=Path(""))
+    with pytest.raises(ValueError, match="are not directly mountable to the router"):
+        app_controller.register(TestLayoutController())
 
 
 def test_generate_openapi():

--- a/mountaineer/__tests__/test_app.py
+++ b/mountaineer/__tests__/test_app.py
@@ -72,6 +72,7 @@ def test_generate_openapi():
         "TestExceptionActionResponse",
         "ExampleException",
         "ExampleSubModel",
+        "TestExceptionActionResponseRaw",
     }
 
 
@@ -133,6 +134,7 @@ def test_handle_conflicting_exception_names():
 
     assert openapi_definition.components.schemas.keys() == {
         "TestExceptionActionResponse",
+        "TestExceptionActionResponseRaw",
         "mountaineer.__tests__.test_1.ExampleException",
         "mountaineer.__tests__.test_2.ExampleException",
     }

--- a/mountaineer/__tests__/test_app.py
+++ b/mountaineer/__tests__/test_app.py
@@ -199,6 +199,9 @@ def test_inherit_parent_spec():
     assert parent_controller.definition
     assert child_controller.definition
 
+    assert parent_controller.definition.render_router
+    assert child_controller.definition.render_router
+
     parent_routes = parent_controller.definition.render_router.routes
     child_routes = child_controller.definition.render_router.routes
 

--- a/mountaineer/__tests__/test_cli.py
+++ b/mountaineer/__tests__/test_cli.py
@@ -100,7 +100,7 @@ def test_dev_thrown_exception_on_get(env_process: IsolatedEnvProcess):
         response = test_client.get("/")
         assert response.status_code == 500
         assert (
-            '<div id="root">Passthrough: {"exception":"This is a test",'
+            '<div id="root">Passthrough: {"ExceptionController":{"exception":"This is a test",'
             in response.text
         )
 

--- a/mountaineer/__tests__/test_controller.py
+++ b/mountaineer/__tests__/test_controller.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from mountaineer.controller import ControllerBase
+from mountaineer.controller import BuildMetadata, ControllerBase
 from mountaineer.render import (
     LinkAttribute,
     MetaAttribute,
@@ -196,6 +196,7 @@ def test_resolve_paths(tmp_path: Path):
     view_base = tmp_path / "views"
     ssr_base = view_base / "_ssr"
     static_base = view_base / "_static"
+    metadata_base = view_base / "_metadata"
 
     controller = StubController()
     assert not controller.resolve_paths(view_base)
@@ -212,12 +213,18 @@ def test_resolve_paths(tmp_path: Path):
     (ssr_base / "stub_controller.js.map").touch()
     assert not controller.resolve_paths(view_base)
 
-    # Finally, create the static script file
     # Our hash has to be exactly 32 digits to match the regex
     static_base.mkdir()
     random_hash = "b5ecd0c4405374100d6ef93088b86898"
     (static_base / f"stub_controller-{random_hash}.js").touch()
     (static_base / f"stub_controller-{random_hash}.js.map").touch()
+    assert not controller.resolve_paths(view_base)
+
+    # Finally, create the metadata file
+    metadata_base.mkdir()
+    (metadata_base / "stub_controller.json").write_text(
+        BuildMetadata(view_path=Path()).model_dump_json()
+    )
     assert controller.resolve_paths(view_base)
 
     # Now ensure that the paths are correctly set

--- a/mountaineer/__tests__/test_controller_layout.py
+++ b/mountaineer/__tests__/test_controller_layout.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+
+import pytest
+
+from mountaineer.app import AppController
+from mountaineer.controller_layout import LayoutControllerBase
+
+
+class ExampleLayoutController(LayoutControllerBase):
+    async def render(self) -> None:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_disallows_direct_rendering():
+    """
+    Layouts can't be rendered directly. They're intended for use
+    only as pages wrappers.
+
+    """
+    layout_controller = ExampleLayoutController()
+
+    with pytest.raises(NotImplementedError):
+        await layout_controller._generate_html(global_metadata={})
+
+    with pytest.raises(NotImplementedError):
+        layout_controller._generate_ssr_html({})
+
+
+def test_layout_registration():
+    """
+    Layout controllers must register with the AppController for them
+    to be used by client render controllers.
+
+    """
+    app_controller = AppController(view_root=Path(""))
+    layout_controller = ExampleLayoutController()
+
+    app_controller.register(layout_controller)
+    assert len(app_controller.controllers) == 1
+
+    assert app_controller.controllers[0].controller == layout_controller

--- a/mountaineer/__tests__/test_paths.py
+++ b/mountaineer/__tests__/test_paths.py
@@ -143,6 +143,7 @@ def test_managed_view_paths_code_directories(tmpdir):
     assert root_path.get_managed_code_dir() == root_path / "_server"
     assert root_path.get_managed_static_dir() == root_path / "_static"
     assert root_path.get_managed_ssr_dir() == root_path / "_ssr"
+    assert root_path.get_managed_metadata_dir() == root_path / "_metadata"
 
     # Non-root paths should only yield the server directory
     non_root_path = root_path / "subdir"

--- a/mountaineer/__tests__/test_ssr.py
+++ b/mountaineer/__tests__/test_ssr.py
@@ -26,7 +26,7 @@ def test_ssr_speed_baseline():
         start = monotonic_ns()
         render_ssr(
             js_contents,
-            FakeModel(random_id=uuid4()),
+            FakeModel(random_id=uuid4()).model_dump(mode="json"),
             hard_timeout=1,
         )
         all_measurements.append((monotonic_ns() - start) / 1e9)
@@ -54,7 +54,9 @@ def test_ssr_timeout():
     with pytest.raises(TimeoutError):
         render_ssr(
             script=js_contents,
-            render_data=FakeWaitDurationModel(delay_loops=5, random_id=uuid4()),
+            render_data=FakeWaitDurationModel(
+                delay_loops=5, random_id=uuid4()
+            ).model_dump(mode="json"),
             hard_timeout=0.5,
         )
     assert ((monotonic_ns() - start) / 1e9) < 1.0
@@ -84,7 +86,7 @@ def test_ssr_exception_context():
     try:
         render_ssr(
             script=js_contents,
-            render_data=FakeModel(random_id=uuid4()),
+            render_data=FakeModel(random_id=uuid4()).model_dump(mode="json"),
             hard_timeout=0,
         )
     except V8RuntimeError as e:

--- a/mountaineer/actions/fields.py
+++ b/mountaineer/actions/fields.py
@@ -9,6 +9,7 @@ from inspect import (
 )
 from json import loads as json_loads
 from typing import (
+    TYPE_CHECKING,
     Any,
     Callable,
     Optional,
@@ -26,11 +27,9 @@ from pydantic.fields import FieldInfo
 from mountaineer.annotation_helpers import MountaineerUnsetValue
 from mountaineer.exceptions import APIException
 from mountaineer.render import FieldClassDefinition, Metadata, RenderBase, RenderNull
-from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from mountaineer.controller import ControllerBase
-
 
 
 class FunctionActionType(Enum):
@@ -240,11 +239,9 @@ def fuse_metadata_to_response_typehint(
 
     # Each action also includes the controller type in the response
     # signature so the frontend can differentiate between different controllers
-    wrapper_model : Type[BaseModel] = create_model(
+    wrapper_model: Type[BaseModel] = create_model(
         base_response_name,
-        **{
-            controller.__class__.__name__: (model, FieldInfo())
-        },
+        **{controller.__class__.__name__: (model, FieldInfo())},  # type: ignore
     )
 
     return wrapper_model
@@ -272,24 +269,19 @@ def format_final_action_response(
     if len(responses) > 1:
         raise ValueError(f"Multiple conflicting responses returned: {responses}")
 
-
     # The final transformation should include our controller name
     # This signals to the frontend which state subset we want to update
     action_root = controller.__class__.__name__
 
     if len(responses) == 0:
-        return {
-            action_root: dict_payload
-        }
+        return {action_root: dict_payload}
 
     response_key, response = responses[0]
     dict_payload[response_key] = json_loads(response.body)
 
     # Now inject the newly formatted response into the response object
     return JSONResponse(
-        content={
-            action_root: dict_payload
-        },
+        content={action_root: dict_payload},
         status_code=response.status_code,
         headers={
             key: value

--- a/mountaineer/actions/fields.py
+++ b/mountaineer/actions/fields.py
@@ -26,6 +26,11 @@ from pydantic.fields import FieldInfo
 from mountaineer.annotation_helpers import MountaineerUnsetValue
 from mountaineer.exceptions import APIException
 from mountaineer.render import FieldClassDefinition, Metadata, RenderBase, RenderNull
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from mountaineer.controller import ControllerBase
+
 
 
 class FunctionActionType(Enum):
@@ -151,6 +156,7 @@ def annotation_is_metadata(annotation: type | None):
 
 def fuse_metadata_to_response_typehint(
     metadata: FunctionMetadata,
+    controller: "ControllerBase",
     render_model: Type[RenderBase] | None,
 ) -> Type[BaseModel]:
     """
@@ -228,13 +234,24 @@ def fuse_metadata_to_response_typehint(
         )
 
     model: Type[BaseModel] = create_model(
-        base_response_name,
+        base_response_name + "Raw",
         **base_response_params,  # type: ignore
     )
-    return model
+
+    # Each action also includes the controller type in the response
+    # signature so the frontend can differentiate between different controllers
+    wrapper_model : Type[BaseModel] = create_model(
+        base_response_name,
+        **{
+            controller.__class__.__name__: (model, FieldInfo())
+        },
+    )
+
+    return wrapper_model
 
 
-def handle_explicit_responses(
+def format_final_action_response(
+    controller: "ControllerBase",
     dict_payload: dict[str, Any],
 ):
     """
@@ -255,15 +272,24 @@ def handle_explicit_responses(
     if len(responses) > 1:
         raise ValueError(f"Multiple conflicting responses returned: {responses}")
 
+
+    # The final transformation should include our controller name
+    # This signals to the frontend which state subset we want to update
+    action_root = controller.__class__.__name__
+
     if len(responses) == 0:
-        return dict_payload
+        return {
+            action_root: dict_payload
+        }
 
     response_key, response = responses[0]
     dict_payload[response_key] = json_loads(response.body)
 
     # Now inject the newly formatted response into the response object
     return JSONResponse(
-        content=dict_payload,
+        content={
+            action_root: dict_payload
+        },
         status_code=response.status_code,
         headers={
             key: value

--- a/mountaineer/actions/passthrough.py
+++ b/mountaineer/actions/passthrough.py
@@ -157,7 +157,7 @@ def passthrough(*args, **kwargs):  # type: ignore
                 if isasyncgen(response):
                     return wrap_passthrough_generator(response)
 
-                return format_final_action_response(dict(passthrough=response))
+                return format_final_action_response(self, dict(passthrough=response))
 
             metadata = init_function_metadata(inner, FunctionActionType.PASSTHROUGH)
             metadata.passthrough_model = passthrough_model

--- a/mountaineer/actions/passthrough.py
+++ b/mountaineer/actions/passthrough.py
@@ -27,7 +27,7 @@ from mountaineer.actions.fields import (
     FunctionActionType,
     ResponseModelType,
     extract_response_model_from_signature,
-    handle_explicit_responses,
+    format_final_action_response,
     init_function_metadata,
 )
 from mountaineer.constants import STREAM_EVENT_TYPE
@@ -157,7 +157,7 @@ def passthrough(*args, **kwargs):  # type: ignore
                 if isasyncgen(response):
                     return wrap_passthrough_generator(response)
 
-                return handle_explicit_responses(dict(passthrough=response))
+                return format_final_action_response(dict(passthrough=response))
 
             metadata = init_function_metadata(inner, FunctionActionType.PASSTHROUGH)
             metadata.passthrough_model = passthrough_model

--- a/mountaineer/actions/sideeffect.py
+++ b/mountaineer/actions/sideeffect.py
@@ -16,7 +16,6 @@ from urllib.parse import urlparse
 
 from fastapi import Request
 from fastapi.responses import JSONResponse
-from mountaineer.controller_layout import LayoutControllerBase
 from pydantic import BaseModel
 from starlette.routing import Match
 
@@ -27,6 +26,7 @@ from mountaineer.actions.fields import (
     format_final_action_response,
     init_function_metadata,
 )
+from mountaineer.controller_layout import LayoutControllerBase
 from mountaineer.cropper import crop_function_for_return_keys
 from mountaineer.dependencies import get_function_dependencies
 from mountaineer.exceptions import APIException
@@ -175,7 +175,7 @@ def sideeffect(*args, **kwargs):  # type: ignore
                         dict(
                             sideeffect=server_data,
                             passthrough=passthrough_values,
-                        )
+                        ),
                     )
 
             # Update the signature of 'inner' to include 'request: Request'
@@ -255,7 +255,11 @@ async def get_render_parameters(
     # we already know which route should be resolved so we can shortcut having to
     # match non-relevant paths.
     # https://github.com/encode/starlette/blob/5c43dde0ec0917673bb280bcd7ab0c37b78061b7/starlette/routing.py#L544
-    for route in (controller.definition.render_router.routes if controller.definition.render_router is not None else []):
+    for route in (
+        controller.definition.render_router.routes
+        if controller.definition.render_router is not None
+        else []
+    ):
         match, child_scope = route.matches(view_request.scope)
         if match != Match.FULL:
             raise RuntimeError(
@@ -271,8 +275,12 @@ async def get_render_parameters(
     try:
         async with get_function_dependencies(
             callable=controller.render,
-            url=controller.url if not isinstance(controller, LayoutControllerBase) else None,
-            request=view_request if not isinstance(controller, LayoutControllerBase) else None,
+            url=controller.url
+            if not isinstance(controller, LayoutControllerBase)
+            else None,
+            request=view_request
+            if not isinstance(controller, LayoutControllerBase)
+            else None,
         ) as values:
             yield values
     except RuntimeError as e:

--- a/mountaineer/actions/sideeffect.py
+++ b/mountaineer/actions/sideeffect.py
@@ -23,7 +23,7 @@ from mountaineer.actions.fields import (
     FunctionActionType,
     ResponseModelType,
     extract_response_model_from_signature,
-    handle_explicit_responses,
+    format_final_action_response,
     init_function_metadata,
 )
 from mountaineer.cropper import crop_function_for_return_keys
@@ -169,7 +169,8 @@ def sideeffect(*args, **kwargs):  # type: ignore
                     if isawaitable(server_data):
                         server_data = await server_data
 
-                    return handle_explicit_responses(
+                    return format_final_action_response(
+                        self,
                         dict(
                             sideeffect=server_data,
                             passthrough=passthrough_values,

--- a/mountaineer/app.py
+++ b/mountaineer/app.py
@@ -9,8 +9,6 @@ from fastapi.openapi.utils import get_openapi
 from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
 from inflection import underscore
-from mountaineer.controller_layout import LayoutControllerBase
-from mountaineer.dependencies.base import get_function_dependencies
 from pydantic import BaseModel
 from starlette.routing import BaseRoute
 
@@ -23,6 +21,8 @@ from mountaineer.actions.fields import FunctionMetadata
 from mountaineer.annotation_helpers import MountaineerUnsetValue
 from mountaineer.config import ConfigBase
 from mountaineer.controller import ControllerBase
+from mountaineer.controller_layout import LayoutControllerBase
+from mountaineer.dependencies.base import get_function_dependencies
 from mountaineer.exceptions import APIException, APIExceptionInternalModelBase
 from mountaineer.js_compiler.base import ClientBuilderBase
 from mountaineer.js_compiler.javascript import JavascriptBundler
@@ -192,14 +192,14 @@ class AppController:
                 for candidate_layout_controller in self.controllers
                 if (
                     candidate_layout_controller.controller.build_metadata
-                    and candidate_layout_controller.controller.build_metadata.view_path in controller.build_metadata.layout_view_paths
+                    and candidate_layout_controller.controller.build_metadata.view_path
+                    in controller.build_metadata.layout_view_paths
                 )
             ]
-            print("LAYOUT CONTROLLERS", layout_controllers)
 
             # Perform their initial rendering, we only need their data to hydrate
             # the controller view
-            layout_metadata : dict[str, Any] = {}
+            layout_metadata: dict[str, Any] = {}
             for definition in layout_controllers:
                 # We won't be able to rely on fastapi to get the required params, because the function
                 # signature of the render function just applies to the page itself. We could create
@@ -222,14 +222,12 @@ class AppController:
 
                 layout_metadata[definition.controller.__class__.__name__] = server_data
 
-            print("Layout metadata", layout_metadata)
-
             try:
                 return await controller._generate_html(
                     *args,
                     global_metadata=self.global_metadata,
                     other_render_contexts=layout_metadata,
-                    **kwargs
+                    **kwargs,
                 )
             except Exception as e:
                 # If a user explicitly is raising an APIException, we don't want to log it

--- a/mountaineer/app.py
+++ b/mountaineer/app.py
@@ -285,7 +285,7 @@ class AppController:
         if isinstance(controller, LayoutControllerBase):
             if hasattr(controller, "url"):
                 raise ValueError(
-                    f"LayoutControllers are not directly mountable. {controller} should not have a url specified."
+                    f"LayoutControllers are not directly mountable to the router. {controller} should not have a url specified."
                 )
             view_router = None
         else:

--- a/mountaineer/cli.py
+++ b/mountaineer/cli.py
@@ -240,7 +240,7 @@ class IsolatedEnvProcess(Process):
 
             self.alert_notification_channel()
         except BuildProcessException as e:
-            CONSOLE.print(f"[bold red]⚠️ Build failed: {e}")
+            CONSOLE.print(f"[bold red]🪲 Build failed: {e}")
             app_controller.build_exception = e
 
     def stop(self, hard_timeout: float = 5.0):

--- a/mountaineer/client_builder/builder.py
+++ b/mountaineer/client_builder/builder.py
@@ -599,6 +599,11 @@ class ClientBuilder:
 
         """
         # Validation 1: Ensure that all view paths are unique
+        # This applies to both exact equivalence (two controllers pointing to the
+        # same page.tsx) as well as conflicting folder structures (one controller pointing
+        # to a page and another pointing to a layout in the same directory).
+        # Both of these causes would cause conflicting _server files to be generated
+        # which we need to avoid
         view_counts = defaultdict(list)
         for controller_definition in self.app.controllers:
             controller = controller_definition.controller

--- a/mountaineer/client_builder/builder.py
+++ b/mountaineer/client_builder/builder.py
@@ -504,6 +504,7 @@ class ClientBuilder:
             tmp_path = Path(tmp_dir)
             tmp_static_dir = tmp_path / "static"
             tmp_ssr_dir = tmp_path / "ssr"
+            tmp_metadata_dir = tmp_path / "metadata"
 
             # Since the tmp builds are within their parent folder, we need to move
             # them out of the way before we clear
@@ -516,10 +517,12 @@ class ClientBuilder:
                 self.view_root.get_managed_static_dir(tmp_build=True), tmp_static_dir
             )
             shutil_move(self.view_root.get_managed_ssr_dir(tmp_build=True), tmp_ssr_dir)
+            shutil_move(self.view_root.get_managed_metadata_dir(tmp_build=True), tmp_metadata_dir)
 
             static_dir = self.view_root.get_managed_static_dir()
             ssr_dir = self.view_root.get_managed_ssr_dir()
-            for clear_dir in [static_dir, ssr_dir]:
+            metadata_dir = self.view_root.get_managed_metadata_dir()
+            for clear_dir in [static_dir, ssr_dir, metadata_dir]:
                 if clear_dir.exists():
                     shutil_rmtree(clear_dir)
 
@@ -531,6 +534,9 @@ class ClientBuilder:
             )
             shutil_move(
                 tmp_ssr_dir, self.view_root.get_managed_ssr_dir(create_dir=False)
+            )
+            shutil_move(
+                tmp_metadata_dir, self.view_root.get_managed_metadata_dir(create_dir=False)
             )
 
     def cache_is_outdated(self):

--- a/mountaineer/client_builder/builder.py
+++ b/mountaineer/client_builder/builder.py
@@ -518,7 +518,10 @@ class ClientBuilder:
                 self.view_root.get_managed_static_dir(tmp_build=True), tmp_static_dir
             )
             shutil_move(self.view_root.get_managed_ssr_dir(tmp_build=True), tmp_ssr_dir)
-            shutil_move(self.view_root.get_managed_metadata_dir(tmp_build=True), tmp_metadata_dir)
+            shutil_move(
+                self.view_root.get_managed_metadata_dir(tmp_build=True),
+                tmp_metadata_dir,
+            )
 
             static_dir = self.view_root.get_managed_static_dir()
             ssr_dir = self.view_root.get_managed_ssr_dir()
@@ -537,7 +540,8 @@ class ClientBuilder:
                 tmp_ssr_dir, self.view_root.get_managed_ssr_dir(create_dir=False)
             )
             shutil_move(
-                tmp_metadata_dir, self.view_root.get_managed_metadata_dir(create_dir=False)
+                tmp_metadata_dir,
+                self.view_root.get_managed_metadata_dir(create_dir=False),
             )
 
     def cache_is_outdated(self):
@@ -721,7 +725,9 @@ class ClientBuilder:
                     else None
                 )
                 self._openapi_render_specs[controller] = RenderSpec(
-                    url=None if isinstance(controller, LayoutControllerBase) else controller.url,
+                    url=None
+                    if isinstance(controller, LayoutControllerBase)
+                    else controller.url,
                     view_path=str(controller.view_path),
                     spec=spec,
                 )

--- a/mountaineer/client_builder/builder.py
+++ b/mountaineer/client_builder/builder.py
@@ -305,6 +305,7 @@ class ClientBuilder:
         """
         for controller_definition in self.app.controllers:
             controller = controller_definition.controller
+            controller_key = controller.__class__.__name__
 
             chunks: list[str] = []
 
@@ -373,7 +374,7 @@ class ClientBuilder:
             # server state that's only relevant to this controller
             chunks.append(
                 "export const useServer = () : ServerState => {\n"
-                + f"const [ serverState, setServerState ] = useState(SERVER_DATA as {render_model_name});\n"
+                + f"const [ serverState, setServerState ] = useState(SERVER_DATA['{controller_key}'] as {render_model_name});\n"
                 # Local function to just override the current controller
                 # We make sure to wait for the previous state to be set, in case of a
                 # differential update
@@ -389,7 +390,7 @@ class ClientBuilder:
                 + ",\n".join(
                     [
                         (
-                            f"{metadata.function_name}: applySideEffect({metadata.function_name}, setControllerState)"
+                            f"{metadata.function_name}: applySideEffect({metadata.function_name}, setControllerState, '{controller_key}')"
                             if metadata.action_type == FunctionActionType.SIDEEFFECT
                             else f"{metadata.function_name}: {metadata.function_name}"
                         )

--- a/mountaineer/controller.py
+++ b/mountaineer/controller.py
@@ -1,10 +1,10 @@
 from abc import ABC, abstractmethod
 from importlib.metadata import PackageNotFoundError
 from inspect import getmembers, isawaitable, ismethod
+from json import dumps as json_dumps
 from pathlib import Path
 from re import compile as re_compile
 from time import monotonic_ns
-from json import dumps as json_dumps
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -20,6 +20,7 @@ from typing import (
 
 from fastapi.responses import HTMLResponse
 from inflection import underscore
+from pydantic import BaseModel
 
 from mountaineer.actions import (
     FunctionActionType,
@@ -39,12 +40,12 @@ from mountaineer.render import (
     ScriptAttribute,
 )
 from mountaineer.ssr import V8RuntimeError, render_ssr
-from pydantic import BaseModel
 
 if TYPE_CHECKING:
     from mountaineer.app import ControllerDefinition
 
 RenderInput = ParamSpec("RenderInput")
+
 
 class BuildMetadata(BaseModel):
     """
@@ -54,12 +55,14 @@ class BuildMetadata(BaseModel):
     relative to the controllers.
 
     """
+
     # All paths in the metadata should be absolute paths, since they are consistent
     # with regard to the builder filesystem but might be different when deployed
     view_path: Path
 
     # Organized by hierarchy, first index is the outermost layout
     layout_view_paths: list[Path] = []
+
 
 class ControllerBase(ABC, Generic[RenderInput]):
     url: str

--- a/mountaineer/controller_layout.py
+++ b/mountaineer/controller_layout.py
@@ -1,10 +1,9 @@
 from mountaineer.controller import ControllerBase
-from mountaineer.render import Metadata, RenderBase
 
 
 class LayoutControllerBase(ControllerBase):
-    async def _generate_html(self, *args, global_metadata: Metadata | None, **kwargs):
+    async def _generate_html(self, *args, global_metadata, **kwargs):
         raise NotImplementedError
 
-    def _generate_ssr_html(self, server_data: RenderBase) -> str:
+    def _generate_ssr_html(self, server_data) -> str:
         raise NotImplementedError

--- a/mountaineer/controller_layout.py
+++ b/mountaineer/controller_layout.py
@@ -1,0 +1,10 @@
+from mountaineer.controller import ControllerBase
+from mountaineer.render import Metadata, RenderBase
+
+
+class LayoutControllerBase(ControllerBase):
+    async def _generate_html(self, *args, global_metadata: Metadata | None, **kwargs):
+        raise NotImplementedError
+
+    def _generate_ssr_html(self, server_data: RenderBase) -> str:
+        raise NotImplementedError

--- a/mountaineer/controller_layout.py
+++ b/mountaineer/controller_layout.py
@@ -2,6 +2,20 @@ from mountaineer.controller import ControllerBase
 
 
 class LayoutControllerBase(ControllerBase):
+    """
+    Base class for layouts. Layout controllers are used to generate the HTML that wrap
+    a regular view controller. They support all actions that a regular controller
+    does (@sideeffect and @passthrough).
+
+    Their limitations:
+    - They are run in an isolated dependency injection context, they don't share
+        dependency injected values with the given page
+    - The current page Request is not supported within render()
+    - Sideeffect updates to the layout don't affect the page state, and vice-versa
+    - Layout controllers can't be mounted as a URL route
+
+    """
+
     async def _generate_html(self, *args, global_metadata, **kwargs):
         raise NotImplementedError
 

--- a/mountaineer/js_compiler/javascript.py
+++ b/mountaineer/js_compiler/javascript.py
@@ -177,7 +177,9 @@ class JavascriptBundler(ClientBuilderBase):
         controller_base = underscore(controller.__class__.__name__)
         root_path = file_path.get_package_root_link()
         metadata_dir = root_path.get_managed_metadata_dir(tmp_build=True)
-        metadata_payload = self.build_metadata_archive(page_path=file_path, controller=controller)
+        metadata_payload = self.build_metadata_archive(
+            page_path=file_path, controller=controller
+        )
         (metadata_dir / f"{controller_base}.json").write_text(metadata_payload)
 
         # Now we can process the files in bulk

--- a/mountaineer/js_compiler/javascript.py
+++ b/mountaineer/js_compiler/javascript.py
@@ -176,7 +176,7 @@ class JavascriptBundler(ClientBuilderBase):
         # we have the file location context
         controller_base = underscore(controller.__class__.__name__)
         root_path = file_path.get_package_root_link()
-        metadata_dir = root_path.get_managed_ssr_dir(tmp_build=True)
+        metadata_dir = root_path.get_managed_metadata_dir(tmp_build=True)
         metadata_payload = self.build_metadata_archive(page_path=file_path, controller=controller)
         (metadata_dir / f"{controller_base}.json").write_text(metadata_payload)
 
@@ -339,7 +339,7 @@ class JavascriptBundler(ClientBuilderBase):
             page_path=page_path, view_root_path=page_path.get_root_link()
         )
         metadata = BuildMetadata(
-            view_path=controller.view_path,
+            view_path=page_path,
             layout_view_paths=layout_paths,
         )
         return metadata.model_dump_json()

--- a/mountaineer/paths.py
+++ b/mountaineer/paths.py
@@ -114,7 +114,9 @@ class ManagedViewPath(type(Path())):  # type: ignore
             path.mkdir(exist_ok=True)
         return path
 
-    def get_managed_metadata_dir(self, tmp_build: bool = False, create_dir: bool = True):
+    def get_managed_metadata_dir(
+        self, tmp_build: bool = False, create_dir: bool = True
+    ):
         # Only root paths can have metadata directories
         if not self.is_root_link:
             raise ValueError(

--- a/mountaineer/paths.py
+++ b/mountaineer/paths.py
@@ -114,6 +114,18 @@ class ManagedViewPath(type(Path())):  # type: ignore
             path.mkdir(exist_ok=True)
         return path
 
+    def get_managed_metadata_dir(self, tmp_build: bool = False, create_dir: bool = True):
+        # Only root paths can have metadata directories
+        if not self.is_root_link:
+            raise ValueError(
+                "Cannot get metadata directory from a non-root linked view path"
+            )
+        path = self.get_managed_dir_common("_metadata", create_dir=create_dir)
+        if tmp_build:
+            path = path / "tmp"
+            path.mkdir(exist_ok=True)
+        return path
+
     def get_managed_dir_common(
         self,
         managed_dir: str,

--- a/mountaineer/ssr.py
+++ b/mountaineer/ssr.py
@@ -1,13 +1,10 @@
+from json import dumps as json_dumps
 from re import finditer as re_finditer
-from typing import cast
-
-from pydantic import BaseModel
+from typing import Any, cast
 
 from mountaineer import mountaineer as mountaineer_rs  # type: ignore
 from mountaineer.cache import extended_lru_cache
 from mountaineer.static import get_static_path
-from json import dumps as json_dumps
-from typing import Any
 
 
 class V8RuntimeError(Exception):

--- a/mountaineer/ssr.py
+++ b/mountaineer/ssr.py
@@ -6,6 +6,8 @@ from pydantic import BaseModel
 from mountaineer import mountaineer as mountaineer_rs  # type: ignore
 from mountaineer.cache import extended_lru_cache
 from mountaineer.static import get_static_path
+from json import dumps as json_dumps
+from typing import Any
 
 
 class V8RuntimeError(Exception):
@@ -45,7 +47,7 @@ def fix_exception_lines(*, exception: str, injected_script: str):
 
 @extended_lru_cache(maxsize=128, max_size_mb=5)
 def render_ssr(
-    script: str, render_data: BaseModel, hard_timeout: int | float | None = None
+    script: str, render_data: dict[str, Any], hard_timeout: int | float | None = None
 ) -> str:
     """
     Render the React component in the provided SSR javascript bundle. This file will
@@ -66,7 +68,7 @@ def render_ssr(
 
     """
     polyfill_script = get_static_path("ssr_polyfills.js").read_text()
-    data_json = render_data.model_dump_json()
+    data_json = json_dumps(render_data)
 
     injected_script = f"const SERVER_DATA = {data_json};\n{polyfill_script}\n"
     full_script = f"{injected_script}{script}"

--- a/mountaineer/static/api.ts
+++ b/mountaineer/static/api.ts
@@ -151,19 +151,24 @@ const handleStreamOutputFormat = async (
   })();
 };
 
-type ApiFunctionReturnType<S, P> = {
-  sideeffect: S;
-  passthrough?: P;
+type ApiFunctionReturnType<S, P, K extends PropertyKey> = {
+  // Generic typehint for any key parameter
+  [key in K]: {
+    sideeffect: S;
+    passthrough?: P;
+  };
 };
 
 export function applySideEffect<
   ARG extends any[],
   S,
   P,
-  RE extends ApiFunctionReturnType<S, P>,
+  K extends PropertyKey,
+  RE extends ApiFunctionReturnType<S, P, K>,
 >(
   apiFunction: (...args: ARG) => Promise<RE>,
   setControllerState: (payload: S) => void,
+  controllerKey: K,
 ): (...args: ARG) => Promise<RE> {
   /*
    * Executes an API server function, triggering any appropriate exceptions.
@@ -171,7 +176,7 @@ export function applySideEffect<
    */
   return async (...args: ARG) => {
     const result = await apiFunction(...args);
-    setControllerState(result.sideeffect);
+    setControllerState(result[controllerKey].sideeffect);
     return result;
   };
 }

--- a/mountaineer/watch.py
+++ b/mountaineer/watch.py
@@ -43,7 +43,7 @@ class ChangeEventHandler(FileSystemEventHandler):
     def __init__(
         self,
         callbacks: list[CallbackDefinition],
-        ignore_list=["__pycache__", "_ssr", "_static", "_server"],
+        ignore_list=["__pycache__", "_ssr", "_static", "_server", "_metadata"],
         ignore_hidden=True,
         debounce_interval=0.1,
     ):


### PR DESCRIPTION
## Background

As originally discussed in https://github.com/piercefreeman/mountaineer/issues/47, this PR introduces support for controller layouts. We've supported the notion of layouts for some time - since 0.2 at least. Layouts are specified as `layout.tsx` files that are hierarchically rendered depending on the page's view path. For instance:

```
app/
└── views/
    ├── layout.tsx --> root layout
    ├── (admin)/
    │   ├── layout.tsx --> admin layout
    │   ├── settings/
    │   │   └── page.tsx
    │   └── users/
    │       └── page.tsx
    └── (auth)/
        └── page.tsx
```

Taking the above application as an example, the `(admin)/settings/auth.tsx` page would have both the root layout and then the admin layout applied to it. The `(auth)/page.tsx` on the other hand would just have the root layout applied. These files each export a default component with the {children} React property provided:

```typescript
const Layout = ({children}: {children: ReactNode}) => {
  return (
    <div>
        <h1>My Layout</h1>
        <div>{children}</div>
    </div>
  )
}
export default Layout;
```

## PR Scope

Previously, these layouts had to be static. They would be reused as react templates across pages but couldn't be loaded with any data or introduce actions of themselves. This PR expands layouts to simply be special cases of regular `ControllerBase` layouts. With this you can add linkGenerators or actions directly to layouts.

```typescript
import { useServer } from "./_server";

const Layout = ({children}: {children: ReactNode}) => {
  const serverState = useServer();

  return (
    <div>
        <h1>My Layout</h1>
        <div>{children}</div>
    </div>
  )
}
```

This new, dynamic layout is backed by the same ControllerBase as a regular page controller is. This lets you specify page metadata, rendering functions, dependency injection, etc as you normally would.

```python
from mountaineer import LayoutControllerBase, RenderBase
from mountaineer.actions import sideeffect

class RootLayoutRender(RenderBase):
    layout_value: int

class RootLayoutController(LayoutControllerBase):
    view_path = "/app/layout.tsx"

    def __init__(self):
        super().__init__()
        self.layout_value = 0

    def render(self) -> RootLayoutRender:
        return RootLayoutRender(
            layout_value=self.layout_value,
        )

    @sideeffect
    async def increment_layout_value(self) -> None:
        self.layout_value += 1
```

To keep this PR focused:
- For now each controller will be rendered in an isolated scope - so sideeffects in one controller won't affect the others. This extends to the dependency injected functions as well. They are run in an isolated, synthetic context - not with the same dependency injection parameters that the page is.
- Layout controllers have limited access to the `Request` that is sent to the page.
- Layout controllers don't modify the page signature. Query params on layouts won't be extracted and will likely fail during rendering.

## Demo

A quick demo based on the `ci-webapp`.

https://github.com/piercefreeman/mountaineer/assets/1712066/58a4a9a0-70f4-4520-843d-ee89e830cdd0
