### PR TITLE
Support list-based page query params

### DIFF
--- a/docs_website/mkdocs.yml
+++ b/docs_website/mkdocs.yml
@@ -35,8 +35,8 @@ nav:
   - Quickstart: quickstart.md
   - Learn:
     - structure.md
-    - client_actions.md
     - views.md
+    - client_actions.md
     - metadata.md
     - database.md
     - error_handling.md

--- a/mountaineer/__tests__/client_builder/test_build_links.py
+++ b/mountaineer/__tests__/client_builder/test_build_links.py
@@ -1,10 +1,10 @@
 from enum import StrEnum
 from re import sub as re_sub
-from typing import Callable
+from typing import Annotated, Callable
 from uuid import UUID
 
 import pytest
-from fastapi import APIRouter
+from fastapi import APIRouter, Query
 from fastapi.openapi.utils import get_openapi
 
 from mountaineer.client_builder.build_links import OpenAPIToTypescriptLinkConverter
@@ -18,7 +18,11 @@ def view_endpoint_path_params(path_a: str, path_b: int):
     pass
 
 
-def view_endpoint_query_params(query_a: str, query_b: int | None = None):
+def view_endpoint_query_params(
+    query_a: str,
+    query_b: int | None = None,
+    query_c: Annotated[list[int] | None, Query()] = None,
+):
     pass
 
 
@@ -94,15 +98,18 @@ def enum_view_url(model_type: RouteType, model_id: UUID):
                 """
                 export const getLink = ({
                     query_a,
-                    query_b
+                    query_b,
+                    query_c
                 }:{
                     query_a: string,
-                    query_b?: null | number
+                    query_b?: null | number,
+                    query_c?: Array<number> | null
                 }) => {
                     const url = `/query_params`;
                     const queryParameters: Record<string,any> = {
                         query_a,
-                        query_b
+                        query_b,
+                        query_c
                     };
                     const pathParameters: Record<string,any> = {};
                     return __getLink({

--- a/mountaineer/__tests__/client_builder/test_typescript.py
+++ b/mountaineer/__tests__/client_builder/test_typescript.py
@@ -104,6 +104,7 @@ def test_collapse_repeated_literals(
 @pytest.mark.parametrize(
     "url_parameter, expected_ts_key, expected_ts_type",
     [
+        # Single typed URL parameter
         (
             URLParameterDefinition.from_meta(
                 name="test",
@@ -117,6 +118,7 @@ def test_collapse_repeated_literals(
             "test",
             "string",
         ),
+        # Multiple types for a single URL parameter
         (
             URLParameterDefinition.from_meta(
                 name="test",
@@ -136,6 +138,22 @@ def test_collapse_repeated_literals(
             ),
             "test",
             "number | string",
+        ),
+        # Support for list-based values in the URL string
+        (
+            URLParameterDefinition.from_meta(
+                name="test",
+                required=True,
+                schema_ref=OpenAPIProperty.from_meta(
+                    variable_type=OpenAPISchemaType.ARRAY,
+                    items=OpenAPIProperty.from_meta(
+                        variable_type=OpenAPISchemaType.STRING
+                    ),
+                ),
+                in_location=ParameterLocationType.PATH,
+            ),
+            "test",
+            "Array<string>",
         ),
     ],
 )

--- a/mountaineer/static/api.ts
+++ b/mountaineer/static/api.ts
@@ -192,7 +192,16 @@ export const __getLink = (params: GetLinkParams) => {
   // access to the URLSearchParams API.
   const parsedParams = Object.entries(params.queryParameters).reduce(
     (acc, [key, value]) => {
-      if (value !== undefined) {
+      if (value === undefined) {
+        return acc;
+      }
+
+      // If we've been given an array, we want separate key-value pairs for each element
+      if (Array.isArray(value)) {
+        for (const element of value) {
+          acc.push(`${key}=${element}`);
+        }
+      } else {
         acc.push(`${key}=${value}`);
       }
       return acc;


### PR DESCRIPTION
This PR adds support for render functions to specify list-based query parameters. This can be useful to persist client-side state that can be sent to other users, bookmarked, etc.

```python
from typing import Annotated
from fastapi import Query

class MyController(ControllerBase):
    async def render(
        self,
        my_arg: Annotated[list[int] | None, Query()] = None,
    ):
        pass
```

These list values will render in the URL of the final page like:

```
localhost:5006/my_page?my_arg=1&my_arg=2
```

And in the typescript signature like:

```typescript
export const getLink = ({
  my_arg
  }:{
    my_arg?: Array<number> | null
    }) => {
  ...
}
```