### PR TITLE
Merge signatures of layout and page controllers

### DIFF
--- a/ci_webapp/ci_webapp/cli.py
+++ b/ci_webapp/ci_webapp/cli.py
@@ -1,5 +1,5 @@
 from click import command
-from mountaineer.cli import handle_runserver, handle_watch
+from mountaineer.cli import handle_build, handle_runserver, handle_watch
 
 
 @command()
@@ -19,4 +19,11 @@ def watch():
         package="ci_webapp",
         webcontroller="ci_webapp.app:controller",
         subscribe_to_mountaineer=True,
+    )
+
+
+@command()
+def build():
+    handle_build(
+        webcontroller="ci_webapp.app:controller",
     )

--- a/ci_webapp/ci_webapp/controllers/root_layout.py
+++ b/ci_webapp/ci_webapp/controllers/root_layout.py
@@ -4,6 +4,7 @@ from mountaineer.actions import sideeffect
 
 class RootLayoutRender(RenderBase):
     layout_value: int
+    layout_arg: int
 
 
 class RootLayoutController(LayoutControllerBase):
@@ -13,9 +14,10 @@ class RootLayoutController(LayoutControllerBase):
         super().__init__()
         self.layout_value = 0
 
-    def render(self) -> RootLayoutRender:
+    def render(self, layout_arg: int | None = None) -> RootLayoutRender:
         return RootLayoutRender(
             layout_value=self.layout_value,
+            layout_arg=layout_arg or 0,
         )
 
     @sideeffect

--- a/ci_webapp/ci_webapp/views/app/layout.tsx
+++ b/ci_webapp/ci_webapp/views/app/layout.tsx
@@ -6,7 +6,9 @@ const Layout = ({ children }: { children: ReactNode }) => {
 
   return (
     <div className="p-6">
-      <h1>Layout State: {serverState.layout_value}</h1>
+      <h1>
+        Layout State: {serverState.layout_value} : {serverState.layout_arg}
+      </h1>
       <div>{children}</div>
       <div>
         <button

--- a/ci_webapp/pyproject.toml
+++ b/ci_webapp/pyproject.toml
@@ -14,6 +14,7 @@ mountaineer = { path = "../", develop = true }
 [tool.poetry.scripts]
 runserver = "ci_webapp.cli:runserver"
 watch = "ci_webapp.cli:watch"
+build = "ci_webapp.cli:build"
 
 [tool.poetry.group.dev.dependencies]
 types-setuptools = "^69.0.0.20240125"

--- a/docs_website/docs/views.md
+++ b/docs_website/docs/views.md
@@ -239,9 +239,9 @@ app_controller = AppController(...)
 app_controller.register(RootLayoutController())
 ```
 
-In general you can implement layout controllers just like you do for pages. But since they're shared across multiple child controllers, make sure the keyword arguments you use in your `render` signature don't have any conflicts. Mountaineer will merge these signatures at runtime and check for duplicate keyword names across the layout's child pages. Arguments are allowed to share the same name _and_ type, in which case they will be resolved to the same value.
+In general you can implement layout controllers just like you do for pages. But since they're shared across multiple child controllers, make sure the keyword arguments you use in your `render` signature don't have any conflicts. Mountaineer will merge these signatures at runtime and check for duplicate keyword names across the layout's child pages. Arguments are allowed to share the same name _and_ type, in which case they will be resolved to the same value. Arguments with conflicting types will raise a `TypeError`.
 
-It's also worth nothing that layout controllers will resolve their dependencies in the same scope as the page controllers. So if you need database access within your layout, you'll receive the same underlying transaction as the page controller. This makes dependency injection a powerful way to save on resources, and potentially even save state across layouts and pages, but be careful to not treat them as isolated objects.
+It's also worth noting that layout controllers will resolve their dependencies in the same scope as the page controllers. So if you need database access within your layout, you'll receive the same underlying transaction as the page controller. This makes dependency injection a powerful way to save on resources, but be careful to not treat them as isolated objects.
 
 ## Typescript Configuration
 

--- a/docs_website/docs/views.md
+++ b/docs_website/docs/views.md
@@ -239,13 +239,9 @@ app_controller = AppController(...)
 app_controller.register(RootLayoutController())
 ```
 
-In general you can implement layout controllers just like you do for pages. But since they're shared across multiple pages there are a few important differences to keep in mind:
+In general you can implement layout controllers just like you do for pages. But since they're shared across multiple child controllers, make sure the keyword arguments you use in your `render` signature are unique. Mountaineer will merge these signatures at runtime and any naming conflicts will throw an error. A simple way to handle this is to prefix all your layout keyword arguments with a certain convention, like `layout_root_db`, `layout_root_query`, etc.
 
-- Layout controllers will be rendered in an isolated scope. Sideeffects in one layout controller won't affect the others.
-- Dependency injections are similarly isolated. They are run in an isolated, synthetic context and not with the same dependency injection parameters that the page uses.
-- Layout controllers don't modify the page signature. Query params on layouts won't be extracted, for instance.
-
-As long as you write your layout controllers without directly referencing the page that they might be wrapping, which is the case for most layouts, you should be good to go.
+It's also worth nothing that layout controllers will resolve their dependencies in the same scope as the page controllers. So if you need database access within your layout, you'll receive the same underlying transaction as the page controller. This makes dependency injection a powerful way to save on resources, and potentially even save state across layouts and pages, but be careful to not treat them as isolated objects.
 
 ## Typescript Configuration
 

--- a/docs_website/docs/views.md
+++ b/docs_website/docs/views.md
@@ -239,7 +239,7 @@ app_controller = AppController(...)
 app_controller.register(RootLayoutController())
 ```
 
-In general you can implement layout controllers just like you do for pages. But since they're shared across multiple child controllers, make sure the keyword arguments you use in your `render` signature are unique. Mountaineer will merge these signatures at runtime and any naming conflicts will throw an error. A simple way to handle this is to prefix all your layout keyword arguments with a certain convention, like `layout_root_db`, `layout_root_query`, etc.
+In general you can implement layout controllers just like you do for pages. But since they're shared across multiple child controllers, make sure the keyword arguments you use in your `render` signature don't have any conflicts. Mountaineer will merge these signatures at runtime and check for duplicate keyword names across the layout's child pages. Arguments are allowed to share the same name _and_ type, in which case they will be resolved to the same value.
 
 It's also worth nothing that layout controllers will resolve their dependencies in the same scope as the page controllers. So if you need database access within your layout, you'll receive the same underlying transaction as the page controller. This makes dependency injection a powerful way to save on resources, and potentially even save state across layouts and pages, but be careful to not treat them as isolated objects.
 

--- a/mountaineer/__tests__/actions/test_fields.py
+++ b/mountaineer/__tests__/actions/test_fields.py
@@ -1,4 +1,4 @@
-from typing import AsyncIterator, Iterator, Optional, Type, cast
+from typing import AsyncIterator, Iterator, Optional, Type
 
 import pytest
 from fastapi.responses import JSONResponse
@@ -124,24 +124,19 @@ def test_fuse_metadata_to_response_typehint(
         metadata, sample_controller, render_model
     )
 
-    assert "ExampleController" in raw_model.model_fields.keys()
-
-    fused_model = cast(
-        BaseModel, raw_model.model_fields["ExampleController"].annotation
-    )
     if expected_sideeffect_fields:
-        assert "sideeffect" in fused_model.model_fields.keys()
-        assert fused_model.model_fields["sideeffect"].annotation
+        assert "sideeffect" in raw_model.model_fields.keys()
+        assert raw_model.model_fields["sideeffect"].annotation
         basic_compare_model_fields(
-            fused_model.model_fields["sideeffect"].annotation.model_fields,
+            raw_model.model_fields["sideeffect"].annotation.model_fields,
             expected_sideeffect_fields,
         )
 
     if expected_passthrough_fields:
-        assert "passthrough" in fused_model.model_fields.keys()
-        assert fused_model.model_fields["passthrough"].annotation
+        assert "passthrough" in raw_model.model_fields.keys()
+        assert raw_model.model_fields["passthrough"].annotation
         basic_compare_model_fields(
-            fused_model.model_fields["passthrough"].annotation.model_fields,
+            raw_model.model_fields["passthrough"].annotation.model_fields,
             expected_passthrough_fields,
         )
 

--- a/mountaineer/__tests__/actions/test_passthrough_dec.py
+++ b/mountaineer/__tests__/actions/test_passthrough_dec.py
@@ -100,11 +100,9 @@ async def test_can_call_passthrough():
 
     # The response payload should be the same both both sync and async endpoints
     expected_response = {
-        "TestController": {
-            "passthrough": ExamplePassthroughModel(
-                status="success",
-            )
-        }
+        "passthrough": ExamplePassthroughModel(
+            status="success",
+        )
     }
 
     assert return_value_sync == expected_response

--- a/mountaineer/__tests__/actions/test_sideeffect_dec.py
+++ b/mountaineer/__tests__/actions/test_sideeffect_dec.py
@@ -101,13 +101,11 @@ async def call_sideeffect_common(controller: ControllerCommon):
 
         # The response payload should be the same both both sync and async endpoints
         expected_response = {
-            controller.__class__.__name__: {
-                "sideeffect": ExampleRenderModel(
-                    value_a="Hello",
-                    value_b="World",
-                ),
-                "passthrough": None,
-            }
+            "sideeffect": ExampleRenderModel(
+                value_a="Hello",
+                value_b="World",
+            ),
+            "passthrough": None,
         }
 
         assert return_value_sync == expected_response
@@ -279,10 +277,8 @@ def test_limit_codepath_experimental(
     elapsed = (monotonic_ns() - start) / 1e9
     assert response.status_code == 200
     assert response.json() == {
-        "ExampleController": {
-            "sideeffect": {
-                "value_a": "Hello 1229",
-            }
+        "sideeffect": {
+            "value_a": "Hello 1229",
         }
     }
 

--- a/mountaineer/__tests__/test_app.py
+++ b/mountaineer/__tests__/test_app.py
@@ -1,14 +1,16 @@
 from contextlib import asynccontextmanager
+from inspect import Parameter, signature
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-from fastapi import FastAPI
+from fastapi import APIRouter, FastAPI
+from fastapi.routing import APIRoute
 from fastapi.testclient import TestClient
 from pydantic import BaseModel
 
 from mountaineer.actions import passthrough
-from mountaineer.app import AppController
+from mountaineer.app import AppController, ControllerDefinition
 from mountaineer.client_builder.openapi import OpenAPIDefinition
 from mountaineer.config import ConfigBase
 from mountaineer.controller import ControllerBase
@@ -319,3 +321,123 @@ def test_unique_controller_names():
 
     with pytest.raises(ValueError, match="already registered"):
         app.register(make_controller("/example2")())
+
+
+class TargetController(ControllerBase):
+    url = "/target"
+
+    async def render(self) -> None:
+        pass
+
+
+class ReferenceController(ControllerBase):
+    url = "/reference"
+
+    async def render(self) -> None:
+        pass
+
+
+def test_merge_render_signatures():
+    def target_fn(a: int, b: int):
+        pass
+
+    # Partial overlap with (a) and inclusion of a new variable
+    def reference_fn(a: int, c: int):
+        pass
+
+    app = AppController(view_root=Path(""))
+
+    target_definition = ControllerDefinition(
+        controller=TargetController(),
+        router=APIRouter(),
+        view_route=target_fn,
+        url_prefix="/target_prefix",
+        render_router=APIRouter(),
+    )
+    reference_definition = ControllerDefinition(
+        controller=ReferenceController(),
+        router=APIRouter(),
+        view_route=reference_fn,
+        url_prefix="/reference_prefix",
+        render_router=APIRouter(),
+    )
+
+    initial_routes = [
+        route.path for route in app.app.routes if isinstance(route, APIRoute)
+    ]
+    assert initial_routes == []
+
+    app.merge_render_signatures(
+        target_definition, reference_controller=reference_definition
+    )
+
+    assert list(signature(target_definition.view_route).parameters.values()) == [
+        Parameter("a", Parameter.POSITIONAL_OR_KEYWORD, annotation=int),
+        Parameter("b", Parameter.POSITIONAL_OR_KEYWORD, annotation=int),
+        # Items only in the reference function should be included as kwargs
+        Parameter("c", Parameter.KEYWORD_ONLY, annotation=int, default=Parameter.empty),
+    ]
+
+    # After the merging the signature should be updated, and the app controller should
+    # have a new endpoint (since the merging must re-mount)
+    final_routes = [
+        route.path for route in app.app.routes if isinstance(route, APIRoute)
+    ]
+    assert final_routes == ["/target"]
+
+
+def test_merge_render_signatures_conflicting_types():
+    """
+    If the two functions share a parameter, it must be typehinted with the
+    same type in both functions.
+
+    """
+
+    def target_fn(a: int, b: int):
+        pass
+
+    # Partial overlap with (a) and inclusion of a new variable
+    def reference_fn(a: str, c: int):
+        pass
+
+    app = AppController(view_root=Path(""))
+
+    target_definition = ControllerDefinition(
+        controller=TargetController(),
+        router=APIRouter(),
+        view_route=target_fn,
+        url_prefix="/target_prefix",
+        render_router=APIRouter(),
+    )
+    reference_definition = ControllerDefinition(
+        controller=ReferenceController(),
+        router=APIRouter(),
+        view_route=reference_fn,
+        url_prefix="/reference_prefix",
+        render_router=APIRouter(),
+    )
+
+    with pytest.raises(TypeError, match="Conflicting types"):
+        app.merge_render_signatures(
+            target_definition, reference_controller=reference_definition
+        )
+
+
+def test_get_value_mask_for_signature():
+    def target_fn(a: int, b: str):
+        pass
+
+    values = {
+        "a": 1,
+        "b": "test",
+        "c": "other",
+    }
+
+    app = AppController(view_root=Path(""))
+    assert app.get_value_mask_for_signature(
+        signature(target_fn),
+        values,
+    ) == {
+        "a": 1,
+        "b": "test",
+    }

--- a/mountaineer/__tests__/test_app.py
+++ b/mountaineer/__tests__/test_app.py
@@ -95,7 +95,6 @@ def test_generate_openapi():
         "TestExceptionActionResponse",
         "ExampleException",
         "ExampleSubModel",
-        "TestExceptionActionResponseRaw",
     }
 
 
@@ -157,7 +156,6 @@ def test_handle_conflicting_exception_names():
 
     assert openapi_definition.components.schemas.keys() == {
         "TestExceptionActionResponse",
-        "TestExceptionActionResponseRaw",
         "mountaineer.__tests__.test_1.ExampleException",
         "mountaineer.__tests__.test_2.ExampleException",
     }

--- a/mountaineer/actions/passthrough_dec.py
+++ b/mountaineer/actions/passthrough_dec.py
@@ -157,7 +157,7 @@ def passthrough(*args, **kwargs):  # type: ignore
                 if isasyncgen(response):
                     return wrap_passthrough_generator(response)
 
-                return format_final_action_response(self, dict(passthrough=response))
+                return format_final_action_response(dict(passthrough=response))
 
             metadata = init_function_metadata(inner, FunctionActionType.PASSTHROUGH)
             metadata.passthrough_model = passthrough_model

--- a/mountaineer/actions/sideeffect_dec.py
+++ b/mountaineer/actions/sideeffect_dec.py
@@ -171,7 +171,6 @@ def sideeffect(*args, **kwargs):  # type: ignore
                         server_data = await server_data
 
                     return format_final_action_response(
-                        self,
                         dict(
                             sideeffect=server_data,
                             passthrough=passthrough_values,

--- a/mountaineer/app.py
+++ b/mountaineer/app.py
@@ -456,7 +456,7 @@ class AppController:
                 reference_annotation_type = parameter.annotation
 
                 if target_annotation_type != reference_annotation_type:
-                    raise ValueError(
+                    raise TypeError(
                         f"Duplicate parameter {parameter.name} in {target_controller.controller} and {reference_controller.controller}.\n"
                         f"Conflicting types: {target_annotation_type} vs {reference_annotation_type}"
                     )

--- a/mountaineer/app.py
+++ b/mountaineer/app.py
@@ -1,12 +1,13 @@
 from collections import defaultdict
 from functools import wraps
-from inspect import isawaitable, isclass, signature
+from inspect import Parameter, Signature, isawaitable, isclass, signature
 from pathlib import Path
 from typing import Any, Callable, Type
 
 from fastapi import APIRouter, FastAPI, HTTPException, Request
 from fastapi.openapi.utils import get_openapi
 from fastapi.responses import JSONResponse
+from fastapi.routing import APIRoute
 from fastapi.staticfiles import StaticFiles
 from inflection import underscore
 from pydantic import BaseModel
@@ -20,9 +21,9 @@ from mountaineer.actions import (
 from mountaineer.actions.fields import FunctionMetadata
 from mountaineer.annotation_helpers import MountaineerUnsetValue
 from mountaineer.config import ConfigBase
+from mountaineer.console import CONSOLE, ERROR_CONSOLE
 from mountaineer.controller import ControllerBase
 from mountaineer.controller_layout import LayoutControllerBase
-from mountaineer.dependencies.base import get_function_dependencies
 from mountaineer.exceptions import APIException, APIExceptionInternalModelBase
 from mountaineer.js_compiler.base import ClientBuilderBase
 from mountaineer.js_compiler.javascript import JavascriptBundler
@@ -211,23 +212,27 @@ class AppController:
                 #
                 # For now we assume that the render method of layouts will specify no URL parameters
                 # and can be leveraged in an isoltaed context.
-                async with get_function_dependencies(
-                    callable=definition.controller.render, url=controller.url
-                ) as values:
-                    server_data = definition.controller.render(**values)
-                    if isawaitable(server_data):
-                        server_data = await server_data
-                    if server_data is None:
-                        server_data = RenderNull()
+                layout_values = self.get_value_mask_for_signature(
+                    signature(definition.controller.render), kwargs
+                )
+                server_data = definition.controller.render(**layout_values)
+                if isawaitable(server_data):
+                    server_data = await server_data
+                if server_data is None:
+                    server_data = RenderNull()
 
                 layout_metadata[definition.controller.__class__.__name__] = server_data
 
             try:
+                render_values = self.get_value_mask_for_signature(
+                    signature(controller.render), kwargs
+                )
                 return await controller._generate_html(
-                    *args,
+                    # *args,
                     global_metadata=self.global_metadata,
                     other_render_contexts=layout_metadata,
-                    **kwargs,
+                    # **kwargs,
+                    **render_values,
                 )
             except Exception as e:
                 # If a user explicitly is raising an APIException, we don't want to log it
@@ -351,11 +356,137 @@ class AppController:
         self.controllers.append(controller_definition)
         self.controller_names.add(controller_name)
 
+        # Handle the resolution of the full signature of the render function
+        self.greedy_merge_signatures(controller_definition)
+
     async def handle_exception(self, request: Request, exc: APIException):
         return JSONResponse(
             status_code=exc.status_code,
             content=exc.internal_model.model_dump(),
         )
+
+    def greedy_merge_signatures(
+        self,
+        controller_def: ControllerDefinition,
+    ):
+        """
+        As soon as a new controller is mounted, we try to determine whether the new resolution of this
+        controller modifies (or is modified by) existing controllers.
+
+        Specifically:
+
+        - If the new controller is a LayoutController, it might modify controllers that are already
+            mounted. We need to back-fill the relationship between the layout and the controllers.
+        - If the new controller is a standard controller, it might be modified by a LayoutController
+            that is already mounted. We should back-fill in the same way.
+
+        """
+        # Too early in the build lifecycle, hasn't yet built artifacts
+        if not controller_def.controller.build_metadata:
+            CONSOLE.print(
+                "[red]No metadata found for controller on disk. Skipping layout merging until after first build is completed."
+            )
+            return
+
+        # Exclude the self reference
+        other_controllers = [
+            definition
+            for definition in self.controllers
+            if definition is not controller_def
+        ]
+
+        if isinstance(controller_def.controller, LayoutControllerBase):
+            # Go back through the existing controllers and back-fill
+            # the relationship
+            for existing_controller_def in other_controllers:
+                if (
+                    existing_controller_def.controller.build_metadata
+                    and controller_def.controller.build_metadata.view_path
+                    in existing_controller_def.controller.build_metadata.layout_view_paths
+                ):
+                    self.merge_render_signatures(
+                        existing_controller_def,
+                        reference_controller=controller_def,
+                    )
+        else:
+            for candidate_layout_controller in other_controllers:
+                if candidate_layout_controller.controller.build_metadata and (
+                    candidate_layout_controller.controller.build_metadata.view_path
+                    in controller_def.controller.build_metadata.layout_view_paths
+                ):
+                    self.merge_render_signatures(
+                        controller_def,
+                        reference_controller=candidate_layout_controller,
+                    )
+
+    def merge_render_signatures(
+        self,
+        target_controller: ControllerDefinition,
+        *,
+        reference_controller: ControllerDefinition,
+    ):
+        """
+        Collects the signature from the "reference_controller" and replaces the active render endpoint
+        with this new signature. We require all these new parameters to be kwargs so they
+        can be injected into the render function by name alone.
+
+        """
+        reference_signature = signature(reference_controller.view_route)
+        target_signature = signature(target_controller.view_route)
+
+        reference_parameters = reference_signature.parameters.values()
+        target_parameters = list(target_signature.parameters.values())
+
+        # For any additional arguments provided by the reference, inject them into
+        # the target controller
+        # For duplicate ones, the target controller should win
+        for parameter in reference_parameters:
+            if parameter.name not in target_signature.parameters:
+                target_parameters.append(
+                    parameter.replace(
+                        kind=Parameter.KEYWORD_ONLY,
+                    )
+                )
+            else:
+                ERROR_CONSOLE.print(
+                    f"[red]Duplicate parameter {parameter.name} in {target_controller.controller} and {reference_controller.controller}, ignoring..."
+                )
+
+        target_controller.view_route.__signature__ = target_signature.replace(  # type: ignore
+            parameters=target_parameters
+        )
+
+        # Re-mount the controller exactly as it was first mounted
+        if target_controller.render_router:
+            # Clear the previous definition before re-adding it
+            # Both the app route is required (for the actual page resolution) and the render router
+            # (to avoid conflicts in the OpenAPI generation)
+            for route_list in [self.app.routes, target_controller.render_router.routes]:
+                for route in list(route_list):
+                    if (
+                        isinstance(route, APIRoute)
+                        and route.path == target_controller.controller.url
+                        and route.methods == {"GET"}
+                    ):
+                        route_list.remove(route)
+
+            target_controller.render_router.get(target_controller.controller.url)(
+                target_controller.view_route
+            )
+            self.app.include_router(target_controller.render_router)
+
+    def get_value_mask_for_signature(
+        self,
+        signature: Signature,
+        values: dict[str, Any],
+    ):
+        # Assume the values match the parameters specified in the signature
+        passthrough_names = {
+            parameter.name for parameter in signature.parameters.values()
+        }
+        return {
+            name: value for name, value in values.items() if name in passthrough_names
+        }
 
     def generate_openapi(self, routes: list[BaseRoute] | None = None):
         """

--- a/mountaineer/client_builder/builder.py
+++ b/mountaineer/client_builder/builder.py
@@ -390,7 +390,7 @@ class ClientBuilder:
                 + ",\n".join(
                     [
                         (
-                            f"{metadata.function_name}: applySideEffect({metadata.function_name}, setControllerState, '{controller_key}')"
+                            f"{metadata.function_name}: applySideEffect({metadata.function_name}, setControllerState)"
                             if metadata.action_type == FunctionActionType.SIDEEFFECT
                             else f"{metadata.function_name}: {metadata.function_name}"
                         )

--- a/mountaineer/static/api.ts
+++ b/mountaineer/static/api.ts
@@ -151,24 +151,19 @@ const handleStreamOutputFormat = async (
   })();
 };
 
-type ApiFunctionReturnType<S, P, K extends PropertyKey> = {
-  // Generic typehint for any key parameter
-  [key in K]: {
-    sideeffect: S;
-    passthrough?: P;
-  };
+type ApiFunctionReturnType<S, P> = {
+  sideeffect: S;
+  passthrough?: P;
 };
 
 export function applySideEffect<
   ARG extends any[],
   S,
   P,
-  K extends PropertyKey,
-  RE extends ApiFunctionReturnType<S, P, K>,
+  RE extends ApiFunctionReturnType<S, P>,
 >(
   apiFunction: (...args: ARG) => Promise<RE>,
   setControllerState: (payload: S) => void,
-  controllerKey: K,
 ): (...args: ARG) => Promise<RE> {
   /*
    * Executes an API server function, triggering any appropriate exceptions.
@@ -176,7 +171,7 @@ export function applySideEffect<
    */
   return async (...args: ARG) => {
     const result = await apiFunction(...args);
-    setControllerState(result[controllerKey].sideeffect);
+    setControllerState(result.sideeffect);
     return result;
   };
 }


### PR DESCRIPTION
Follow-on PR to https://github.com/piercefreeman/mountaineer/pull/104, to bring layout controllers to full dependency injection parity as page controllers. We accomplish this by inspecting the signature of the page / layout endpoints during AppController registration, and progressively combine additional signatures as the pages come into scope. This allows us to keep the dynamic mode of controller registration with the AppController, while allowing the `render` methods of layout controllers to have the full scope of dependency injection arguments. This includes query parameters and request-based parameters, like extracting user headers.

A convenient benefit of our new implementation is that layout controllers will share the underlying dependency injected objects with the controller itself. In the case of heavy shared dependencies (like database connections) this can significantly increase the speed of page resolution.