### PR TITLE
Fix database migration edge cases

### DIFF
--- a/docs_website/docs/api/database/migrations.md
+++ b/docs_website/docs/api/database/migrations.md
@@ -1,0 +1,20 @@
+# Database Migrations
+
+## CLI
+
+::: mountaineer.migrations.cli.handle_generate
+::: mountaineer.migrations.cli.handle_apply
+::: mountaineer.migrations.cli.handle_rollback
+
+## Migrations
+
+::: mountaineer.migrations.migration.MigrationRevisionBase
+::: mountaineer.migrations.migrator.Migrator
+::: mountaineer.migrations.migrator.NoCommitAsyncSession
+
+## Actions
+
+::: mountaineer.migrations.actions.DatabaseActions
+
+::: mountaineer.migrations.actions.ColumnType
+::: mountaineer.migrations.actions.ConstraintType

--- a/docs_website/docs/client_actions.md
+++ b/docs_website/docs/client_actions.md
@@ -63,7 +63,7 @@ If the action has a passthrough, it will be supplied in `response.passthrough`. 
 
 ### Experimental Render Reloader
 
-!!! tip
+!!! warning
 
     This feature is experimental and only supports relatively simple render() function implementations. If you use it for a more complicated render() function and it doesn't work as expected, report a bug to improve the test coverage.
 

--- a/docs_website/docs/database_migrations.md
+++ b/docs_website/docs/database_migrations.md
@@ -1,0 +1,164 @@
+# Database Migrations
+
+!!! warning
+
+    This feature is experimental. Explore using it while developing locally but make sure to backup your data before applying changes. It should support all SQLModel definitions, but if you encounter a bug or lack of support, please report it so we can improve the test coverage.
+
+## Overview
+
+Once your application is in production, you'll need some method of updating your database schema as you update your application's functionality. You _could_ write raw SQL to accomplish these migrations, or manually modify database table definitions. But the former is inconvenient and the second is risky. Mountaineer ships with a migration tool that can automatically generate migration files for you and apply them to your database. Its features:
+
+- Fast with no external dependencies outside of Mountaineer core.
+- Programmatic with zero config required, but options that can be specified in code.
+- Baked-in support for common Postgres types that overlap with Python, most specifically Enums and datetimes.
+- File-based groundtruth of migration logic, so it can be audited in source control and customized by you.
+- Simple API surface, with atomic Python functions that perform the most common migration operations. Direct database queries (or integration with ORM objects in limited cases) can be used for more complex migration logic.
+
+## Project Integration
+
+Following the current standard for Mountaineer CLI integrations, we require client applications to explicitly define their CLI endpoints. We include basic handlers for import in `mountaineer.migrations.cli`. This should look very similar to the default handlers for `runserver` and `build`.
+
+You can integrate like so in your CLI file:
+
+```python title="myapp/cli.py"
+from click import group, option
+
+from mountaineer.io import async_to_sync
+from mountaineer.migrations.cli import handle_apply, handle_generate, handle_rollback
+from myapp.config import AppConfig
+
+@group
+def migrate():
+    pass
+
+@migrate.command()
+@option("--message", required=False)
+@async_to_sync
+async def generate(message: str | None):
+    _ = AppConfig()  # type: ignore
+    await handle_generate(message=message)
+
+@migrate.command()
+@async_to_sync
+async def apply():
+    _ = AppConfig()  # type: ignore
+    await handle_apply()
+
+@migrate.command()
+@async_to_sync
+async def rollback():
+    _ = AppConfig()  # type: ignore
+    await handle_rollback()
+```
+
+Also modify your project's pyproject.toml file.
+
+```toml title="pyproject.toml"
+[tool.poetry.scripts]
+migrate = "myapp.cli:migrate"
+```
+
+### Generate
+
+```bash
+$ poetry run migrate generate --message "Add author column to article"
+```
+
+Generate a migration file, to update the database schema to the ones defined in your code.
+
+### Apply
+
+```bash
+$ poetry run migrate apply
+```
+
+Apply all migration files that have not been applied to the database.
+
+### Rollback
+
+```bash
+$ poetry run migrate rollback
+```
+
+Rollback the last migration that was applied to the database.
+
+## Migration files
+
+All data changes live in separate migration files. You can generate them through the Mountaineer CLI and modify them as you need to handle your data migrations.
+
+The goal of a migration file is to determine the goal database state (ie. what you current have in code). It then figures out how to transition the current database state to the new goal state. As such, before generating your migration file, make sure your local database has the same schema configuration as your production database. Otherwise your migration files might be incorrect and not apply properly.
+
+```bash
+poetry run migrate generate --message "Add author column to article"
+```
+
+The created migration will be placed into `myapp/migrations` and include a unix timestamp of when the migration was created. Since most IDEs will sort directories by integer value, you can look towards the bottom of your migrations directory to see the most recent migration that will be run.
+
+```python
+from mountaineer.migrations.migrator import Migrator
+from mountaineer.migrations.migration import MigrationRevisionBase
+from mountaineer.migrations.dependency import MigrationDependencies
+from fastapi.param_functions import Depends
+
+class MigrationRevision(MigrationRevisionBase):
+    up_revision: str = "1715044020"
+    down_revision: str | None = None
+
+    async def up(
+        self,
+        migrator: Migrator = Depends(MigrationDependencies.get_migrator),
+    ):
+        await migrator.actor.add_not_null(
+            table_name="article",
+            column_name="author"
+        )
+
+    async def down(
+        self,
+        migrator: Migrator = Depends(MigrationDependencies.get_migrator),
+    ):
+        await migrator.actor.drop_not_null(
+            table_name="article",
+            column_name="author"
+        )
+```
+
+Let's break down the migration file that was just generated:
+
+There's an `up` function that covers the migration to the new application state. These are standard dependency injection functions, so you can use any dependency injector in your application if you want to inject other variables. By default we just supply the migrator: Migrator which is a shallow wrapper that provides a database session (with an open connection) alongside an actor object that includes some common migration recipes.
+
+The `down` function does the inverse. It takes the database state after your migration has been run and downgrades it to the last version. It's useful to have this specified in case you need to rollback your migration to conform to the previously deployed service. This often requires some care at considering how you can safely rollback your migration, perhaps through keeping temporary columns around inbetween migrations that you know you might have to rollback.
+
+The `up_revision` and `down_revision` are used to track the migration state. The `up_revision` is the timestamp of the migration file, and the `down_revision` is the timestamp of the previous migration file. If you don't have a down revision, it will be set to `None`. These will be injected into a dynamic "migration_info" table in your database to track the current state of your migrations.
+
+## Extending Migration Files
+
+The `Migrator` object is a thin wrapper around the `DatabaseActions` object, which is a collection of common migration operations. If you need to perform a more complex migration operation, you can customize the logic by calling `migrator.actor` yourself. Head over to the [DatabaseActions documentation](/database/migrations) to see the full list of available migration operations.
+
+In addition to the actor, you can also access the underlying database session object. This is useful if you need to run raw SQL queries that aren't covered by the actor object.
+
+```python
+async def up(
+    self,
+    migrator: Migrator = Depends(MigrationDependencies.get_migrator),
+):
+    result = await migrator.db_session.execute("SELECT * FROM article")
+```
+
+We recommend using the actor object whenever possible, as it provides a more consistent and safe way to run migrations. If you are using the raw database session object, be aware that we require migrations to be run in a single transaction. This ensures that if a migration fails, the database will be rolled back to its previous state. We therefore disable calling `db_session.commit()` explicitly from within user code.
+
+## Alternatives
+
+While the Mountaineer core authors only support its native migration workflow, since the database primitives build off of SQLModel/SQLAlchemy there are other options in the ecosystem for migration generation.
+
+The industry standard migration package for SQLAlchemy is Alembic, which is a powerful and robust file-based migration library. A quick list of pros and our perceived cons:
+
+Pros:
+
+- Mature project with a large user base and extensive documentation.
+- It has a rich feature set, including support for multiple database backends and complex migration operations.
+
+Cons:
+
+- Non-trivial setup complexity with configuration files and a separate CLI.
+- In steady state it's sometimes unclear what migration responsibility Alembic owns, versus what should be delegated to SQLAlchemy.

--- a/docs_website/mkdocs.yml
+++ b/docs_website/mkdocs.yml
@@ -39,6 +39,7 @@ nav:
     - client_actions.md
     - metadata.md
     - database.md
+    - database_migrations.md
     - error_handling.md
     - links.md
     - static_analysis.md
@@ -59,6 +60,7 @@ nav:
     - Database:
       - api/database/config.md
       - api/database/dependencies.md
+      - api/database/migrations.md
     - Build Plugins:
       - api/build_plugins/javascript.md
       - api/build_plugins/postcss.md

--- a/mountaineer/__tests__/migrations/test_actions.py
+++ b/mountaineer/__tests__/migrations/test_actions.py
@@ -160,6 +160,23 @@ async def test_add_table(
 
 
 @pytest.mark.asyncio
+async def test_add_table_reserved_keyword(
+    db_backed_actions: DatabaseActions,
+    db_session: AsyncSession,
+):
+    """
+    Confirm that table migrations will wrap the table name in double quotes
+    to avoid conflicts with reserved keywords.
+
+    """
+    await db_backed_actions.add_table("user")
+    await db_session.commit()
+
+    # We should have a table in the database
+    assert await db_session.execute(text("SELECT * FROM user"))
+
+
+@pytest.mark.asyncio
 async def test_drop_table(
     db_backed_actions: DatabaseActions,
     db_session: AsyncSession,

--- a/mountaineer/__tests__/migrations/test_actions.py
+++ b/mountaineer/__tests__/migrations/test_actions.py
@@ -1,8 +1,30 @@
 from unittest.mock import AsyncMock
 
 import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import text
 
-from mountaineer.migrations.actions import DatabaseActions, DryRunAction
+from mountaineer.migrations.actions import (
+    DatabaseActions,
+    DryRunAction,
+    assert_is_safe_sql_identifier,
+    format_sql_values,
+)
+
+
+@pytest.fixture
+def db_backed_actions(
+    db_session: AsyncSession,
+    isolated_sqlalchemy,
+    clear_all_database_objects,
+):
+    """
+    Fixture that should be used for actions that should actually be executed
+    against a database. We will clear all database objects before and after
+    the test, so no SQLModel backed objects will be available.
+
+    """
+    return DatabaseActions(dry_run=False, db_session=db_session)
 
 
 def example_action_fn(arg_1: str):
@@ -48,3 +70,85 @@ async def test_record_signature_incorrect_kwarg():
     # A required kwarg is missing
     with pytest.raises(ValueError):
         await database_actions._record_signature(example_action_fn, {}, "SQL")
+
+
+@pytest.mark.parametrize(
+    "identifier, expected_is_valid",
+    [
+        # Valid identifiers
+        ("validTableName", True),
+        ("_valid_table_name", True),
+        ("Table123", True),
+        ("_", True),
+        ("t", True),
+        # Invalid identifiers
+        ("123table", False),
+        ("table-name", False),
+        ("table name", False),
+        ("table$name", False),
+        ("table!name", False),
+        ("table@name", False),
+        ("table#name", False),
+        ("", False),
+        (" ", False),
+        (" table", False),
+        ("table ", False),
+        ("table\n", False),
+        # SQL injection attempts
+        ("table; DROP TABLE users;", False),
+        ("table; SELECT * FROM users", False),
+        ("1;1", False),
+        (";", False),
+        ("--comment", False),
+        ("' OR '1'='1", False),
+        ('" OR "1"="1', False),
+        ("table`", False),
+        ("[table]", False),
+        ("{table}", False),
+        ("<script>", False),
+        ('"; DROP TABLE users; --', False),
+        ("'; DROP TABLE users; --", False),
+    ],
+)
+def test_is_safe_sql_identifier(identifier: str, expected_is_valid: bool):
+    if expected_is_valid:
+        assert_is_safe_sql_identifier(identifier)
+    else:
+        with pytest.raises(ValueError):
+            assert_is_safe_sql_identifier(identifier)
+
+
+@pytest.mark.parametrize(
+    "values, expected",
+    [
+        # Simple strings without special characters
+        (["single"], "'single'"),
+        ([], ""),
+        (["apple", "banana"], "'apple', 'banana'"),
+        # Strings with single quotes that need escaping
+        (["O'Neill", "d'Artagnan"], "'O''Neill', 'd''Artagnan'"),
+        # Mixed strings, no special characters and with special characters
+        (["hello", "it's a test"], "'hello', 'it''s a test'"),
+        # Strings that contain SQL-like syntax
+        (
+            ["SELECT * FROM users;", "DROP TABLE students;"],
+            "'SELECT * FROM users;', 'DROP TABLE students;'",
+        ),
+        # Empty strings and spaces
+        (["", " ", "   "], "'', ' ', '   '"),
+    ],
+)
+def test_format_sql_values(values, expected):
+    assert format_sql_values(values) == expected
+
+
+@pytest.mark.asyncio
+async def test_add_table(
+    db_backed_actions: DatabaseActions,
+    db_session: AsyncSession,
+):
+    await db_backed_actions.add_table("test_table")
+    await db_session.commit()
+
+    # We should have a table in the database
+    assert await db_session.execute(text("SELECT * FROM test_table"))

--- a/mountaineer/__tests__/migrations/test_db_serializer.py
+++ b/mountaineer/__tests__/migrations/test_db_serializer.py
@@ -63,7 +63,13 @@ def compare_db_objects(
             Field(),
             [
                 (
-                    DBType(name="valueenumstandard", values=frozenset({"A"})),
+                    DBType(
+                        name="valueenumstandard",
+                        values=frozenset({"A"}),
+                        reference_columns=frozenset(
+                            {("exampledbmodel", "standard_enum")}
+                        ),
+                    ),
                     [
                         DBTable(table_name="exampledbmodel"),
                     ],
@@ -73,13 +79,23 @@ def compare_db_objects(
                         table_name="exampledbmodel",
                         column_name="standard_enum",
                         column_type=DBType(
-                            name="valueenumstandard", values=frozenset({"A"})
+                            name="valueenumstandard",
+                            values=frozenset({"A"}),
+                            reference_columns=frozenset(
+                                {("exampledbmodel", "standard_enum")}
+                            ),
                         ),
                         column_is_list=False,
                         nullable=False,
                     ),
                     [
-                        DBType(name="valueenumstandard", values=frozenset({"A"})),
+                        DBType(
+                            name="valueenumstandard",
+                            values=frozenset({"A"}),
+                            reference_columns=frozenset(
+                                {("exampledbmodel", "standard_enum")}
+                            ),
+                        ),
                         DBTable(table_name="exampledbmodel"),
                     ],
                 ),
@@ -91,7 +107,11 @@ def compare_db_objects(
             Field(),
             [
                 (
-                    DBType(name="valueenumstr", values=frozenset({"A"})),
+                    DBType(
+                        name="valueenumstr",
+                        values=frozenset({"A"}),
+                        reference_columns=frozenset({("exampledbmodel", "str_enum")}),
+                    ),
                     [
                         DBTable(table_name="exampledbmodel"),
                     ],
@@ -101,13 +121,23 @@ def compare_db_objects(
                         table_name="exampledbmodel",
                         column_name="str_enum",
                         column_type=DBType(
-                            name="valueenumstr", values=frozenset({"A"})
+                            name="valueenumstr",
+                            values=frozenset({"A"}),
+                            reference_columns=frozenset(
+                                {("exampledbmodel", "str_enum")}
+                            ),
                         ),
                         column_is_list=False,
                         nullable=False,
                     ),
                     [
-                        DBType(name="valueenumstr", values=frozenset({"A"})),
+                        DBType(
+                            name="valueenumstr",
+                            values=frozenset({"A"}),
+                            reference_columns=frozenset(
+                                {("exampledbmodel", "str_enum")}
+                            ),
+                        ),
                         DBTable(table_name="exampledbmodel"),
                     ],
                 ),
@@ -119,7 +149,11 @@ def compare_db_objects(
             Field(),
             [
                 (
-                    DBType(name="valueenumint", values=frozenset({"A"})),
+                    DBType(
+                        name="valueenumint",
+                        values=frozenset({"A"}),
+                        reference_columns=frozenset({("exampledbmodel", "int_enum")}),
+                    ),
                     [
                         DBTable(table_name="exampledbmodel"),
                     ],
@@ -129,13 +163,23 @@ def compare_db_objects(
                         table_name="exampledbmodel",
                         column_name="int_enum",
                         column_type=DBType(
-                            name="valueenumint", values=frozenset({"A"})
+                            name="valueenumint",
+                            values=frozenset({"A"}),
+                            reference_columns=frozenset(
+                                {("exampledbmodel", "int_enum")}
+                            ),
                         ),
                         column_is_list=False,
                         nullable=False,
                     ),
                     [
-                        DBType(name="valueenumint", values=frozenset({"A"})),
+                        DBType(
+                            name="valueenumint",
+                            values=frozenset({"A"}),
+                            reference_columns=frozenset(
+                                {("exampledbmodel", "int_enum")}
+                            ),
+                        ),
                         DBTable(table_name="exampledbmodel"),
                     ],
                 ),

--- a/mountaineer/__tests__/migrations/test_db_stubs.py
+++ b/mountaineer/__tests__/migrations/test_db_stubs.py
@@ -1,0 +1,21 @@
+from mountaineer.migrations.db_stubs import DBType
+
+
+def test_merge_type_columns():
+    type_a = DBType(
+        name="type_a",
+        values=frozenset({"A"}),
+        reference_columns=frozenset({("table_a", "column_a")}),
+    )
+    type_b = DBType(
+        name="type_a",
+        values=frozenset({"A"}),
+        reference_columns=frozenset({("table_b", "column_b")}),
+    )
+
+    merged = type_a.merge(type_b)
+    assert merged.name == "type_a"
+    assert merged.values == frozenset({"A"})
+    assert merged.reference_columns == frozenset(
+        {("table_a", "column_a"), ("table_b", "column_b")}
+    )

--- a/mountaineer/__tests__/migrations/test_generator.py
+++ b/mountaineer/__tests__/migrations/test_generator.py
@@ -104,6 +104,8 @@ class ExampleDataclass:
         ),
         (ExampleModel(value="test"), 'ExampleModel(value="test")'),
         (ExampleDataclass(value="test"), 'ExampleDataclass(value="test")'),
+        (True, "True"),
+        (False, "False"),
     ],
 )
 def test_format_arg(value: Any, expected_value: str):

--- a/mountaineer/__tests__/migrations/test_handlers.py
+++ b/mountaineer/__tests__/migrations/test_handlers.py
@@ -4,6 +4,7 @@ import sqlalchemy as sa
 from sqlmodel import Field, SQLModel
 
 from mountaineer.migrations.actions import (
+    CheckConstraint,
     ColumnType,
     ConstraintType,
     ForeignKeyConstraint,
@@ -79,6 +80,71 @@ def test_sa_foreign_key(isolated_sqlalchemy):
                 foreign_key_constraint=None,
             ),
             [DBColumnPointer(table_name="examplemodel", column_name="id")],
+        ),
+    ]
+
+
+def test_check_constraint(isolated_sqlalchemy):
+    """
+    Foreign keys are usually specified by a Field(foreign_key=xx) definition. However, they
+    can also be specified as a native SQLAlchemy Column object. This test ensures that
+    we still parse column foreign keys into the proper format.
+
+    """
+
+    class ExampleModel(SQLModel, table=True):
+        id: UUID = Field(primary_key=True)
+        price: int
+
+        __table_args__ = (sa.CheckConstraint("price >= 0"),)
+
+    migrator = DatabaseMemorySerializer()
+    db_objects = list(migrator.delegate([ExampleModel], context=None))
+    assert db_objects == [
+        (DBTable(table_name="examplemodel"), []),
+        (
+            DBColumn(
+                table_name="examplemodel",
+                column_name="id",
+                column_type=ColumnType.UUID,
+                column_is_list=False,
+                nullable=False,
+            ),
+            [DBTable(table_name="examplemodel")],
+        ),
+        (
+            DBColumn(
+                table_name="examplemodel",
+                column_name="price",
+                column_type=ColumnType.INTEGER,
+                column_is_list=False,
+                nullable=False,
+            ),
+            [DBTable(table_name="examplemodel")],
+        ),
+        (
+            DBConstraint(
+                table_name="examplemodel",
+                constraint_name="examplemodel_pkey",
+                columns=frozenset({"id"}),
+                constraint_type=ConstraintType.PRIMARY_KEY,
+                foreign_key_constraint=None,
+                check_constraint=None,
+            ),
+            [DBColumnPointer(table_name="examplemodel", column_name="id")],
+        ),
+        # This is the critical extracted object, should translate the internal representation
+        # of the SQL text into a regular string
+        (
+            DBConstraint(
+                table_name="examplemodel",
+                constraint_name="examplemodel_key",
+                columns=frozenset(),
+                constraint_type=ConstraintType.CHECK,
+                foreign_key_constraint=None,
+                check_constraint=CheckConstraint(check_condition="price >= 0"),
+            ),
+            [DBTable(table_name="examplemodel")],
         ),
     ]
 

--- a/mountaineer/migrations/actions.py
+++ b/mountaineer/migrations/actions.py
@@ -233,13 +233,16 @@ class DatabaseActions:
         assert_is_safe_sql_identifier(table_name)
         assert_is_safe_sql_identifier(column_name)
 
+        # We only need to check the custom data type, since we know
+        # the explicit data types come from the enum and are safe.
+        if custom_data_type:
+            assert_is_safe_sql_identifier(custom_data_type)
+
         column_type = self._get_column_type(
             explicit_data_type=explicit_data_type,
             explicit_data_is_list=explicit_data_is_list,
             custom_data_type=custom_data_type,
         )
-
-        assert_is_safe_sql_identifier(column_type)
 
         await self._record_signature(
             self.add_column,
@@ -309,13 +312,16 @@ class DatabaseActions:
         assert_is_safe_sql_identifier(table_name)
         assert_is_safe_sql_identifier(column_name)
 
+        # We only need to check the custom data type, since we know
+        # the explicit data types come from the enum and are safe.
+        if custom_data_type:
+            assert_is_safe_sql_identifier(custom_data_type)
+
         column_type = self._get_column_type(
             explicit_data_type=explicit_data_type,
             explicit_data_is_list=explicit_data_is_list,
             custom_data_type=custom_data_type,
         )
-
-        assert_is_safe_sql_identifier(column_type)
 
         await self._record_signature(
             self.modify_column_type,

--- a/mountaineer/migrations/actions.py
+++ b/mountaineer/migrations/actions.py
@@ -201,7 +201,7 @@ class DatabaseActions:
             self.add_table,
             dict(table_name=table_name),
             f"""
-            CREATE TABLE {table_name} ();
+            CREATE TABLE "{table_name}" ();
             """,
         )
 
@@ -212,7 +212,7 @@ class DatabaseActions:
             self.drop_table,
             dict(table_name=table_name),
             f"""
-            DROP TABLE {table_name}
+            DROP TABLE "{table_name}"
             """,
         )
 
@@ -257,7 +257,7 @@ class DatabaseActions:
                 custom_data_type=custom_data_type,
             ),
             f"""
-            ALTER TABLE {table_name}
+            ALTER TABLE "{table_name}"
             ADD COLUMN {column_name} {column_type}
             """,
         )
@@ -270,7 +270,7 @@ class DatabaseActions:
             self.drop_column,
             dict(table_name=table_name, column_name=column_name),
             f"""
-            ALTER TABLE {table_name}
+            ALTER TABLE "{table_name}"
             DROP COLUMN {column_name}
             """,
         )
@@ -290,7 +290,7 @@ class DatabaseActions:
                 new_column_name=new_column_name,
             ),
             f"""
-            ALTER TABLE {table_name}
+            ALTER TABLE "{table_name}"
             RENAME COLUMN {old_column_name} TO {new_column_name}
             """,
         )
@@ -336,7 +336,7 @@ class DatabaseActions:
                 custom_data_type=custom_data_type,
             ),
             f"""
-            ALTER TABLE {table_name}
+            ALTER TABLE "{table_name}"
             MODIFY COLUMN {column_name} {column_type}
             """,
         )
@@ -388,7 +388,7 @@ class DatabaseActions:
             assert_is_safe_sql_identifier(column_name)
 
         columns_formatted = ", ".join(columns)
-        sql = f"ALTER TABLE {table_name} ADD CONSTRAINT {constraint_name} "
+        sql = f'ALTER TABLE "{table_name}" ADD CONSTRAINT {constraint_name} '
 
         if constraint == ConstraintType.PRIMARY_KEY:
             sql += f"PRIMARY KEY ({columns_formatted})"
@@ -443,7 +443,7 @@ class DatabaseActions:
                 constraint_name=constraint_name,
             ),
             f"""
-            ALTER TABLE {table_name}
+            ALTER TABLE "{table_name}"
             DROP CONSTRAINT {constraint_name}
             """,
         )
@@ -456,7 +456,7 @@ class DatabaseActions:
             self.add_not_null,
             dict(table_name=table_name, column_name=column_name),
             f"""
-            ALTER TABLE {table_name}
+            ALTER TABLE "{table_name}"
             ALTER COLUMN {column_name}
             SET NOT NULL
             """,
@@ -470,7 +470,7 @@ class DatabaseActions:
             self.drop_not_null,
             dict(table_name=table_name, column_name=column_name),
             f"""
-            ALTER TABLE {table_name}
+            ALTER TABLE "{table_name}"
             ALTER COLUMN {column_name}
             DROP NOT NULL
             """,
@@ -498,7 +498,7 @@ class DatabaseActions:
             formatted_value = format_sql_values([value])
             sql_commands.append(
                 f"""
-            ALTER TYPE {type_name} ADD VALUE {formatted_value}
+            ALTER TYPE "{type_name}" ADD VALUE {formatted_value}
             """
             )
 
@@ -533,7 +533,7 @@ class DatabaseActions:
             [
                 (
                     # The "USING" param is required for enum migration
-                    f"EXECUTE 'ALTER TABLE {table_name} ALTER COLUMN {column_name} TYPE {type_name}"
+                    f'EXECUTE \'ALTER TABLE "{table_name}" ALTER COLUMN {column_name} TYPE "{type_name}"'
                     f" USING {column_name}::text::{type_name}'"
                 )
                 for table_name, column_name in target_columns
@@ -551,7 +551,7 @@ class DatabaseActions:
                 vals text;
             BEGIN
                 -- Move the current enum to a temporary type
-                EXECUTE 'ALTER TYPE {type_name} RENAME TO {type_name}_old';
+                EXECUTE 'ALTER TYPE "{type_name}" RENAME TO "{type_name}_old"';
 
                 -- Retrieve all current enum values except those to be excluded
                 SELECT string_agg('''' || unnest || '''', ', ' ORDER BY unnest) INTO vals
@@ -559,13 +559,13 @@ class DatabaseActions:
                 WHERE unnest NOT IN ({values_to_remove});
 
                 -- Create and populate our new type with the desired changes
-                EXECUTE format('CREATE TYPE {type_name} AS ENUM (%s)', vals);
+                EXECUTE format('CREATE TYPE "{type_name}" AS ENUM (%s)', vals);
 
                 -- Switch over affected columns to the new type
                 {column_modifications}
 
                 -- Drop the old type
-                EXECUTE 'DROP TYPE {type_name}_old';
+                EXECUTE 'DROP TYPE "{type_name}_old"';
             END $$;
             """,
         )
@@ -577,7 +577,7 @@ class DatabaseActions:
             self.drop_type,
             dict(type_name=type_name),
             f"""
-            DROP TYPE {type_name}
+            DROP TYPE "{type_name}"
             """,
         )
 

--- a/mountaineer/migrations/db_memory_serializer.py
+++ b/mountaineer/migrations/db_memory_serializer.py
@@ -125,16 +125,16 @@ class DatabaseMemorySerializer:
             if isinstance(db_object, DBObjectPointer):
                 continue
 
-            # If the object is already in the dictionary, make sure the values
-            # are equal. Otherwise this indicates that there is a conflicting
+            # If the object is already in the dictionary, try to merge the two
+            # different values. Otherwise this indicates that there is a conflicting
             # name with a different definition which we don't allow
             if db_object.representation() in db_objects_by_name:
-                ground_truth_obj = db_objects_by_name[db_object.representation()]
-                if ground_truth_obj != db_object:
-                    raise ValueError(
-                        f"Conflicting definitions for {db_object.representation()}\n{ground_truth_obj} != {db_object}"
-                    )
-            db_objects_by_name[db_object.representation()] = db_object
+                current_obj = db_objects_by_name[db_object.representation()]
+                db_objects_by_name[db_object.representation()] = current_obj.merge(
+                    db_object
+                )
+            else:
+                db_objects_by_name[db_object.representation()] = db_object
 
         # Make sure all the pointers can be resolved by full objects
         # Otherwise we want a verbose error that gives more context

--- a/mountaineer/migrations/db_stubs.py
+++ b/mountaineer/migrations/db_stubs.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel, Field, model_validator
 
 from mountaineer.compat import Self
 from mountaineer.migrations.actions import (
+    CheckConstraint,
     ColumnType,
     ConstraintType,
     DatabaseActions,
@@ -175,6 +176,7 @@ class DBConstraint(DBObject):
     constraint_type: ConstraintType
 
     foreign_key_constraint: ForeignKeyConstraint | None = None
+    check_constraint: CheckConstraint | None = None
 
     @model_validator(mode="after")
     def validate_constraint_type(self):
@@ -228,6 +230,15 @@ class DBConstraint(DBObject):
                 constraint=self.constraint_type,
                 constraint_name=self.constraint_name,
                 constraint_args=self.foreign_key_constraint,
+                columns=list(self.columns),
+            )
+        elif self.constraint_type == ConstraintType.CHECK:
+            assert self.check_constraint is not None
+            await actor.add_constraint(
+                self.table_name,
+                constraint=self.constraint_type,
+                constraint_name=self.constraint_name,
+                constraint_args=self.check_constraint,
                 columns=list(self.columns),
             )
         else:

--- a/mountaineer/migrations/dependency/__init__.py
+++ b/mountaineer/migrations/dependency/__init__.py
@@ -1,1 +1,3 @@
-import mountaineer.migrations.dependency.core as MigrationDependencies  # noqa: F401
+from mountaineer.migrations.dependency import (
+    core as MigrationDependencies,  # noqa: F401
+)

--- a/mountaineer/migrations/generator.py
+++ b/mountaineer/migrations/generator.py
@@ -166,6 +166,8 @@ class MigrationGenerator:
             self.track_import(value.__class__)
             class_name = value.__class__.__name__
             return f"{class_name}.{value.name}"
+        elif isinstance(value, bool):
+            return "True" if value else "False"
         elif isinstance(value, (str, int, float)):
             # JSON dumps is used here for proper string escaping
             return json_dumps(value)

--- a/mountaineer/migrations/handlers.py
+++ b/mountaineer/migrations/handlers.py
@@ -606,6 +606,9 @@ class EnumHandler(HandlerBase[ALL_ENUM_TYPES]):
                 custom_type=DBType(
                     name=next.__name__.lower(),
                     values=frozenset([value.name for value in next]),
+                    reference_columns=frozenset(
+                        {(context.current_table, context.current_column)}
+                    ),
                 ),
                 is_list=False,
             ),

--- a/mountaineer/migrations/migration.py
+++ b/mountaineer/migrations/migration.py
@@ -1,22 +1,7 @@
 from abc import abstractmethod
 
-from sqlalchemy.ext.asyncio import AsyncSession
-
 from mountaineer.dependencies import get_function_dependencies
 from mountaineer.migrations.migrator import Migrator
-
-
-class MigrationAsyncSession(AsyncSession):
-    """
-    Internal Mountaineer session to disallow clients from using
-    the commit() method.
-
-    """
-
-    async def commit(self):
-        raise NotImplementedError(
-            "Commit isn't supported during migrations, since we need to wrap the whole transaction chain in a single transaction."
-        )
 
 
 class MigrationRevisionBase:
@@ -32,6 +17,9 @@ class MigrationRevisionBase:
     down_revision: str | None
 
     async def handle_up(self):
+        """
+        Internal method to handle the up migration.
+        """
         async with get_function_dependencies(
             callable=self.up,
         ) as values:
@@ -46,6 +34,9 @@ class MigrationRevisionBase:
             await migrator.set_active_revision(self.up_revision)
 
     async def handle_down(self):
+        """
+        Internal method to handle the down migration.
+        """
         async with get_function_dependencies(
             callable=self.down,
         ) as values:
@@ -61,8 +52,18 @@ class MigrationRevisionBase:
 
     @abstractmethod
     async def up(self, migrator: Migrator):
+        """
+        Perform the migration "up" action. Clients should place their
+        migration logic here.
+
+        """
         pass
 
     @abstractmethod
     async def down(self, migrator: Migrator):
+        """
+        Perform the migration "down" action. Clients should place their
+        migration logic here.
+
+        """
         pass


### PR DESCRIPTION
This PR mainly addresses edge cases with our experimental data migration plugin.

- Add additional unit tests to check expected transformation when executed against Postgres. This validates the accuracy (and syntax) of our templated SQL queries.
- Workaround for dropping enums from existing table columns. Enums in Postgres can't be modified in-place, so the best workaround is to recreate them and then drop the old values. We now keep track of where enum values are referenced so we can migrate these to a new enum object that will replace the old one.
- Add support for "check" constraints.
- Modify a group of enum values at the same time (ie. pass all different enums) to avoid verbose migration files and repeated SQL commands to create/drop old enum types.
- Allow reserved table names within identifier strings (like a "user" table separate from the postgres "USER" command).

We also add some initial docs on getting started with the migration pipeline.