### PR TITLE
Expand support for migration edge cases

### DIFF
--- a/docs_website/docs/database_migrations.md
+++ b/docs_website/docs/database_migrations.md
@@ -9,7 +9,8 @@
 Once your application is in production, you'll need some method of updating your database schema as you update your application's functionality. You _could_ write raw SQL to accomplish these migrations, or manually modify database table definitions. But the former is inconvenient and the second is risky. Mountaineer ships with a migration tool that can automatically generate migration files for you and apply them to your database. Its features:
 
 - Fast with no external dependencies outside of Mountaineer core.
-- Programmatic with zero config required, but options that can be specified in code.
+- Zero config required, optional programmatic customization.
+- Unit-testable migration paths that work with normal `pytest` harnesses.
 - Baked-in support for common Postgres types that overlap with Python, most specifically Enums and datetimes.
 - File-based groundtruth of migration logic, so it can be audited in source control and customized by you.
 - Simple API surface, with atomic Python functions that perform the most common migration operations. Direct database queries (or integration with ORM objects in limited cases) can be used for more complex migration logic.

--- a/mountaineer/__tests__/migrations/test_db_serializer.py
+++ b/mountaineer/__tests__/migrations/test_db_serializer.py
@@ -22,6 +22,7 @@ from mountaineer.migrations.db_stubs import (
     DBObjectPointer,
     DBTable,
     DBType,
+    DBTypePointer,
 )
 
 
@@ -78,12 +79,8 @@ def compare_db_objects(
                     DBColumn(
                         table_name="exampledbmodel",
                         column_name="standard_enum",
-                        column_type=DBType(
+                        column_type=DBTypePointer(
                             name="valueenumstandard",
-                            values=frozenset({"A"}),
-                            reference_columns=frozenset(
-                                {("exampledbmodel", "standard_enum")}
-                            ),
                         ),
                         column_is_list=False,
                         nullable=False,
@@ -120,12 +117,8 @@ def compare_db_objects(
                     DBColumn(
                         table_name="exampledbmodel",
                         column_name="str_enum",
-                        column_type=DBType(
+                        column_type=DBTypePointer(
                             name="valueenumstr",
-                            values=frozenset({"A"}),
-                            reference_columns=frozenset(
-                                {("exampledbmodel", "str_enum")}
-                            ),
                         ),
                         column_is_list=False,
                         nullable=False,
@@ -162,12 +155,8 @@ def compare_db_objects(
                     DBColumn(
                         table_name="exampledbmodel",
                         column_name="int_enum",
-                        column_type=DBType(
+                        column_type=DBTypePointer(
                             name="valueenumint",
-                            values=frozenset({"A"}),
-                            reference_columns=frozenset(
-                                {("exampledbmodel", "int_enum")}
-                            ),
                         ),
                         column_is_list=False,
                         nullable=False,

--- a/mountaineer/__tests__/migrations/test_db_stubs.py
+++ b/mountaineer/__tests__/migrations/test_db_stubs.py
@@ -2,6 +2,11 @@ from mountaineer.migrations.db_stubs import DBType
 
 
 def test_merge_type_columns():
+    """
+    Allow separately yielded type definitions to collect their reference columns. If an
+    enum is referenced in one place, this should build up to the full definition.
+
+    """
     type_a = DBType(
         name="type_a",
         values=frozenset({"A"}),

--- a/mountaineer/__tests__/migrations/test_generator.py
+++ b/mountaineer/__tests__/migrations/test_generator.py
@@ -71,6 +71,18 @@ def test_actions_to_code():
     ]
 
 
+def test_actions_to_code_pass():
+    """
+    We support generating migrations where there are no schema-level changes, so users can
+    write their own data migration logic. In these cases we should pass the code-block
+    so the resulting file is still legitimate.
+
+    """
+    migration_generator = MigrationGenerator()
+    code = migration_generator.actions_to_code([])
+    assert code == ["pass"]
+
+
 class ExampleEnum(Enum):
     A = "a"
     B = "b"

--- a/mountaineer/__tests__/migrations/test_generator.py
+++ b/mountaineer/__tests__/migrations/test_generator.py
@@ -106,6 +106,10 @@ class ExampleDataclass:
         (ExampleDataclass(value="test"), 'ExampleDataclass(value="test")'),
         (True, "True"),
         (False, "False"),
+        (frozenset({"A", "B"}), 'frozenset({"A", "B"})'),
+        ({"A", "B"}, '{"A", "B"}'),
+        (("A",), '("A",)'),
+        (("A", "B"), '("A", "B")'),
     ],
 )
 def test_format_arg(value: Any, expected_value: str):

--- a/mountaineer/__tests__/test_io.py
+++ b/mountaineer/__tests__/test_io.py
@@ -1,0 +1,43 @@
+import pytest
+
+from mountaineer.io import lru_cache_async
+
+
+@pytest.mark.asyncio
+async def test_lru_cache_async_infinite_cache():
+    exec_counts = 0
+
+    @lru_cache_async(maxsize=None)
+    async def cache_values():
+        nonlocal exec_counts
+        exec_counts += 1
+        return exec_counts
+
+    assert await cache_values() == 1
+    assert await cache_values() == 1
+    assert await cache_values() == 1
+
+
+@pytest.mark.asyncio
+async def test_lru_cache_async_limited_cache():
+    exec_counts = 0
+
+    @lru_cache_async(maxsize=2)
+    async def cache_values(a: int):
+        nonlocal exec_counts
+        exec_counts += 1
+        return exec_counts
+
+    assert await cache_values(1) == 1
+    assert await cache_values(1) == 1
+    assert await cache_values(1) == 1
+
+    assert await cache_values(2) == 2
+
+    # At this point the cache is full with [1, 2]
+    # If the next value is out of scope, it will clear
+    # the oldest value (1)
+    assert await cache_values(3) == 3
+
+    # This new call will recompute the value for 1
+    assert await cache_values(1) == 4

--- a/mountaineer/client_builder/builder.py
+++ b/mountaineer/client_builder/builder.py
@@ -11,6 +11,7 @@ from typing import Any
 from click import secho
 from fastapi import APIRouter
 from inflection import camelize
+from pydantic_core import ValidationError
 
 from mountaineer.actions import get_function_metadata
 from mountaineer.actions.fields import FunctionActionType
@@ -125,7 +126,13 @@ class ClientBuilder:
             controller = controller_definition.controller
 
             action_spec_openapi = self.openapi_action_specs[controller]
-            action_base = OpenAPIDefinition(**action_spec_openapi)
+            try:
+                action_base = OpenAPIDefinition(**action_spec_openapi)
+            except ValidationError as e:
+                LOGGER.error(
+                    f"Error parsing {controller} action spec: {action_spec_openapi} {e}"
+                )
+                raise e
 
             render_spec_openapi = self.openapi_render_specs[controller]
             render_base = (

--- a/mountaineer/client_builder/openapi.py
+++ b/mountaineer/client_builder/openapi.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Optional, Union
+from typing import Any, Literal, Optional, Union
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
@@ -75,7 +75,9 @@ class OpenAPIProperty(BaseModel):
     title: str | None = None
     description: str | None = None
     properties: dict[str, Union["OpenAPIProperty", EmptyAPIProperty]] = {}
-    additionalProperties: Union["OpenAPIProperty", EmptyAPIProperty, None] = None
+    additionalProperties: Union[
+        "OpenAPIProperty", EmptyAPIProperty, Literal[False], None
+    ] = None
     required: list[str] = []
 
     # Just specified on the leaf object

--- a/mountaineer/io.py
+++ b/mountaineer/io.py
@@ -1,6 +1,6 @@
 import asyncio
 import socket
-from functools import wraps
+from functools import lru_cache, wraps
 from typing import Any, Callable, Coroutine, TypeVar
 
 
@@ -46,3 +46,20 @@ def get_free_port() -> int:
         port = s.getsockname()[1]
         s.close()
     return int(port)
+
+
+def lru_cache_async(
+    maxsize: int | None = 100,
+):
+    def decorator(
+        async_function: Callable[..., Coroutine[Any, Any, T]],
+    ):
+        @lru_cache(maxsize=maxsize)
+        @wraps(async_function)
+        def internal(*args, **kwargs):
+            coroutine = async_function(*args, **kwargs)
+            return asyncio.ensure_future(coroutine)
+
+        return internal
+
+    return decorator

--- a/mountaineer/io.py
+++ b/mountaineer/io.py
@@ -58,6 +58,8 @@ def lru_cache_async(
         @wraps(async_function)
         def internal(*args, **kwargs):
             coroutine = async_function(*args, **kwargs)
+            # Unlike regular coroutine functions, futures can be awaited multiple times
+            # so our caller functions can await the same future on multiple cache hits
             return asyncio.ensure_future(coroutine)
 
         return internal

--- a/mountaineer/migrations/cli.py
+++ b/mountaineer/migrations/cli.py
@@ -61,6 +61,7 @@ async def handle_generate(message: str | None = None):
         # Get the current revision from the database, this should represent the "down" revision
         # for the new migration
         migrator = Migrator(db_session)
+        await migrator.init_db()
         current_revision = await migrator.get_active_revision()
 
         # Make sure there's not a duplicate revision that already have this down revision. If so that means
@@ -124,6 +125,7 @@ async def handle_apply():
 
         # Get the current revision from the database
         migrator = Migrator(db_session)
+        await migrator.init_db()
         current_revision = await migrator.get_active_revision()
 
         # Find the item in the sequence that has down_revision equal to the current_revision
@@ -172,6 +174,7 @@ async def handle_rollback():
 
         # Get the current revision from the database
         migrator = Migrator(db_session)
+        await migrator.init_db()
         current_revision = await migrator.get_active_revision()
 
         # Find the item in the sequence that has down_revision equal to the current_revision

--- a/mountaineer/migrations/db_memory_serializer.py
+++ b/mountaineer/migrations/db_memory_serializer.py
@@ -175,11 +175,10 @@ class DatabaseMemorySerializer:
             obj.representation(): order for obj, order in previous_ordering.items()
         }
         next_ordering_by_name = {
-            obj.representation(): order
-            for obj, order in next_ordering.items()
-            for obj, order in next_ordering.items()
+            obj.representation(): order for obj, order in next_ordering.items()
         }
 
+        # Verification that the ordering dictionaries align with the objects
         for ordering, objects in [
             (previous_ordering_by_name, previous_by_name),
             (next_ordering_by_name, next_by_name),

--- a/mountaineer/migrations/db_serializer.py
+++ b/mountaineer/migrations/db_serializer.py
@@ -1,9 +1,9 @@
-from functools import lru_cache
 
 from sqlalchemy import text
 from sqlalchemy.engine.result import Result
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from mountaineer.io import lru_cache_async
 from mountaineer.migrations.actions import (
     CheckConstraint,
     ColumnType,
@@ -216,7 +216,7 @@ class DatabaseSerializer:
 
     # Enum values are not expected to change within one session, cache the same
     # type if we see it within the same session
-    @lru_cache(maxsize=None)
+    @lru_cache_async(maxsize=None)
     async def fetch_custom_type(self, session: AsyncSession, type_name: str):
         # Get the values in this enum
         values_query = text(

--- a/mountaineer/migrations/db_serializer.py
+++ b/mountaineer/migrations/db_serializer.py
@@ -1,4 +1,3 @@
-
 from sqlalchemy import text
 from sqlalchemy.engine.result import Result
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -17,6 +16,7 @@ from mountaineer.migrations.db_stubs import (
     DBObject,
     DBTable,
     DBType,
+    DBTypePointer,
 )
 
 
@@ -109,7 +109,11 @@ class DatabaseSerializer:
                 DBColumn(
                     table_name=table_name,
                     column_name=row.column_name,
-                    column_type=column_type,
+                    column_type=(
+                        DBTypePointer(name=column_type.name)
+                        if isinstance(column_type, DBType)
+                        else column_type
+                    ),
                     column_is_list=column_is_list,
                     nullable=(row.is_nullable == "YES"),
                 ),

--- a/mountaineer/migrations/db_stubs.py
+++ b/mountaineer/migrations/db_stubs.py
@@ -64,6 +64,7 @@ class DBObject(BaseModel):
             )
         return self
 
+
 class DBObjectPointer(BaseModel):
     """
     A pointer to an object that was already created elsewhere. Used only for DAG comparisons. Make sure
@@ -285,6 +286,7 @@ class DBConstraint(DBObject):
             await self.destroy(actor)
             await self.create(actor)
 
+
 class DBTypeBase(BaseModel):
     name: str
 
@@ -292,8 +294,10 @@ class DBTypeBase(BaseModel):
         # Type definitions are global by nature
         return self.name
 
+
 class DBTypePointer(DBTypeBase, DBObjectPointer):
     pass
+
 
 class DBType(DBTypeBase, DBObject):
     values: frozenset[str]
@@ -335,7 +339,9 @@ class DBType(DBTypeBase, DBObject):
         # but might have different reference columns since they might be produced by
         # different parts of the pipeline.
         if self.name != other.name or self.values != other.values:
-            raise ValueError("Cannot merge types with different core values: {self.name}({self.values}) != {other.name}({other.values})")
+            raise ValueError(
+                "Cannot merge types with different core values: {self.name}({self.values}) != {other.name}({other.values})"
+            )
 
         return DBType(
             name=self.name,

--- a/mountaineer/migrations/db_stubs.py
+++ b/mountaineer/migrations/db_stubs.py
@@ -71,6 +71,12 @@ class DBObjectPointer(BaseModel):
     the representation mirrors the root object string - otherwise comparison
     won't work properly.
 
+    We typically use pointers in cases where we want to reference an object that should
+    already be created, and the change in the child value shouldn't auto-update the parent.
+    Since by default we use direct model-equality to determine whether we create a migration
+    stage, nesting a full DBObject within a parent object would otherwise cause the parent
+    to update.
+
     """
 
     model_config = {

--- a/mountaineer/migrations/generator.py
+++ b/mountaineer/migrations/generator.py
@@ -177,12 +177,17 @@ class MigrationGenerator:
         elif isinstance(value, list):
             return f"[{', '.join([self.format_arg(v) for v in value])}]"
         elif isinstance(value, frozenset):
-            return f"frozenset({{{', '.join([self.format_arg(v) for v in value])}}})"
+            # Sorting values isn't necessary for client code, but useful for test stability over time
+            return f"frozenset({{{', '.join([self.format_arg(v) for v in sorted(value)])}}})"
         elif isinstance(value, set):
-            return f"{{{', '.join([self.format_arg(v) for v in value])}}}"
+            return f"{{{', '.join([self.format_arg(v) for v in sorted(value)])}}}"
         elif isinstance(value, tuple):
-            # Trailing comma is necessary for single element tuples
-            return f"({', '.join([self.format_arg(v) for v in value])},)"
+            tuple_values = f"{', '.join([self.format_arg(v) for v in value])}"
+            if len(value) == 1:
+                # Trailing comma is necessary for single element tuples
+                return f"({tuple_values},)"
+            else:
+                return f"({tuple_values})"
         elif isinstance(value, dict):
             return (
                 "{"

--- a/mountaineer/migrations/generator.py
+++ b/mountaineer/migrations/generator.py
@@ -173,6 +173,13 @@ class MigrationGenerator:
             return json_dumps(value)
         elif isinstance(value, list):
             return f"[{', '.join([self.format_arg(v) for v in value])}]"
+        elif isinstance(value, frozenset):
+            return f"frozenset({{{', '.join([self.format_arg(v) for v in value])}}})"
+        elif isinstance(value, set):
+            return f"{{{', '.join([self.format_arg(v) for v in value])}}}"
+        elif isinstance(value, tuple):
+            # Trailing comma is necessary for single element tuples
+            return f"({', '.join([self.format_arg(v) for v in value])},)"
         elif isinstance(value, dict):
             return (
                 "{"
@@ -204,7 +211,7 @@ class MigrationGenerator:
         elif value is None:
             return "None"
         else:
-            raise ValueError(f"Unknown argument type: {value}")
+            raise ValueError(f"Unknown argument type: {value} ({type(value)})")
 
     def track_import(
         self,

--- a/mountaineer/migrations/generator.py
+++ b/mountaineer/migrations/generator.py
@@ -154,6 +154,9 @@ class MigrationGenerator:
             else:
                 raise ValueError(f"Unknown action type: {action}")
 
+        if not code_lines:
+            code_lines.append("pass")
+
         return code_lines
 
     def format_arg(self, value: Any) -> str:

--- a/mountaineer/migrations/handlers.py
+++ b/mountaineer/migrations/handlers.py
@@ -30,6 +30,7 @@ from mountaineer.migrations.db_stubs import (
     DBObjectPointer,
     DBTable,
     DBType,
+    DBTypePointer,
 )
 from mountaineer.migrations.generics import (
     remove_null_type,
@@ -254,7 +255,11 @@ class ColumnHandler(HandlerBase[PydanticFieldInfo]):
         if type_payload.custom_type:
             yield type_payload.custom_type, type_dependencies
 
-        column_type = type_payload.custom_type or type_payload.primitive_type
+        column_type = (
+            DBTypePointer(name=type_payload.custom_type.name)
+            if type_payload.custom_type
+            else type_payload.primitive_type
+        )
         if not column_type:
             raise ValueError(
                 f"No column type found for column {context.current_column} in table {context.current_table}"

--- a/mountaineer/migrations/handlers.py
+++ b/mountaineer/migrations/handlers.py
@@ -69,6 +69,15 @@ class HandlerBaseMeta(type):
 
 
 class HandlerBase(Generic[N], metaclass=HandlerBaseMeta):
+    """
+    Unlike table schema definitions that are defined in Postgres, in-memory representations
+    of a data model are more ambiguous / varied. SQLModels for instance can support
+    their own native types/attributes, SQLAlchemy columns, or SQLAlchemy types. We therefore
+    consolidate the parsing logic into DBObjects into multiple refactored classes
+    that own a particular family of types with the same parsing strategy.
+
+    """
+
     def __init__(self, migrator: "DatabaseMemorySerializer"):
         self.serializer = migrator
 

--- a/mountaineer/migrations/migrator.py
+++ b/mountaineer/migrations/migrator.py
@@ -68,7 +68,7 @@ class Migrator:
         within the attached postgres database. This will be a no-op if the table
         already exists.
 
-        Client callers should call this method before running any migrations.
+        Client callers should call this method once before running any migrations.
 
         """
         # Create the table if it doesn't exist
@@ -95,7 +95,7 @@ class Migrator:
             await self.db_session.flush()
 
         # Assume client callers are calling before the transaction block
-        # run client code
+        # runs client code
         await self.db_session.commit()
 
     async def set_active_revision(self, value: str | None):

--- a/mountaineer/migrations/migrator.py
+++ b/mountaineer/migrations/migrator.py
@@ -40,8 +40,6 @@ class Migrator:
         self.actor = DatabaseActions(dry_run=False, db_session=db_session)
         self.db_session = db_session
 
-        self._management_table_initialized = False
-
     @classmethod
     @asynccontextmanager
     async def new_migrator(
@@ -100,12 +98,7 @@ class Migrator:
         # run client code
         await self.db_session.commit()
 
-        self._management_table_initialized = True
-
     async def set_active_revision(self, value: str | None):
-        if not self._management_table_initialized:
-            raise RuntimeError("Migrator table not initialized")
-
         LOGGER.info(f"Setting active revision to {value}")
 
         query = text(
@@ -120,9 +113,6 @@ class Migrator:
         LOGGER.info("Active revision set")
 
     async def get_active_revision(self) -> str | None:
-        if not self._management_table_initialized:
-            raise RuntimeError("Migrator table not initialized")
-
         query = text(
             """
             SELECT active_revision FROM migration_info


### PR DESCRIPTION
- Support custom SQLAlchemy column constraint names, if users specify a `Field(sa_column)` attribute.
- Expand code generation support to set/frozenset/tuple types that are used in some cases.
- Fix potential freeze on database writes when running multiple migrations in a row; refactor out migration table creation to the top level CLI modules.
- Switch to DBTypePointer references in columns, instead of the fully serialized type object. While the previous method still yielded correct migrations, it might create redundant migration steps if attributes internal to the type object change but the rest of the column stays the same. We already take care of performing column-level migrations from within our type value migration action, so we instead should only migrate column types if the _representation_ changes.