### PR TITLE
Pass query parameters to sideeffect re-renders

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ test-scripts:
 
 define test-common
 	echo "Running tests for $(2)..."
-	@(cd $(1) && poetry run pytest -W error $(test-args) $(2))
+	@(cd $(1) && poetry run pytest -vvv -W error $(test-args) $(2))
 endef
 
 define test-rust-common

--- a/mountaineer/__tests__/conftest.py
+++ b/mountaineer/__tests__/conftest.py
@@ -13,5 +13,12 @@ def ignore_httpx_deprecation_warnings():
 
 
 @pytest.fixture(autouse=True)
+def ignore_memory_object_resource_warnings():
+    # @pierce - Fix a warning exposed in test_build_exception_on_get
+    # from one of our underlying libraries
+    filterwarnings("ignore", category=ResourceWarning, module="anyio.*")
+
+
+@pytest.fixture(autouse=True)
 def clear_config_cache():
     unregister_config()


### PR DESCRIPTION
Add unit tests and fix an edge case where query parameters weren't passed to the sideeffect re-rendering functions.