### PR TITLE
Align with sqlmodel's uuid refactor

### DIFF
--- a/mountaineer/annotation_helpers.py
+++ b/mountaineer/annotation_helpers.py
@@ -39,7 +39,7 @@ def get_value_by_alias(model: BaseModel | dict[str, Any], alias: str):
 
 
 def resolve_forwardrefs(
-    current_type: type,
+    current_type: type | str,
     *,
     _globals: dict[str, Any] | None = None,
     _locals: dict[str, Any] | None = None,
@@ -88,7 +88,7 @@ def yield_all_subtypes(
     # Track the models we've already validated to avoid circular dependencies
     already_validated: set[Type[BaseModel]] = set()
 
-    def resolve_types(current_type: type):
+    def resolve_types(current_type: type | str):
         nonlocal already_validated
 
         # Always echo back the current type to make sure that everything that we've processed

--- a/mountaineer/database/sqlmodel.py
+++ b/mountaineer/database/sqlmodel.py
@@ -230,6 +230,6 @@ class GenericSQLModelMetaclass(SQLModelMetaclassBase):
 class SQLModel(SQLModelBase, metaclass=GenericSQLModelMetaclass):
     def __init__(self, **data: Any):
         if hasattr(self, "_original_model"):
-            self._original_model(**data)
+            self._original_model(**data)  # type: ignore
         if finish_init.get():
             sqlmodel_init(self=self, data=data)

--- a/mountaineer/migrations/handlers.py
+++ b/mountaineer/migrations/handlers.py
@@ -9,10 +9,10 @@ import sqlalchemy as sa
 from pydantic import BaseModel
 from pydantic.fields import FieldInfo as PydanticFieldInfo
 from pydantic_core import PydanticUndefinedType
+from sqlalchemy.sql import sqltypes
 from sqlmodel import SQLModel
 from sqlmodel._compat import is_field_noneable
 from sqlmodel.main import FieldInfo as SQLModelFieldInfo
-from sqlmodel.sql import sqltypes
 
 from mountaineer.compat import StrEnum
 from mountaineer.migrations.actions import (
@@ -165,7 +165,7 @@ class TableHandler(HandlerBase[SQLModel]):
         # We need to wrap in a custom class to indicate to the proper handler that it
         # needs to pick up this normal dictionary
         if hasattr(next, "__table_args__"):
-            for constraint in next.__table_args__:
+            for constraint in next.__table_args__:  # type: ignore
                 yield from self.serializer.delegate(
                     constraint,
                     context=context,
@@ -586,7 +586,7 @@ class PrimitiveHandler(HandlerBase[PRIMITIVE_WRAPPER_TYPES]):
 
 
 SQLALCHEMY_PRIMITIVE_TYPES = (
-    sa.UUID | sqltypes.GUID | sa.Float | sa.String | sa.Boolean | sa.Integer | sa.JSON
+    sa.UUID | sqltypes.Uuid | sa.Float | sa.String | sa.Boolean | sa.Integer | sa.JSON
 )
 
 
@@ -600,7 +600,7 @@ class SQLAlchemyPrimitiveHandler(HandlerBase[SQLALCHEMY_PRIMITIVE_TYPES]):
             sa.String: ColumnType.VARCHAR,
             sa.Boolean: ColumnType.BOOLEAN,
             sa.UUID: ColumnType.UUID,
-            sqltypes.GUID: ColumnType.UUID,
+            sqltypes.Uuid: ColumnType.UUID,
             sa.JSON: ColumnType.JSON,
         }
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1052,18 +1052,18 @@ sqlcipher = ["sqlcipher3_binary"]
 
 [[package]]
 name = "sqlmodel"
-version = "0.0.14"
+version = "0.0.20"
 description = "SQLModel, SQL databases in Python, designed for simplicity, compatibility, and robustness."
 optional = false
-python-versions = ">=3.7,<4.0"
+python-versions = ">=3.7"
 files = [
-    {file = "sqlmodel-0.0.14-py3-none-any.whl", hash = "sha256:accea3ff5d878e41ac439b11e78613ed61ce300cfcb860e87a2d73d4884cbee4"},
-    {file = "sqlmodel-0.0.14.tar.gz", hash = "sha256:0bff8fc94af86b44925aa813f56cf6aabdd7f156b73259f2f60692c6a64ac90e"},
+    {file = "sqlmodel-0.0.20-py3-none-any.whl", hash = "sha256:744756c49e24095808984754cc4d3a32c2d8361fef803c4914fadcb912239bc9"},
+    {file = "sqlmodel-0.0.20.tar.gz", hash = "sha256:94dd1f63e4ceb0ab405e304e1ad3e8b8c8800b47c3ca5f68736807be8e5b9314"},
 ]
 
 [package.dependencies]
 pydantic = ">=1.10.13,<3.0.0"
-SQLAlchemy = ">=2.0.0,<2.1.0"
+SQLAlchemy = ">=2.0.14,<2.1.0"
 
 [[package]]
 name = "starlette"
@@ -1459,4 +1459,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "5b801f1347a7b955d82ad06ff31653c4821e115c083b58eb92b1186b97531138"
+content-hash = "22bb45017dff2659a8ce3760f5b5b36be83bc4b7ef08bc43025a70d6379ba4cd"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ click = "^8.1.7"
 uvicorn = { extras = ["standard"], version = "^0.27.0.post1" }
 packaging = "^23.2"
 pydantic-settings = "^2.1.0"
-sqlmodel = "^0.0.14"
+sqlmodel = "^0.0.20"
 asyncpg = "^0.29.0"
 sqlalchemy = { extras = ["asyncio"], version = "^2.0.26" }
 


### PR DESCRIPTION
With the [release](https://github.com/tiangolo/sqlmodel/commit/95936bb5085b6ee467c4cd9051c7bfc8395c9b13) of sqlmodel's 0.0.20 release, they introduce full compatibility with SQLAlchemy's UUID class. We can therefore remove our class based workaround which causes a crash on lower sqlmodel versions.

We also add a new visual progress bar to our migration CLI for more obvious feedback about the completed migrations.