### PR TITLE
Add --host argument to runserver cli

### DIFF
--- a/create_mountaineer_app/create_mountaineer_app/templates/project/[project_name]/cli.py
+++ b/create_mountaineer_app/create_mountaineer_app/templates/project/[project_name]/cli.py
@@ -10,12 +10,14 @@ from {{project_name}}.config import AppConfig
 
 @command()
 @option("--port", default=5006, help="Port to run the server on")
-def runserver(port: int):
+@option("--host", default="127.0.0.1", help="Host to run the server on")
+def runserver(port: int, host: str):
     handle_runserver(
         package="{{project_name}}",
         webservice="{{project_name}}.main:app",
         webcontroller="{{project_name}}.app:controller",
         port=port,
+        host=host,
     )
 
 

--- a/mountaineer/__tests__/fixtures/ci_webapp/ci_webapp/cli.py
+++ b/mountaineer/__tests__/fixtures/ci_webapp/ci_webapp/cli.py
@@ -4,12 +4,14 @@ from mountaineer.cli import handle_build, handle_runserver, handle_watch
 
 @command()
 @option("--port", default=5006)
-def runserver(port):
+@option("--host", default="127.0.0.1", help="Host to run the server on")
+def runserver(port, host):
     handle_runserver(
         package="ci_webapp",
         webservice="ci_webapp.main:app",
         webcontroller="ci_webapp.app:controller",
         port=port,
+        host=host,
         subscribe_to_mountaineer=True,
     )
 

--- a/mountaineer/cli.py
+++ b/mountaineer/cli.py
@@ -53,6 +53,7 @@ class IsolatedBuildConfig:
 class IsolatedRunserverConfig:
     entrypoint: str
     port: int
+    host: str
     live_reload_port: int
 
 
@@ -131,6 +132,7 @@ class IsolatedEnvProcess(Process):
             thread = UvicornThread(
                 app=app_controller.app,
                 port=self.runserver_config.port,
+                host=self.runserver_config.host,
             )
             thread.start()
             try:
@@ -342,6 +344,7 @@ def handle_runserver(
     webservice: str,
     webcontroller: str,
     port: int,
+    host: str = "127.0.0.1",
     subscribe_to_mountaineer: bool = False,
 ):
     """
@@ -349,6 +352,7 @@ def handle_runserver(
     :param webservice: Ex. "ci_webapp.app:app"
     :param webcontroller: Ex. "ci_webapp.app:controller"
     :param port: Desired port for the webapp while running locally
+    :param host: Desired host for the webapp while running locally
     :param subscribe_to_mountaineer: See `handle_watch` for more details.
 
     """
@@ -365,7 +369,7 @@ def handle_runserver(
     # Start the webservice - it should persist for the lifetime of the
     # runserver, so a single websocket frontend can be notified across
     # multiple builds
-    watcher_webservice = WatcherWebservice()
+    watcher_webservice = WatcherWebservice(webservice_host=host)
     watcher_webservice.start()
 
     def update_build(metadata: CallbackMetadata):
@@ -385,6 +389,7 @@ def handle_runserver(
             runserver_config=IsolatedRunserverConfig(
                 entrypoint=webservice,
                 port=port,
+                host=host,
                 live_reload_port=watcher_webservice.port,
             ),
             build_config=IsolatedBuildConfig(

--- a/mountaineer/watch_server.py
+++ b/mountaineer/watch_server.py
@@ -20,10 +20,11 @@ class WatcherWebservice:
 
     """
 
-    def __init__(self, webservice_port: int | None = None):
+    def __init__(self, webservice_port: int | None = None, webservice_host: str = "127.0.0.1"):
         self.app = self.build_app()
         self.websockets: list[WebSocket] = []
         self.port = webservice_port or get_free_port()
+        self.host = webservice_host
         self.notification_queue: Queue[bool | None] = Queue()
 
         self.webservice_thread: UvicornThread | None = None
@@ -75,6 +76,7 @@ class WatcherWebservice:
         self.webservice_thread = UvicornThread(
             app=self.app,
             port=self.port,
+            host=self.host,
             log_level="warning",
         )
 

--- a/mountaineer/webservice.py
+++ b/mountaineer/webservice.py
@@ -11,10 +11,11 @@ from mountaineer.console import CONSOLE
 
 
 class UvicornThread(Thread):
-    def __init__(self, *, app: FastAPI, port: int, log_level: str = "info"):
+    def __init__(self, *, app: FastAPI, port: int, host: str, log_level: str = "info"):
         super().__init__(daemon=True)
         self.app = app
         self.port = port
+        self.host = host
         self.log_level = log_level
         self.server: Server | None = None
 
@@ -22,6 +23,7 @@ class UvicornThread(Thread):
         loop = asyncio.new_event_loop()
         config = Config(
             app=self.app,
+            host=self.host,
             port=self.port,
             reload=False,
             access_log=False,


### PR DESCRIPTION
+ Currently the runserver cli always starts on 127.0.0.1, which is a sensible default for dev and generally a good security measure for developer environments
+ However several usecases (incl mobile debugging against runserver, or running mountaineer dev loop in a devcontainer like Github Codespaces) need to be able to access the uvicorn server from nonlocal devices
+ This PR adds a --host flag to the dev, which passes down to the Uvicorn thread handler, for binding to different host addresses (such as 0.0.0.0 or the host's IP)