### PR TITLE
Fix deprecated docker-compose command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,11 +83,11 @@ lint-validation-scripts:
 
 # Tests
 test-lib:
-	(cd $(LIB_DIR) && docker-compose -f docker-compose.test.yml up -d)
+	(cd $(LIB_DIR) && docker compose -f docker-compose.test.yml up -d)
 	@$(call wait-for-postgres,30,5438)
 	@set -e; \
 	$(call test-common,$(LIB_DIR),$(LIB_NAME))
-	(cd $(LIB_DIR) && docker-compose -f docker-compose.test.yml down)
+	(cd $(LIB_DIR) && docker compose -f docker-compose.test.yml down)
 	$(call test-rust-common,$(LIB_DIR),$(LIB_NAME))
 test-lib-integrations:
 	$(call test-common-integrations,$(LIB_DIR),$(LIB_NAME))

--- a/README.md
+++ b/README.md
@@ -62,10 +62,10 @@ Every service file is nested under the `my_webapp` root package. Views are defin
 
 ### Development
 
-If you're starting a new application from scratch, you'll typically want to create your new database tables. Make sure you have postgres running. We bundle a docker-compose file for convenience with `create-mountaineer-app`.
+If you're starting a new application from scratch, you'll typically want to create your new database tables. Make sure you have postgres running. We bundle a docker compose file for convenience with `create-mountaineer-app`.
 
 ```bash
-docker-compose up -d
+docker compose up -d
 poetry run createdb
 ```
 
@@ -123,10 +123,10 @@ Update the index file as well:
 from .todo import TodoItem # noqa: F401
 ```
 
-Make sure you have a Postgres database running. We bundle a docker-compose file for convenience with `create-mountaineer-app`. Launch it in the background and create the new database tables from these code definitions:
+Make sure you have a Postgres database running. We bundle a docker compose file for convenience with `create-mountaineer-app`. Launch it in the background and create the new database tables from these code definitions:
 
 ```bash
-docker-compose up -d
+docker compose up -d
 poetry run createdb
 poetry run runserver
 ```

--- a/create_mountaineer_app/create_mountaineer_app/__tests__/test_builder.py
+++ b/create_mountaineer_app/create_mountaineer_app/__tests__/test_builder.py
@@ -129,7 +129,7 @@ def test_valid_permutations(
         "COMPOSE_PROJECT_NAME": f"test_project-{uuid4()}",
     }
     subprocess.run(
-        ["docker-compose", "up", "-d"],
+        ["docker", "compose", "up", "-d"],
         cwd=metadata.project_path,
         check=True,
         env=docker_compose_env,
@@ -202,7 +202,7 @@ def test_valid_permutations(
 
         secho("Shutting down docker...")
         subprocess.run(
-            ["docker-compose", "down"],
+            ["docker", "compose", "down"],
             cwd=metadata.project_path,
             check=True,
             env=docker_compose_env,

--- a/docs_website/docs/quickstart.md
+++ b/docs_website/docs/quickstart.md
@@ -21,10 +21,10 @@ Mountaineer projects all follow a similar structure. For more on this, see our d
 
 ### Development
 
-If you're starting a new application from scratch, you'll typically want to create your new database tables. Make sure you have postgres running. We bundle a docker-compose file for convenience with `create-mountaineer-app`.
+If you're starting a new application from scratch, you'll typically want to create your new database tables. Make sure you have postgres running. We bundle a docker compose file for convenience with `create-mountaineer-app`.
 
 ```bash
-docker-compose up -d
+docker compose up -d
 poetry run createdb
 ```
 
@@ -78,10 +78,10 @@ Update the index file as well:
 from .todo import TodoItem # noqa: F401
 ```
 
-Make sure you have a Postgres database running. We bundle a docker-compose file for convenience with `create-mountaineer-app`. Launch it in the background and create the new database tables from these code definitions:
+Make sure you have a Postgres database running. We bundle a docker compose file for convenience with `create-mountaineer-app`. Launch it in the background and create the new database tables from these code definitions:
 
 ```bash
-docker-compose up -d
+docker compose up -d
 poetry run createdb
 poetry run runserver
 ```

--- a/docs_website/docs/structure.md
+++ b/docs_website/docs/structure.md
@@ -6,7 +6,7 @@ For a project called `my_webapp`, you should have something like the following:
 ```
 my_webapp/
 ├── README.md
-├── docker-compose.yml
+├── docker compose.yml
 ├── my_webapp
 │   ├── __init__.py
 │   ├── app.py


### PR DESCRIPTION
Github Actions have removed support for the `docker-compose` independent bin entrypoint. We switch to the modern `docker compose` so builds continue to succeed on CI.