### PR TITLE
Use SQLModel Session for better typehinting

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ class HomeController(ControllerBase):
         request: Request,
         session: AsyncSession = Depends(DatabaseDependencies.get_db_session)
     ) -> HomeRender:
-        todos = await session.execute(select(TodoItem))
+        todos = (await session.exec(select(TodoItem))).all()
 
         return HomeRender(
             client_ip=(
@@ -166,7 +166,7 @@ class HomeController(ControllerBase):
                 if request.client
                 else "unknown"
             ),
-            todos=todos.scalars().all()
+            todos=todos
         )
 ```
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ from mountaineer import sideeffect, ControllerBase, RenderBase
 from mountaineer.database import DatabaseDependencies
 
 from fastapi import Request, Depends
-from sqlmodel.ext.asyncio.session import AsyncSession
+from mountaineer.database.session import AsyncSession
 from sqlmodel import select
 
 from my_webapp.models.todo import TodoItem

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ from mountaineer import sideeffect, ControllerBase, RenderBase
 from mountaineer.database import DatabaseDependencies
 
 from fastapi import Request, Depends
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel.ext.asyncio.session import AsyncSession
 from sqlmodel import select
 
 from my_webapp.models.todo import TodoItem

--- a/create_mountaineer_app/create_mountaineer_app/templates/project/[project_name]/controllers/detail.py
+++ b/create_mountaineer_app/create_mountaineer_app/templates/project/[project_name]/controllers/detail.py
@@ -5,7 +5,7 @@ from mountaineer import Metadata, RenderBase, ControllerBase, APIException, side
 from mountaineer.database import DatabaseDependencies
 
 from fastapi import Request, Depends
-from sqlmodel.ext.asyncio.session import AsyncSession
+from mountaineer.database.session import AsyncSession
 from fastapi.exceptions import HTTPException
 from pydantic import BaseModel
 

--- a/create_mountaineer_app/create_mountaineer_app/templates/project/[project_name]/controllers/detail.py
+++ b/create_mountaineer_app/create_mountaineer_app/templates/project/[project_name]/controllers/detail.py
@@ -5,7 +5,7 @@ from mountaineer import Metadata, RenderBase, ControllerBase, APIException, side
 from mountaineer.database import DatabaseDependencies
 
 from fastapi import Request, Depends
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel.ext.asyncio.session import AsyncSession
 from fastapi.exceptions import HTTPException
 from pydantic import BaseModel
 

--- a/create_mountaineer_app/create_mountaineer_app/templates/project/[project_name]/controllers/home.py
+++ b/create_mountaineer_app/create_mountaineer_app/templates/project/[project_name]/controllers/home.py
@@ -7,7 +7,7 @@ from mountaineer.database import DatabaseDependencies
 from fastapi import Request, Depends
 from pydantic import BaseModel
 from sqlmodel import select
-from sqlmodel.ext.asyncio.session import AsyncSession
+from mountaineer.database.session import AsyncSession
 
 from {{project_name}} import models
 

--- a/create_mountaineer_app/create_mountaineer_app/templates/project/[project_name]/controllers/home.py
+++ b/create_mountaineer_app/create_mountaineer_app/templates/project/[project_name]/controllers/home.py
@@ -7,7 +7,7 @@ from mountaineer.database import DatabaseDependencies
 from fastapi import Request, Depends
 from pydantic import BaseModel
 from sqlmodel import select
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel.ext.asyncio.session import AsyncSession
 
 from {{project_name}} import models
 

--- a/create_mountaineer_app/create_mountaineer_app/templates/project/[project_name]/controllers/home.py
+++ b/create_mountaineer_app/create_mountaineer_app/templates/project/[project_name]/controllers/home.py
@@ -24,9 +24,9 @@ class HomeController(ControllerBase):
         self,
         session: AsyncSession = Depends(DatabaseDependencies.get_db_session)
     ) -> HomeRender:
-        items = await session.execute(select(models.DetailItem))
+        items = (await session.exec(select(models.DetailItem))).all()
         return HomeRender(
-            items=items.scalars().all(),
+            items=items,
             metadata=Metadata(title="Home"),
         )
 

--- a/docs_website/docs/database_migrations.md
+++ b/docs_website/docs/database_migrations.md
@@ -143,7 +143,7 @@ async def up(
     self,
     migrator: Migrator = Depends(MigrationDependencies.get_migrator),
 ):
-    result = await migrator.db_session.execute("SELECT * FROM article")
+    result = await migrator.db_session.exec("SELECT * FROM article")
 ```
 
 We recommend using the actor object whenever possible, as it provides a more consistent and safe way to run migrations. If you are using the raw database session object, be aware that we require migrations to be run in a single transaction. This ensures that if a migration fails, the database will be rolled back to its previous state. We therefore disable calling `db_session.commit()` explicitly from within user code.

--- a/docs_website/docs/quickstart.md
+++ b/docs_website/docs/quickstart.md
@@ -111,7 +111,7 @@ class HomeController(ControllerBase):
         request: Request,
         session: AsyncSession = Depends(DatabaseDependencies.get_db_session)
     ) -> HomeRender:
-        todos = await session.execute(select(TodoItem))
+        todos = (await session.exec(select(TodoItem))).all()
 
         return HomeRender(
             client_ip=(
@@ -119,7 +119,7 @@ class HomeController(ControllerBase):
                 if request.client
                 else "unknown"
             ),
-            todos=todos.scalars().all()
+            todos=todos
         )
 ```
 

--- a/docs_website/docs/views.md
+++ b/docs_website/docs/views.md
@@ -51,7 +51,7 @@ A controller backs a view in a 1:1 relationship. It provides the backend plumbin
 from mountaineer import sideeffect, ControllerBase, RenderBase
 from mountaineer.database import DatabaseDependencies
 
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel.ext.asyncio.session import AsyncSession
 from sqlmodel import select
 
 from myapp.models import TodoItem

--- a/docs_website/docs/views.md
+++ b/docs_website/docs/views.md
@@ -51,7 +51,7 @@ A controller backs a view in a 1:1 relationship. It provides the backend plumbin
 from mountaineer import sideeffect, ControllerBase, RenderBase
 from mountaineer.database import DatabaseDependencies
 
-from sqlmodel.ext.asyncio.session import AsyncSession
+from mountaineer.database.session import AsyncSession
 from sqlmodel import select
 
 from myapp.models import TodoItem

--- a/docs_website/docs/views.md
+++ b/docs_website/docs/views.md
@@ -67,10 +67,10 @@ class HomeController(ControllerBase):
         self,
         session: AsyncSession = Depends(DatabaseDependencies.get_db_session)
     ) -> HomeRender:
-        todos = await session.execute(select(TodoItem))
+        todos = (await session.execute(select(TodoItem))).all()
 
         return HomeRender(
-            todos=todos.scalars().all()
+            todos=todos
         )
 ```
 

--- a/mountaineer/__tests__/migrations/conftest.py
+++ b/mountaineer/__tests__/migrations/conftest.py
@@ -6,8 +6,9 @@ import pytest
 import pytest_asyncio
 from fastapi import Depends
 from sqlalchemy import exc as sa_exc
-from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
+from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker
 from sqlmodel import SQLModel, text
+from sqlmodel.ext.asyncio.session import AsyncSession
 
 from mountaineer.config import ConfigBase, unregister_config
 from mountaineer.database import DatabaseDependencies
@@ -130,6 +131,8 @@ async def db_engine(config: MigrationAppConfig):
 
 @pytest_asyncio.fixture
 async def db_session(db_engine: AsyncEngine):
-    session_maker = async_sessionmaker(db_engine, expire_on_commit=False)
+    session_maker = async_sessionmaker(
+        db_engine, class_=AsyncSession, expire_on_commit=False
+    )
     async with session_maker() as session:
         yield session

--- a/mountaineer/__tests__/migrations/conftest.py
+++ b/mountaineer/__tests__/migrations/conftest.py
@@ -8,11 +8,11 @@ from fastapi import Depends
 from sqlalchemy import exc as sa_exc
 from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker
 from sqlmodel import SQLModel, text
-from sqlmodel.ext.asyncio.session import AsyncSession
 
 from mountaineer.config import ConfigBase, unregister_config
 from mountaineer.database import DatabaseDependencies
 from mountaineer.database.config import DatabaseConfig
+from mountaineer.database.session import AsyncSession
 from mountaineer.dependencies.base import get_function_dependencies
 from mountaineer.test_utilities import bootstrap_database
 

--- a/mountaineer/__tests__/migrations/conftest.py
+++ b/mountaineer/__tests__/migrations/conftest.py
@@ -45,7 +45,7 @@ async def clear_all_database_objects(db_session: AsyncSession):
 
     """
     # Step 1: Drop all tables in the public schema
-    await db_session.execute(
+    await db_session.exec(
         text(
             """
         DO $$ DECLARE
@@ -60,7 +60,7 @@ async def clear_all_database_objects(db_session: AsyncSession):
     )
 
     # Step 2: Drop all custom types in the public schema
-    await db_session.execute(
+    await db_session.exec(
         text(
             """
         DO $$ DECLARE

--- a/mountaineer/__tests__/migrations/test_actions.py
+++ b/mountaineer/__tests__/migrations/test_actions.py
@@ -2,8 +2,8 @@ from unittest.mock import AsyncMock
 
 import pytest
 from sqlalchemy.exc import DBAPIError, IntegrityError, ProgrammingError
-from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import text
+from sqlmodel.ext.asyncio.session import AsyncSession
 
 from mountaineer.migrations.actions import (
     CheckConstraint,

--- a/mountaineer/__tests__/migrations/test_actions.py
+++ b/mountaineer/__tests__/migrations/test_actions.py
@@ -3,8 +3,8 @@ from unittest.mock import AsyncMock
 import pytest
 from sqlalchemy.exc import DBAPIError, IntegrityError, ProgrammingError
 from sqlmodel import text
-from sqlmodel.ext.asyncio.session import AsyncSession
 
+from mountaineer.database.session import AsyncSession
 from mountaineer.migrations.actions import (
     CheckConstraint,
     ColumnType,

--- a/mountaineer/__tests__/migrations/test_db_serializer.py
+++ b/mountaineer/__tests__/migrations/test_db_serializer.py
@@ -5,10 +5,10 @@ import sqlalchemy as sa
 from pydantic import create_model
 from sqlalchemy.ext.asyncio import AsyncEngine
 from sqlmodel import Field, SQLModel
-from sqlmodel.ext.asyncio.session import AsyncSession
 from sqlmodel.main import FieldInfo
 
 from mountaineer.compat import StrEnum
+from mountaineer.database.session import AsyncSession
 from mountaineer.migrations.actions import (
     ColumnType,
     ConstraintType,

--- a/mountaineer/__tests__/migrations/test_db_serializer.py
+++ b/mountaineer/__tests__/migrations/test_db_serializer.py
@@ -3,8 +3,9 @@ from enum import Enum, IntEnum
 import pytest
 import sqlalchemy as sa
 from pydantic import create_model
-from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
+from sqlalchemy.ext.asyncio import AsyncEngine
 from sqlmodel import Field, SQLModel
+from sqlmodel.ext.asyncio.session import AsyncSession
 from sqlmodel.main import FieldInfo
 
 from mountaineer.compat import StrEnum

--- a/mountaineer/database/cli.py
+++ b/mountaineer/database/cli.py
@@ -40,7 +40,7 @@ async def handle_createdb(*args, **kwargs):
             await connection.run_sync(SQLModel.metadata.create_all)
 
             # Log the tables that were created
-            result = await connection.exec(
+            result = await connection.execute(
                 text(
                     """
                 SELECT table_name

--- a/mountaineer/database/cli.py
+++ b/mountaineer/database/cli.py
@@ -40,7 +40,7 @@ async def handle_createdb(*args, **kwargs):
             await connection.run_sync(SQLModel.metadata.create_all)
 
             # Log the tables that were created
-            result = await connection.execute(
+            result = await connection.exec(
                 text(
                     """
                 SELECT table_name

--- a/mountaineer/database/dependencies/core.py
+++ b/mountaineer/database/dependencies/core.py
@@ -5,10 +5,10 @@ from sqlalchemy.ext.asyncio import (
     create_async_engine,
 )
 from sqlalchemy.pool import AsyncAdaptedQueuePool, NullPool
-from sqlmodel.ext.asyncio.session import AsyncSession
 
 from mountaineer.cache import AsyncLoopObjectCache
 from mountaineer.database.config import DatabaseConfig, PoolType
+from mountaineer.database.session import AsyncSession
 from mountaineer.dependencies import CoreDependencies
 from mountaineer.logging import LOGGER
 

--- a/mountaineer/database/dependencies/core.py
+++ b/mountaineer/database/dependencies/core.py
@@ -5,6 +5,7 @@ from sqlalchemy.ext.asyncio import (
     create_async_engine,
 )
 from sqlalchemy.pool import AsyncAdaptedQueuePool, NullPool
+from sqlmodel.ext.asyncio.session import AsyncSession
 
 from mountaineer.cache import AsyncLoopObjectCache
 from mountaineer.database.config import DatabaseConfig, PoolType
@@ -88,7 +89,9 @@ async def get_db_session(
     ```
 
     """
-    session_maker = async_sessionmaker(engine, expire_on_commit=False)
+    session_maker = async_sessionmaker(
+        engine, class_=AsyncSession, expire_on_commit=False
+    )
     async with session_maker() as session:
         try:
             yield session

--- a/mountaineer/database/session.py
+++ b/mountaineer/database/session.py
@@ -1,0 +1,87 @@
+from typing import (
+    Any,
+    Dict,
+    Mapping,
+    Optional,
+    Sequence,
+    Union,
+    overload,
+)
+
+from sqlalchemy import util
+from sqlalchemy.engine.result import ScalarResult, TupleResult
+from sqlalchemy.sql.elements import TextClause
+from sqlmodel.ext.asyncio.session import AsyncSession as AsyncSessionBase, _TSelectParam
+from sqlmodel.sql.base import Executable
+from sqlmodel.sql.expression import Select, SelectOfScalar
+
+
+class AsyncSession(AsyncSessionBase):
+    """
+    Provide additional support for common Mountaineer types.
+
+    """
+
+    @overload
+    async def exec(
+        self,
+        statement: Select[_TSelectParam],
+        *,
+        params: Optional[Union[Mapping[str, Any], Sequence[Mapping[str, Any]]]] = None,
+        execution_options: Mapping[str, Any] = util.EMPTY_DICT,
+        bind_arguments: Optional[Dict[str, Any]] = None,
+        _parent_execute_state: Optional[Any] = None,
+        _add_event: Optional[Any] = None,
+    ) -> TupleResult[_TSelectParam]:
+        ...
+
+    @overload
+    async def exec(
+        self,
+        statement: SelectOfScalar[_TSelectParam],
+        *,
+        params: Optional[Union[Mapping[str, Any], Sequence[Mapping[str, Any]]]] = None,
+        execution_options: Mapping[str, Any] = util.EMPTY_DICT,
+        bind_arguments: Optional[Dict[str, Any]] = None,
+        _parent_execute_state: Optional[Any] = None,
+        _add_event: Optional[Any] = None,
+    ) -> ScalarResult[_TSelectParam]:
+        ...
+
+    # @pierce - Relevant conversation https://github.com/fastapi/sqlmodel/issues/909
+    @overload
+    async def exec(
+        self,
+        statement: TextClause,
+        *,
+        params: Optional[Union[Mapping[str, Any], Sequence[Mapping[str, Any]]]] = None,
+        execution_options: Mapping[str, Any] = util.EMPTY_DICT,
+        bind_arguments: Optional[Dict[str, Any]] = None,
+        _parent_execute_state: Optional[Any] = None,
+        _add_event: Optional[Any] = None,
+    ) -> Any:
+        ...
+
+    async def exec(
+        self,
+        statement: Union[
+            Select[_TSelectParam],
+            SelectOfScalar[_TSelectParam],
+            Executable[_TSelectParam],
+            TextClause,
+        ],
+        *,
+        params: Optional[Union[Mapping[str, Any], Sequence[Mapping[str, Any]]]] = None,
+        execution_options: Mapping[str, Any] = util.EMPTY_DICT,
+        bind_arguments: Optional[Dict[str, Any]] = None,
+        _parent_execute_state: Optional[Any] = None,
+        _add_event: Optional[Any] = None,
+    ) -> Union[TupleResult[_TSelectParam], ScalarResult[_TSelectParam], Any]:
+        return await super().exec(  # type: ignore
+            statement=statement,  # type: ignore
+            params=params,
+            execution_options=execution_options,
+            bind_arguments=bind_arguments,
+            _parent_execute_state=_parent_execute_state,
+            _add_event=_add_event,
+        )

--- a/mountaineer/migrations/actions.py
+++ b/mountaineer/migrations/actions.py
@@ -5,9 +5,9 @@ from typing import Any, Callable, Literal, overload
 
 from pydantic import BaseModel
 from sqlmodel import text
-from sqlmodel.ext.asyncio.session import AsyncSession
 
 from mountaineer.compat import StrEnum
+from mountaineer.database.session import AsyncSession
 from mountaineer.logging import LOGGER
 
 

--- a/mountaineer/migrations/actions.py
+++ b/mountaineer/migrations/actions.py
@@ -643,7 +643,7 @@ class DatabaseActions:
             LOGGER.debug(f"Executing migration SQL: {sql}")
 
             self.prod_sqls.append(sql)
-            await self.db_session.execute(text(sql))
+            await self.db_session.exec(text(sql))
 
     def add_comment(self, text: str):
         if self.dry_run:

--- a/mountaineer/migrations/actions.py
+++ b/mountaineer/migrations/actions.py
@@ -4,8 +4,8 @@ from re import fullmatch as re_fullmatch
 from typing import Any, Callable, Literal, overload
 
 from pydantic import BaseModel
-from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import text
+from sqlmodel.ext.asyncio.session import AsyncSession
 
 from mountaineer.compat import StrEnum
 from mountaineer.logging import LOGGER

--- a/mountaineer/migrations/cli.py
+++ b/mountaineer/migrations/cli.py
@@ -4,13 +4,13 @@ from time import monotonic_ns
 from fastapi import Depends
 from sqlalchemy.orm import mapperlib
 from sqlmodel import SQLModel
-from sqlmodel.ext.asyncio.session import AsyncSession
 
 from mountaineer import CoreDependencies
 from mountaineer.config import ConfigBase
 from mountaineer.console import CONSOLE
 from mountaineer.database import DatabaseDependencies
 from mountaineer.database.config import DatabaseConfig
+from mountaineer.database.session import AsyncSession
 from mountaineer.dependencies import get_function_dependencies
 from mountaineer.migrations.client_io import fetch_migrations, sort_migrations
 from mountaineer.migrations.db_serializer import DatabaseSerializer

--- a/mountaineer/migrations/cli.py
+++ b/mountaineer/migrations/cli.py
@@ -2,9 +2,9 @@ from inspect import isclass
 from time import monotonic_ns
 
 from fastapi import Depends
-from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import mapperlib
 from sqlmodel import SQLModel
+from sqlmodel.ext.asyncio.session import AsyncSession
 
 from mountaineer import CoreDependencies
 from mountaineer.config import ConfigBase

--- a/mountaineer/migrations/db_serializer.py
+++ b/mountaineer/migrations/db_serializer.py
@@ -1,6 +1,6 @@
 from sqlalchemy import text
 from sqlalchemy.engine.result import Result
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel.ext.asyncio.session import AsyncSession
 
 from mountaineer.io import lru_cache_async
 from mountaineer.migrations.actions import (

--- a/mountaineer/migrations/db_serializer.py
+++ b/mountaineer/migrations/db_serializer.py
@@ -1,7 +1,7 @@
 from sqlalchemy import text
 from sqlalchemy.engine.result import Result
-from sqlmodel.ext.asyncio.session import AsyncSession
 
+from mountaineer.database.session import AsyncSession
 from mountaineer.io import lru_cache_async
 from mountaineer.migrations.actions import (
     CheckConstraint,

--- a/mountaineer/migrations/migrator.py
+++ b/mountaineer/migrations/migrator.py
@@ -73,7 +73,7 @@ class Migrator:
 
         """
         # Create the table if it doesn't exist
-        result = await self.db_session.execute(
+        result = await self.db_session.exec(
             text(
                 """
             CREATE TABLE IF NOT EXISTS migration_info (
@@ -85,12 +85,10 @@ class Migrator:
         await self.db_session.flush()
 
         # Check if the table is empty and insert a default value if necessary
-        result = await self.db_session.execute(
-            text("SELECT COUNT(*) FROM migration_info")
-        )
+        result = await self.db_session.exec(text("SELECT COUNT(*) FROM migration_info"))
         count = result.scalar_one()
         if count == 0:
-            await self.db_session.execute(
+            await self.db_session.exec(
                 text("INSERT INTO migration_info (active_revision) VALUES (NULL)")
             )
             await self.db_session.flush()
@@ -108,7 +106,7 @@ class Migrator:
         """
         )
 
-        await self.db_session.execute(query, {"value": value})
+        await self.db_session.exec(query, {"value": value})
         await self.db_session.flush()
 
         LOGGER.info("Active revision set")
@@ -120,5 +118,5 @@ class Migrator:
         """
         )
 
-        result = await self.db_session.execute(query)
+        result = await self.db_session.exec(query)
         return cast(str | None, result.scalar_one())

--- a/mountaineer/migrations/migrator.py
+++ b/mountaineer/migrations/migrator.py
@@ -2,8 +2,9 @@ from contextlib import asynccontextmanager
 from typing import cast
 
 from sqlalchemy.exc import InvalidRequestError
-from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
+from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker
 from sqlmodel import text
+from sqlmodel.ext.asyncio.session import AsyncSession
 
 from mountaineer.logging import LOGGER
 from mountaineer.migrations.actions import DatabaseActions

--- a/mountaineer/migrations/migrator.py
+++ b/mountaineer/migrations/migrator.py
@@ -4,8 +4,8 @@ from typing import cast
 from sqlalchemy.exc import InvalidRequestError
 from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker
 from sqlmodel import text
-from sqlmodel.ext.asyncio.session import AsyncSession
 
+from mountaineer.database.session import AsyncSession
 from mountaineer.logging import LOGGER
 from mountaineer.migrations.actions import DatabaseActions
 
@@ -106,7 +106,7 @@ class Migrator:
         """
         )
 
-        await self.db_session.exec(query, {"value": value})
+        await self.db_session.exec(query, params={"value": value})
         await self.db_session.flush()
 
         LOGGER.info("Active revision set")

--- a/mountaineer/test_utilities.py
+++ b/mountaineer/test_utilities.py
@@ -164,7 +164,6 @@ async def bootstrap_database(engine: AsyncEngine):
     # the user likely hasn't booted up the test database
     try:
         async with engine.connect() as conn:
-            # Optionally, you can perform a simple query to ensure the connection is valid
             await conn.execute(text("SELECT 1"))
     except (DBAPIError, OSError) as e:
         # Handle specific database connection errors or raise a custom exception


### PR DESCRIPTION
Mountaineer's database support has focused on using a SQLAlchemy AsyncSession for database connections alongside SQLModel for query construction. This was due to some initial limitations in the async session provided by SQLModel and SQLAlchemy2.

Mixing the sessions works but can result in some clunky code. Each database request has to explicitly get the scalars for typehinting to resolve in mypy:

```python
query_result = await db_session.execute(query)
result = query_result.scalars().all()
```

Additionally, there are some cases where this approach results in the wrong typehints - like when we're trying to fetch a tuple of field:

```python
query = select(models.ModelA, models.ModelB)
```

We expect this would result in a tuple of (model_a, model_b) as the typehint suggests, but it only gathers the first object since scalars() just arbitrarily takes the first value.

To address these shortcomings, we switch to using the typehints provided by SQLModel. Technically we use a thin wrapper on top of `AsyncSession` in order to support text queries like discussed here:
https://github.com/fastapi/sqlmodel/issues/909

Old `.execute` requests are still supported, but clients are advised to switch to `.exec` to get the proper typehints and to avoid the deprecation warning.