### PR TITLE
Update sideeffect typehints to reflect runtime

### DIFF
--- a/mountaineer/__tests__/actions/test_sideeffect_dec.py
+++ b/mountaineer/__tests__/actions/test_sideeffect_dec.py
@@ -158,6 +158,30 @@ async def test_can_call_sideeffect_async_render():
 
 
 @pytest.mark.asyncio
+async def test_can_call_sideeffect_original():
+    """
+    Ensure that we can access the raw underlying function that was
+    wrapped by the decorator.
+
+    """
+
+    class ExampleController(ControllerCommon):
+        def render(
+            self,
+            query_id: int,
+        ) -> ExampleRenderModel:
+            self.render_counts += 1
+            return ExampleRenderModel(
+                value_a="Hello",
+                value_b="World",
+            )
+
+    controller = ExampleController()
+    await ExampleController.call_sideeffect.original(controller, dict())
+    await ExampleController.call_sideeffect_async.original(controller, dict())
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "referer, expected_resolved",
     [

--- a/mountaineer/__tests__/actions/test_sideeffect_dec.py
+++ b/mountaineer/__tests__/actions/test_sideeffect_dec.py
@@ -90,12 +90,12 @@ async def call_sideeffect_common(controller: ControllerCommon):
 
         # Even if the "request" is not required by our sideeffects, it's required
         # by the function injected by the sideeffect decorator.
-        return_value_sync = await controller.call_sideeffect(
+        return_value_sync = await controller.call_sideeffect(  # type: ignore
             {},
             request=Request({"type": "http"}),  # type: ignore
         )
 
-        return_value_async = await controller.call_sideeffect_async(
+        return_value_async = await controller.call_sideeffect_async(  # type: ignore
             {},
             request=Request({"type": "http"}),  # type: ignore
         )

--- a/mountaineer/actions/fields.py
+++ b/mountaineer/actions/fields.py
@@ -2,6 +2,7 @@ import collections
 import collections.abc
 import typing
 import warnings
+from asyncio import iscoroutinefunction
 from enum import Enum
 from inspect import (
     isclass,
@@ -11,9 +12,17 @@ from json import loads as json_loads
 from typing import (
     TYPE_CHECKING,
     Any,
+    Awaitable,
     Callable,
+    Concatenate,
+    Generic,
+    NotRequired,
     Optional,
+    ParamSpec,
+    Protocol,
     Type,
+    TypedDict,
+    TypeVar,
     get_args,
     get_origin,
 )
@@ -41,6 +50,40 @@ class FunctionActionType(Enum):
 class ResponseModelType(Enum):
     SINGLE_RESPONSE = "SINGLE_RESPONSE"
     ITERATOR_RESPONSE = "ITERATOR_RESPONSE"
+
+
+P = TypeVar("P")
+
+
+class SideeffectResponseBase(TypedDict, Generic[P]):
+    passthrough: P
+    # We can't yet typehint across the boundary of the sideeffect -> render
+    # within one class since @sideeffect is isolated to just the wrapped function
+    sideeffect: NotRequired[Any]
+
+
+T = ParamSpec("T")
+R = TypeVar("R")
+C = TypeVar("C", covariant=True)
+
+
+class SideeffectWrappedCallable(Protocol[C, T, R]):
+    def __call__(
+        self: Any, *args: T.args, **kwargs: T.kwargs
+    ) -> Awaitable[SideeffectResponseBase[R]]:
+        ...
+
+    # Since the original function is extracted directly from the class, it's
+    # just a hanging function and no longer an instance method. Users therefore
+    # need to call it with the class instance explicitly as the first argument.
+    original: Callable[Concatenate[C, T], Awaitable[R]]
+
+
+class SideeffectRawCallable(Protocol[C, T, R]):
+    def __call__(self: Any, *args: T.args, **kwargs: T.kwargs) -> Awaitable[R]:
+        ...
+
+    original: Callable[Concatenate[C, T], Awaitable[R]]
 
 
 class FunctionMetadata(BaseModel):
@@ -250,7 +293,7 @@ def format_final_action_response(dict_payload: dict[str, Any]):
     merge the final payload into the explicit response.
 
     """
-    responses = [
+    responses: list[tuple[str, JSONResponse]] = [
         (key, response)
         for key, response in dict_payload.items()
         if isinstance(response, JSONResponse)
@@ -344,3 +387,19 @@ def extract_model_from_decorated_types(
     raise ValueError(
         f"Invalid response_model typehint for standard action: {type_hint}"
     )
+
+
+def create_original_fn(fn):
+    """
+    To fulfill our typehints for "original" that are returned from @sideeffect
+    and @passthrough we have to make them all async even if they weren't originally.
+
+    """
+    if iscoroutinefunction(fn):
+        return fn
+    else:
+
+        async def async_fn(*args, **kwargs):
+            return fn(*args, **kwargs)
+
+        return async_fn

--- a/mountaineer/actions/fields.py
+++ b/mountaineer/actions/fields.py
@@ -16,7 +16,6 @@ from typing import (
     Callable,
     Concatenate,
     Generic,
-    NotRequired,
     Optional,
     ParamSpec,
     Protocol,
@@ -36,6 +35,11 @@ from pydantic.fields import FieldInfo
 from mountaineer.annotation_helpers import MountaineerUnsetValue
 from mountaineer.exceptions import APIException
 from mountaineer.render import FieldClassDefinition, Metadata, RenderBase, RenderNull
+
+try:
+    from typing import NotRequired
+except ImportError:
+    from typing_extensions import NotRequired
 
 if TYPE_CHECKING:
     from mountaineer.controller import ControllerBase

--- a/mountaineer/actions/fields.py
+++ b/mountaineer/actions/fields.py
@@ -1,5 +1,6 @@
 import collections
 import collections.abc
+import sys
 import typing
 import warnings
 from asyncio import iscoroutinefunction
@@ -36,9 +37,9 @@ from mountaineer.annotation_helpers import MountaineerUnsetValue
 from mountaineer.exceptions import APIException
 from mountaineer.render import FieldClassDefinition, Metadata, RenderBase, RenderNull
 
-try:
+if sys.version_info >= (3, 11):
     from typing import NotRequired
-except ImportError:
+else:
     from typing_extensions import NotRequired
 
 if TYPE_CHECKING:
@@ -58,12 +59,17 @@ class ResponseModelType(Enum):
 
 P = TypeVar("P")
 
+if sys.version_info >= (3, 11):
 
-class SideeffectResponseBase(TypedDict, Generic[P]):
-    passthrough: P
-    # We can't yet typehint across the boundary of the sideeffect -> render
-    # within one class since @sideeffect is isolated to just the wrapped function
-    sideeffect: NotRequired[Any]
+    class SideeffectResponseBase(TypedDict, Generic[P]):
+        passthrough: P
+        # We can't yet typehint across the boundary of the sideeffect -> render
+        # within one class since @sideeffect is isolated to just the wrapped function
+        sideeffect: NotRequired[Any]
+else:
+    # Inheriting from both TypedDict and Generic[P] is not supported in Python 3.10 and below
+    class SideeffectResponseBase(dict, Generic[P]):
+        pass
 
 
 T = ParamSpec("T")

--- a/mountaineer/actions/passthrough_dec.py
+++ b/mountaineer/actions/passthrough_dec.py
@@ -165,7 +165,8 @@ def passthrough(*args, **kwargs):  # type: ignore
                 if isasyncgen(response):
                     return wrap_passthrough_generator(response)
 
-                final_payload: SideeffectResponseBase[Any] = {
+                # Following types ignored to support 3.10
+                final_payload: SideeffectResponseBase[Any] = {  # type: ignore
                     "passthrough": response,
                 }
                 return format_final_action_response(final_payload)  # type: ignore

--- a/mountaineer/actions/passthrough_dec.py
+++ b/mountaineer/actions/passthrough_dec.py
@@ -10,8 +10,8 @@ from typing import (
     TYPE_CHECKING,
     Any,
     AsyncIterator,
-    Awaitable,
     Callable,
+    Concatenate,
     Coroutine,
     Literal,
     ParamSpec,
@@ -26,6 +26,10 @@ from pydantic import BaseModel
 from mountaineer.actions.fields import (
     FunctionActionType,
     ResponseModelType,
+    SideeffectRawCallable,
+    SideeffectResponseBase,
+    SideeffectWrappedCallable,
+    create_original_fn,
     extract_response_model_from_signature,
     format_final_action_response,
     init_function_metadata,
@@ -38,6 +42,7 @@ if TYPE_CHECKING:
 
 P = ParamSpec("P")
 R = TypeVar("R", bound=BaseModel | AsyncIterator[BaseModel] | JSONResponse | None)
+C = TypeVar("C")
 
 RawResponseR = TypeVar("RawResponseR", bound=Response)
 
@@ -47,7 +52,10 @@ def passthrough(  # type: ignore
     *,
     response_model: Type[BaseModel] | None = None,  # Deprecated
     exception_models: list[Type[APIException]] | None = None,
-) -> Callable[[Callable[P, R | Coroutine[Any, Any, R]]], Callable[P, Awaitable[R]]]:
+) -> Callable[
+    [Callable[Concatenate[C, P], R | Coroutine[Any, Any, R]]],
+    SideeffectWrappedCallable[C, P, R],
+]:
     ...
 
 
@@ -56,16 +64,16 @@ def passthrough(
     *,
     raw_response: Literal[True] = True,
 ) -> Callable[
-    [Callable[P, RawResponseR | Coroutine[Any, Any, RawResponseR]]],
-    Callable[P, Awaitable[RawResponseR]],
+    [Callable[Concatenate[C, P], RawResponseR | Coroutine[Any, Any, RawResponseR]]],
+    SideeffectRawCallable[C, P, RawResponseR],
 ]:
     ...
 
 
 @overload
 def passthrough(
-    func: Callable[P, R | Coroutine[Any, Any, R]],
-) -> Callable[P, Awaitable[R]]:
+    func: Callable[Concatenate[C, P], R | Coroutine[Any, Any, R]],
+) -> SideeffectWrappedCallable[C, P, R]:
     ...
 
 
@@ -157,7 +165,10 @@ def passthrough(*args, **kwargs):  # type: ignore
                 if isasyncgen(response):
                     return wrap_passthrough_generator(response)
 
-                return format_final_action_response(dict(passthrough=response))
+                final_payload: SideeffectResponseBase[Any] = {
+                    "passthrough": response,
+                }
+                return format_final_action_response(final_payload)  # type: ignore
 
             metadata = init_function_metadata(inner, FunctionActionType.PASSTHROUGH)
             metadata.passthrough_model = passthrough_model
@@ -168,6 +179,8 @@ def passthrough(*args, **kwargs):  # type: ignore
                 if response_type == ResponseModelType.ITERATOR_RESPONSE
                 else None
             )
+
+            inner.original = create_original_fn(func)  # type: ignore
             return inner
 
         return wrapper

--- a/mountaineer/actions/sideeffect_dec.py
+++ b/mountaineer/actions/sideeffect_dec.py
@@ -51,7 +51,6 @@ def sideeffect(
     experimental_render_reload: bool | None = None,
 ) -> Callable[
     [Callable[Concatenate[C, P], R | Coroutine[Any, Any, R]]],
-    # Callable[P, Awaitable[SideeffectResponseBase[R]]],
     SideeffectWrappedCallable[C, P, R],
 ]:
     """
@@ -63,9 +62,7 @@ def sideeffect(
 @overload
 def sideeffect(
     func: Callable[Concatenate[C, P], R | Coroutine[Any, Any, R]],
-) -> SideeffectWrappedCallable[
-    C, P, R
-]:  # Callable[P, Awaitable[SideeffectResponseBase[R]]]:
+) -> SideeffectWrappedCallable[C, P, R]:
     """
     Simple @sideeffect, will use default options.
     """

--- a/mountaineer/actions/sideeffect_dec.py
+++ b/mountaineer/actions/sideeffect_dec.py
@@ -183,7 +183,8 @@ def sideeffect(*args, **kwargs):  # type: ignore
                     if isawaitable(server_data):
                         server_data = await server_data
 
-                    final_payload: SideeffectResponseBase[Any] = {
+                    # Following types ignored to support 3.10
+                    final_payload: SideeffectResponseBase[Any] = {  # type: ignore
                         "sideeffect": server_data,
                         "passthrough": passthrough_values,
                     }

--- a/mountaineer/actions/sideeffect_dec.py
+++ b/mountaineer/actions/sideeffect_dec.py
@@ -24,6 +24,7 @@ from mountaineer.actions.fields import (
     ResponseModelType,
     SideeffectResponseBase,
     SideeffectWrappedCallable,
+    create_original_fn,
     extract_response_model_from_signature,
     format_final_action_response,
     init_function_metadata,
@@ -208,7 +209,7 @@ def sideeffect(*args, **kwargs):  # type: ignore
             metadata.exception_models = exception_models
             metadata.media_type = None  # Use the default json response type
 
-            inner.original = func  # type: ignore
+            inner.original = create_original_fn(func)  # type: ignore
             return inner
 
         return wrapper


### PR DESCRIPTION
Previously, we would mirror our side-effect decorated return value both at runtime (through `@wraps`) and during static typechecking. However, this wouldn't be the actual value that's returned if you were to do a controller.my_sideeffect() call - which can be a bit confusing if you're interacting with side-effects directly and not proxying through a httpx web request in testing.

This PR updates our decorator typehints to typehint the actual return values of sideeffects and passthroughs - namely a dictionary of `sideeffect` and `passthrough` values. We also allow access to our original function via a new `.original` static function that is exposed to the returned function.

```python
controller = ExampleController()
await ExampleController.call_sideeffect.original(controller, dict())
await ExampleController.call_sideeffect_async.original(controller, dict())
```

All of these original functions are converted to be async, even if the original wrapped function is synchronous.