### PR TITLE
Exception handling during reload, subclass reload

### DIFF
--- a/mountaineer/__tests__/fixtures/mock_webapp/simple_classes_1.py
+++ b/mountaineer/__tests__/fixtures/mock_webapp/simple_classes_1.py
@@ -1,0 +1,11 @@
+# Mock classes for testing inheritance
+class SuperClass1:
+    pass
+
+
+class SuperClass2:
+    pass
+
+
+class SubClass1(SuperClass1):
+    pass

--- a/mountaineer/__tests__/fixtures/mock_webapp/simple_classes_2.py
+++ b/mountaineer/__tests__/fixtures/mock_webapp/simple_classes_2.py
@@ -1,0 +1,13 @@
+from .simple_classes_1 import SubClass1, SuperClass2
+
+
+class SubClass2(SuperClass2):
+    pass
+
+
+class SubSubClass(SubClass1, SubClass2):
+    pass
+
+
+class UnrelatedClass:
+    pass

--- a/mountaineer/__tests__/test_app_manager.py
+++ b/mountaineer/__tests__/test_app_manager.py
@@ -3,14 +3,12 @@ import sys
 from inspect import getmembers, isclass
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from time import sleep
 
 import pytest
 from fastapi import Request
 
 from mountaineer.__tests__.fixtures import get_fixture_path
 from mountaineer.app_manager import HotReloadManager
-from mountaineer.webservice import UvicornThread
 
 AppPackageType = tuple[str, Path, Path]
 
@@ -87,18 +85,6 @@ def test_update_module(manager: HotReloadManager, app_package: AppPackageType):
     # Check if the new attribute is present
     assert hasattr(manager.app_controller, "new_attribute")
     assert manager.app_controller.new_attribute == "test"  # type: ignore
-
-
-def test_restart_server(manager: HotReloadManager):
-    manager.restart_server()
-
-    assert manager.webservice_thread is not None
-    assert isinstance(manager.webservice_thread, UvicornThread)
-    assert manager.webservice_thread.is_alive()
-
-    # Give the server another second to boot
-    sleep(1)
-    manager.webservice_thread.stop()
 
 
 def test_objects_in_module(manager: HotReloadManager, app_package: AppPackageType):

--- a/mountaineer/cli.py
+++ b/mountaineer/cli.py
@@ -170,7 +170,7 @@ def handle_runserver(
         objects_to_reload: set[int] = set()
 
         updated_js: set[Path] = set()
-        updated_python: set[Path] = set()
+        updated_modules: set[tuple[str, Path]] = set()
 
         for event in metadata.events:
             if (
@@ -182,39 +182,61 @@ def handle_runserver(
 
             if event.path.suffix == ".py":
                 module_name = app_manager.package_path_to_module(event.path)
-
-                # Get the IDs before we reload the module, since they'll change after
-                # the re-import
-                # If module_name is not already in sys.modules, it hasn't been
-                # imported yet and we don't need to worry about refreshing dependent definitions
-                if module_name in sys.modules:
-                    LOGGER.debug(f"Changed Python: {event.path}")
-                    current_module = sys.modules[module_name]
-                    objects_to_reload |= app_manager.objects_in_module(current_module)
-                else:
-                    LOGGER.debug(f"Module {module_name} is new and not yet imported")
-
-                # Now, once we've cached the ids of objects currently in memory we can clear
-                # the actual model definition from the module cache
-                try:
-                    updated_module = importlib.import_module(module_name)
-                    importlib.reload(updated_module)
-
-                    # Only follow the downstream dependencies if the module was successfully reloaded
-                    updated_python.add(event.path)
-                except Exception as e:
-                    stacktrace = format_exc()
-                    CONSOLE.print(
-                        f"[bold red]Error reloading {module_name}, stopping reload..."
-                    )
-                    CONSOLE.print(f"[bold red]{e}\n{stacktrace}")
-
-                    # In the case of an exception in one module we still want to try to load
-                    # the other ones that were affected, since we want to keep the differential
-                    # state of the app up to date
-                    continue
+                updated_modules.add((module_name, event.path))
             elif event.path.suffix in KNOWN_JS_EXTENSIONS:
                 updated_js.add(event.path)
+
+        # Update the modules in a queue fashion so we can update the dependent modules
+        # where the subclasses live
+        module_queue = list(updated_modules)
+        seen_modules: set[str] = set()
+        updated_python: set[Path] = set()
+
+        while module_queue:
+            module_name, python_path = module_queue.pop(0)
+            if module_name in seen_modules:
+                continue
+
+            # Get the IDs before we reload the module, since they'll change after
+            # the re-import
+            # If module_name is not already in sys.modules, it hasn't been
+            # imported yet and we don't need to worry about refreshing dependent definitions
+            if module_name in sys.modules:
+                LOGGER.debug(f"Changed Python: {python_path}")
+                current_module = sys.modules[module_name]
+                owned_by_module = app_manager.objects_in_module(current_module)
+
+                objects_to_reload |= owned_by_module
+                obj_subclasses = app_manager.get_modified_subclass_modules(
+                    current_module, owned_by_module
+                )
+                subclass_modules = {module for module, _ in obj_subclasses}
+
+                for additional_module in subclass_modules:
+                    module_path = app_manager.module_to_package_path(additional_module)
+                    module_queue.append((additional_module, module_path))
+            else:
+                LOGGER.debug(f"Module {module_name} is new and not yet imported")
+
+            # Now, once we've cached the ids of objects currently in memory we can clear
+            # the actual model definition from the module cache
+            try:
+                updated_module = importlib.import_module(module_name)
+                importlib.reload(updated_module)
+
+                # Only follow the downstream dependencies if the module was successfully reloaded
+                updated_python.add(python_path)
+            except Exception as e:
+                stacktrace = format_exc()
+                CONSOLE.print(
+                    f"[bold red]Error reloading {module_name}, stopping reload..."
+                )
+                CONSOLE.print(f"[bold red]{e}\n{stacktrace}")
+
+                # In the case of an exception in one module we still want to try to load
+                # the other ones that were affected, since we want to keep the differential
+                # state of the app up to date
+                continue
 
         # Pass all updated files to the app compiler to build stylesheets
         # and other asset compilations

--- a/mountaineer/cli.py
+++ b/mountaineer/cli.py
@@ -206,7 +206,7 @@ def handle_runserver(
                         f"[bold red]Error reloading {module_name}, stopping reload..."
                     )
                     CONSOLE.print(f"[bold red]{e}\n{stacktrace}")
-                    continue
+                    return
             elif event.path.suffix in KNOWN_JS_EXTENSIONS:
                 updated_js.add(event.path)
 

--- a/mountaineer/migrations/actions.py
+++ b/mountaineer/migrations/actions.py
@@ -99,6 +99,7 @@ class ConstraintType(StrEnum):
     FOREIGN_KEY = "FOREIGN KEY"
     UNIQUE = "UNIQUE"
     CHECK = "CHECK"
+    INDEX = "INDEX"
 
     # Exclude constraints aren't well-supported in SQLAlchemy since they
     # are postgres-specific, so we don't have built-in handling for them.
@@ -424,6 +425,28 @@ class DatabaseActions:
                 constraint=constraint,
                 constraint_name=constraint_name,
                 constraint_args=constraint_args,
+            ),
+            sql,
+        )
+
+    async def add_index(
+        self,
+        table_name: str,
+        columns: list[str],
+        index_name: str,
+    ):
+        assert_is_safe_sql_identifier(table_name)
+        for column_name in columns:
+            assert_is_safe_sql_identifier(column_name)
+
+        columns_formatted = ", ".join(columns)
+        sql = f'CREATE INDEX {index_name} ON "{table_name}" ({columns_formatted});'
+        await self._record_signature(
+            self.add_index,
+            dict(
+                table_name=table_name,
+                columns=columns,
+                index_name=index_name,
             ),
             sql,
         )

--- a/mountaineer/migrations/actions.py
+++ b/mountaineer/migrations/actions.py
@@ -429,28 +429,6 @@ class DatabaseActions:
             sql,
         )
 
-    async def add_index(
-        self,
-        table_name: str,
-        columns: list[str],
-        index_name: str,
-    ):
-        assert_is_safe_sql_identifier(table_name)
-        for column_name in columns:
-            assert_is_safe_sql_identifier(column_name)
-
-        columns_formatted = ", ".join(columns)
-        sql = f'CREATE INDEX {index_name} ON "{table_name}" ({columns_formatted});'
-        await self._record_signature(
-            self.add_index,
-            dict(
-                table_name=table_name,
-                columns=columns,
-                index_name=index_name,
-            ),
-            sql,
-        )
-
     async def drop_constraint(
         self,
         table_name: str,
@@ -469,6 +447,46 @@ class DatabaseActions:
             ALTER TABLE "{table_name}"
             DROP CONSTRAINT {constraint_name}
             """,
+        )
+
+    async def add_index(
+        self,
+        table_name: str,
+        columns: list[str],
+        index_name: str,
+    ):
+        assert_is_safe_sql_identifier(table_name)
+        for column_name in columns:
+            assert_is_safe_sql_identifier(column_name)
+
+        columns_formatted = ", ".join([f'"{column_name}"' for column_name in columns])
+        sql = f'CREATE INDEX {index_name} ON "{table_name}" ({columns_formatted});'
+        await self._record_signature(
+            self.add_index,
+            dict(
+                table_name=table_name,
+                columns=columns,
+                index_name=index_name,
+            ),
+            sql,
+        )
+
+    async def drop_index(
+        self,
+        table_name: str,
+        index_name: str,
+    ):
+        assert_is_safe_sql_identifier(table_name)
+        assert_is_safe_sql_identifier(index_name)
+
+        sql = f'ALTER TABLE "{table_name}" DROP INDEX {index_name};'
+        await self._record_signature(
+            self.drop_index,
+            dict(
+                table_name=table_name,
+                index_name=index_name,
+            ),
+            sql,
         )
 
     async def add_not_null(self, table_name: str, column_name: str):

--- a/mountaineer/migrations/db_serializer.py
+++ b/mountaineer/migrations/db_serializer.py
@@ -228,7 +228,9 @@ class DatabaseSerializer:
             AND i.indexdef NOT ILIKE '%UNIQUE INDEX%'
         """
         )
-        index_result = await session.execute(index_query, {"table_name": table_name})
+        index_result = await session.exec(
+            index_query, params={"table_name": table_name}
+        )
 
         for row in index_result:
             index_name = row.indexname
@@ -237,6 +239,7 @@ class DatabaseSerializer:
             # Extract columns from index definition
             columns_match = re.search(r"\((.*?)\)", index_def)
             if columns_match:
+                # Reserved names are quoted in the response body
                 columns = [
                     col.strip().strip('"') for col in columns_match.group(1).split(",")
                 ]

--- a/mountaineer/migrations/db_serializer.py
+++ b/mountaineer/migrations/db_serializer.py
@@ -237,7 +237,9 @@ class DatabaseSerializer:
             # Extract columns from index definition
             columns_match = re.search(r"\((.*?)\)", index_def)
             if columns_match:
-                columns = [col.strip() for col in columns_match.group(1).split(",")]
+                columns = [
+                    col.strip().strip('"') for col in columns_match.group(1).split(",")
+                ]
             else:
                 columns = []
 

--- a/mountaineer/migrations/db_stubs.py
+++ b/mountaineer/migrations/db_stubs.py
@@ -278,10 +278,16 @@ class DBConstraint(DBObject):
             )
 
     async def destroy(self, actor: DatabaseActions):
-        await actor.drop_constraint(
-            self.table_name,
-            constraint_name=self.constraint_name,
-        )
+        if self.constraint_type == ConstraintType.INDEX:
+            await actor.drop_index(
+                self.table_name,
+                index_name=self.constraint_name,
+            )
+        else:
+            await actor.drop_constraint(
+                self.table_name,
+                constraint_name=self.constraint_name,
+            )
 
     async def migrate(self, previous: "DBConstraint", actor: DatabaseActions):
         if self.constraint_type != previous.constraint_type:

--- a/mountaineer/migrations/db_stubs.py
+++ b/mountaineer/migrations/db_stubs.py
@@ -236,6 +236,9 @@ class DBConstraint(DBObject):
         elif constraint_type == ConstraintType.UNIQUE:
             elements += sorted(columns)
             elements.append("unique")
+        elif constraint_type == ConstraintType.INDEX:
+            elements += sorted(columns)
+            elements.append("idx")
         else:
             elements += sorted(columns)
             elements.append("key")
@@ -259,6 +262,12 @@ class DBConstraint(DBObject):
                 constraint_name=self.constraint_name,
                 constraint_args=self.check_constraint,
                 columns=list(self.columns),
+            )
+        elif self.constraint_type == ConstraintType.INDEX:
+            await actor.add_index(
+                self.table_name,
+                columns=list(self.columns),
+                index_name=self.constraint_name,
             )
         else:
             await actor.add_constraint(

--- a/mountaineer/migrations/generator.py
+++ b/mountaineer/migrations/generator.py
@@ -203,15 +203,19 @@ class MigrationGenerator:
             if isinstance(value, BaseModel):
                 model_dict = value.model_dump()
             elif is_dataclass(value) and not isinstance(value, type):
-                model_dict = asdict(value)
+                # Currently incorrect typehinting in pyright for isinstance(value, type)
+                # Still results in a type[DataclassInstance] possible type. This can remove
+                # the following 3 type ignores when fixed.
+                # https://github.com/microsoft/pyright/issues/8963
+                model_dict = asdict(value)  # type: ignore
             else:
                 raise TypeError(
                     "Value must be a BaseModel instance or a dataclass instance."
                 )
 
-            self.track_import(value.__class__)
+            self.track_import(value.__class__)  # type: ignore
 
-            code = f"{value.__class__.__name__}("
+            code = f"{value.__class__.__name__}("  # type: ignore
             code += ", ".join(
                 [
                     f"{k}={self.format_arg(v)}"

--- a/poetry.lock
+++ b/poetry.lock
@@ -762,13 +762,13 @@ types = ["typing-extensions"]
 
 [[package]]
 name = "pyright"
-version = "1.1.366"
+version = "1.1.380"
 description = "Command line wrapper for pyright"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pyright-1.1.366-py3-none-any.whl", hash = "sha256:c09e73ccc894976bcd6d6a5784aa84d724dbd9ceb7b873b39d475ca61c2de071"},
-    {file = "pyright-1.1.366.tar.gz", hash = "sha256:10e4d60be411f6d960cd39b0b58bf2ff76f2c83b9aeb102ffa9d9fda2e1303cb"},
+    {file = "pyright-1.1.380-py3-none-any.whl", hash = "sha256:a6404392053d8848bacc7aebcbd9d318bb46baf1a1a000359305481920f43879"},
+    {file = "pyright-1.1.380.tar.gz", hash = "sha256:e6ceb1a5f7e9f03106e0aa1d6fbb4d97735a5e7ffb59f3de6b2db590baf935b2"},
 ]
 
 [package.dependencies]


### PR DESCRIPTION
- Reload the modules that we can during hot-reloading, while ignoring any that are subject to syntax errors / load exceptions.
- Refresh the subclasses of the classes of a modified module, since the runtime will use a cache import of the superclass until it's reloaded explicitly.
- Add support for index generation in migrations.

We also add a new `MOUNTAINEER_HOT_RELOADING` env variable when running locally with `runserver`. This allows users to implement conditional business logic to only load heavy dependencies on the first run but not on subsequent differential reloads of the python runtime.

Typehinting in `MigrationGenerator` will be restored with the fix of https://github.com/microsoft/pyright/issues/8963