### PR TITLE
Fallback to global metadata

### DIFF
--- a/mountaineer/app.py
+++ b/mountaineer/app.py
@@ -591,15 +591,18 @@ class AppController:
         inline_client_script: str | None = None,
         external_client_imports: list[str] | None = None,
     ):
-        # header_str = "\n".join(self._build_header(self._merge_metadatas(metadatas)))
+        header_str: str
         if page_metadata.metadata:
             metadata = page_metadata.metadata
             if not metadata.ignore_global_metadata and self.global_metadata:
                 metadata = metadata.merge(self.global_metadata)
             header_str = "\n".join(metadata.build_header())
-
         else:
-            header_str = ""
+            if self.global_metadata:
+                metadata = self.global_metadata
+                header_str = "\n".join(metadata.build_header())
+            else:
+                header_str = ""
 
         # Client-side react scripts that will hydrate the server side contents on load
         server_data_json = {

--- a/mountaineer/client_builder/openapi.py
+++ b/mountaineer/client_builder/openapi.py
@@ -86,7 +86,7 @@ class OpenAPIProperty(BaseModel):
     # Self-contained type: object, int, etc
     variable_type: OpenAPISchemaType | None = Field(alias="type", default=None)
     # Reference to another type
-    ref: str | None = Field(alias="$ref", default=None)
+    ref: str | None = Field(alias="$ref", default=None)  # type: ignore
     # Array of another type
     items: Union["OpenAPIProperty", EmptyAPIProperty, None] = None
     # Enum type
@@ -177,7 +177,7 @@ class OpenAPIProperty(BaseModel):
 
 class ContentDefinition(BaseModel):
     class Reference(BaseModel):
-        ref: str | None = Field(default=None, alias="$ref")
+        ref: str | None = Field(default=None, alias="$ref")  # type: ignore
 
         model_config = {"populate_by_name": True}
 
@@ -309,7 +309,7 @@ class OpenAPISchema(OpenAPIProperty):
 
     """
 
-    defs: dict[str, OpenAPIProperty] = Field(alias="$defs", default_factory=dict)
+    defs: dict[str, OpenAPIProperty] = Field(alias="$defs", default_factory=dict)  # type: ignore
 
 
 class OpenAPIDefinition(BaseModel):

--- a/mountaineer/controller.py
+++ b/mountaineer/controller.py
@@ -64,6 +64,8 @@ class ControllerBase(ABC, Generic[RenderInput]):
         avoiding blocking the reset of the server process if the React render logic hangs.
 
         """
+        super().__init__()
+
         # Injected by the build framework
         self.bundled_scripts: list[str] = []
         self.initialized = True

--- a/mountaineer/paths.py
+++ b/mountaineer/paths.py
@@ -163,7 +163,19 @@ class ManagedViewPath(type(Path())):  # type: ignore
         path.package_root_link = self.package_root_link
         return path
 
-    if sys.version_info >= (3, 12):
+    if sys.version_info >= (3, 13):
+
+        def rglob(
+            self,
+            pattern: str,
+            *,
+            case_sensitive: bool | None = None,
+            recurse_symlinks: bool = False,
+        ):
+            for path in super().rglob(pattern, case_sensitive=case_sensitive):
+                yield self._inherit_root_link(path)
+
+    elif sys.version_info >= (3, 12):
 
         def rglob(self, pattern: str, *, case_sensitive: bool | None = None):
             for path in super().rglob(pattern, case_sensitive=case_sensitive):

--- a/poetry.lock
+++ b/poetry.lock
@@ -763,21 +763,23 @@ types = ["typing-extensions"]
 
 [[package]]
 name = "pyright"
-version = "1.1.380"
+version = "1.1.385"
 description = "Command line wrapper for pyright"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pyright-1.1.380-py3-none-any.whl", hash = "sha256:a6404392053d8848bacc7aebcbd9d318bb46baf1a1a000359305481920f43879"},
-    {file = "pyright-1.1.380.tar.gz", hash = "sha256:e6ceb1a5f7e9f03106e0aa1d6fbb4d97735a5e7ffb59f3de6b2db590baf935b2"},
+    {file = "pyright-1.1.385-py3-none-any.whl", hash = "sha256:e5b9a1b8d492e13004d822af94d07d235f2c7c158457293b51ab2214c8c5b375"},
+    {file = "pyright-1.1.385.tar.gz", hash = "sha256:1bf042b8f080441534aa02101dea30f8fc2efa8f7b6f1ab05197c21317f5bfa7"},
 ]
 
 [package.dependencies]
 nodeenv = ">=1.6.0"
+typing-extensions = ">=4.1"
 
 [package.extras]
-all = ["twine (>=3.4.1)"]
+all = ["nodejs-wheel-binaries", "twine (>=3.4.1)"]
 dev = ["twine (>=3.4.1)"]
+nodejs = ["nodejs-wheel-binaries"]
 
 [[package]]
 name = "pytest"


### PR DESCRIPTION
Our previous check for a non-null render metadata before global metadata merge meant that page that didn't have any metadata specified wouldn't be merged with the global payload. This PR ensures we fallback to global metadata in all cases.