### PR TITLE
Add exception parsing and styling

### DIFF
--- a/mountaineer/__tests__/controllers/test_traceback.py
+++ b/mountaineer/__tests__/controllers/test_traceback.py
@@ -1,0 +1,144 @@
+from textwrap import dedent
+
+import pytest
+
+from mountaineer.controllers.traceback import ExceptionParser
+
+
+def nested_function(x: int) -> None:
+    local_var = "test string"
+    nested_dict = {"key": "value"}
+    raise ValueError(f"Test error with {x}")
+
+
+def function_with_locals() -> None:
+    x = 42
+    y = "string"
+    z = [1, 2, 3]
+    nested_function(x)
+
+
+@pytest.fixture
+def parser():
+    return ExceptionParser()
+
+
+@pytest.fixture
+def complex_exception() -> ValueError:
+    try:
+        function_with_locals()
+    except ValueError as e:
+        return e
+    raise RuntimeError("Expected ValueError was not raised")
+
+
+def test_basic_exception_parsing(parser):
+    try:
+        raise ValueError("Test error")
+    except ValueError as e:
+        result = parser.parse_exception(e)
+
+    assert result.exc_type == "ValueError"
+    assert result.exc_value == "Test error"
+    assert len(result.frames) > 0
+
+    frame = result.frames[-1]
+    assert frame.file_name.endswith(f"{__name__}.py")
+    assert isinstance(frame.line_number, int)
+    assert frame.function_name == "test_basic_exception_parsing"
+    assert isinstance(frame.code_context, str)
+    assert "<span" in frame.code_context
+    assert isinstance(frame.local_values, dict)
+
+
+def test_nested_exception_with_locals(parser, complex_exception):
+    result = parser.parse_exception(complex_exception)
+
+    assert result.exc_type == "ValueError"
+    assert "Test error with 42" in result.exc_value
+    assert len(result.frames) >= 2
+
+    nested_frame = None
+    for frame in result.frames:
+        if frame.function_name == "nested_function":
+            nested_frame = frame
+            break
+
+    assert nested_frame is not None
+    assert "local_var" in nested_frame.local_values
+    assert "nested_dict" in nested_frame.local_values
+    assert isinstance(nested_frame.local_values["local_var"], str)
+    assert "<span" in nested_frame.local_values["nested_dict"]
+
+
+def test_syntax_highlighting(parser):
+    try:
+        x = {"complex": [1, 2, 3], "dict": {"nested": True}}
+        raise Exception("Test")
+    except Exception as e:
+        result = parser.parse_exception(e)
+
+    frame = result.frames[-1]
+    assert "class=" in frame.code_context
+    assert "span" in frame.code_context
+    assert frame.local_values["x"].count("<span") > 1
+
+
+def test_different_file_types(parser, tmp_path):
+    py_file = tmp_path / "test.py"
+    py_file.write_text(
+        dedent(
+            """
+        def test_function():
+            x = 42
+            raise ValueError("Test")
+    """
+        )
+    )
+
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("test_module", py_file)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    try:
+        module.test_function()
+    except ValueError as e:
+        result = parser.parse_exception(e)
+
+    frame = result.frames[-1]
+    assert frame.file_name == str(py_file)
+    assert "test_function" in frame.code_context
+    assert "<span" in frame.code_context
+
+
+def test_get_style_defs(parser):
+    styles = parser.get_style_defs()
+    assert isinstance(styles, str)
+    assert len(styles) > 0
+
+
+def test_exception_without_traceback(parser):
+    exc = ValueError("Test error")
+    result = parser.parse_exception(exc)
+
+    assert result.exc_type == "ValueError"
+    assert result.exc_value == "Test error"
+    assert isinstance(result.frames, list)
+
+
+def test_line_numbers_accuracy(parser):
+    def error_on_specific_line():
+        x = 1
+        y = 2
+        raise ValueError("Test")
+
+    try:
+        error_on_specific_line()
+    except ValueError as e:
+        result = parser.parse_exception(e)
+
+    frame = result.frames[-1]
+    assert "ValueError" in frame.code_context
+    assert frame.line_number > 0

--- a/mountaineer/__tests__/fixtures/mock_webapp/simple_controller.py
+++ b/mountaineer/__tests__/fixtures/mock_webapp/simple_controller.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from mountaineer import AppController, ControllerBase
+from mountaineer import AppController, ConfigBase, ControllerBase
 
 
 class TestController(ControllerBase):
@@ -11,5 +11,15 @@ class TestController(ControllerBase):
         pass
 
 
-test_controller = AppController(view_root=Path(__file__).parent.joinpath("views"))
+# We need a development config to test dev utilities
+class SimpleConfig(ConfigBase):
+    pass
+
+
+config = SimpleConfig()
+
+test_controller = AppController(
+    view_root=Path(__file__).parent.joinpath("views"),
+    config=config,
+)
 test_controller.register(TestController())

--- a/mountaineer/__tests__/fixtures/mock_webapp/simple_controller.py
+++ b/mountaineer/__tests__/fixtures/mock_webapp/simple_controller.py
@@ -4,7 +4,7 @@ from mountaineer import AppController, ConfigBase, ControllerBase
 
 
 class TestController(ControllerBase):
-    view_path = "/test.tsx"
+    view_path = "/test_controller/page.tsx"
     url = "/"
 
     async def render(self) -> None:

--- a/mountaineer/__tests__/test_app_manager.py
+++ b/mountaineer/__tests__/test_app_manager.py
@@ -90,7 +90,8 @@ def app_package(tmp_app_package_dir: Path):
         (get_fixture_path("mock_webapp") / "simple_controller.py").read_text()
     )
 
-    (views_dir / "test.tsx").write_text("")
+    (views_dir / "test_controller").mkdir()
+    (views_dir / "test_controller" / "page.tsx").write_text("")
 
     # Make the path reachable only within this test scope
     sys.path.insert(0, str(tmp_app_package_dir))
@@ -190,6 +191,9 @@ def test_mount_exceptions(manager: DevAppManager):
 
 @pytest.mark.asyncio
 async def test_handle_dev_exception(manager: DevAppManager):
+    await manager.js_compiler.build_all()
+    await manager.app_compiler.run_builder_plugins()
+
     # Create a mock request
     request = Request({"type": "http", "method": "GET"})
 

--- a/mountaineer/__tests__/test_hotreload.py
+++ b/mountaineer/__tests__/test_hotreload.py
@@ -707,9 +707,12 @@ def test_inheritance_tree_module_updates(test_package_dir: tuple[Path, str]):
     assert "DynamicClass" not in base_deps.subclasses.get("BaseClass", set())
 
 
+@pytest.mark.xfail(strict=False)
 def test_new_file_reload(test_package_dir: tuple[Path, str]):
     """
     Test adding and reloading a new file that imports other modules.
+
+    TODO: We need to investigate why this is unreliable in remote CI but reliable locally.
 
     """
     pkg_dir, pkg_name = test_package_dir

--- a/mountaineer/app_manager.py
+++ b/mountaineer/app_manager.py
@@ -9,12 +9,14 @@ from traceback import format_exception
 from types import ModuleType
 
 from fastapi import Request
-from fastapi.responses import Response
 
 from mountaineer.app import AppController
 from mountaineer.client_builder.builder import ClientBuilder
 from mountaineer.client_compiler.compile import ClientCompiler
-from mountaineer.controllers.exception_controller import ExceptionController
+from mountaineer.controllers.exception_controller import (
+    ExceptionController,
+    get_formatted_traceback,
+)
 from mountaineer.webservice import UvicornThread
 
 
@@ -95,7 +97,6 @@ class DevAppManager:
         # By the time we get to this point, our hot reloader should
         # have already reloaded the module in global space
         self.module = sys.modules[self.module.__name__]
-        # self.module = importlib.reload(self.module)
         initial_state = {name: getattr(self.module, name) for name in dir(self.module)}
         self.app_controller = initial_state[self.controller_name]
 
@@ -152,15 +153,13 @@ class DevAppManager:
         # If we're receiving a GET request, show the exception. Otherwise fall back
         # on the normal REST handlers
         if request.method == "GET":
-            # raise NotImplementedError
-            # response = await self.exception_controller._generate_html(
-            #     global_metadata=None,
-            #     exception=str(exc),
-            #     stack="".join(format_exception(exc)),
-            # )
-            # response.status_code = 500
-            # return response
-            return Response("".join(format_exception(exc)))
+            print(get_formatted_traceback(exc))
+
+            html = await self.exception_controller.definition.view_route(
+                exception=str(exc),
+                stack="".join(format_exception(exc)),
+            )
+            return html
         else:
             raise exc
 

--- a/mountaineer/app_manager.py
+++ b/mountaineer/app_manager.py
@@ -152,7 +152,7 @@ class DevAppManager:
         # If we're receiving a GET request, show the exception. Otherwise fall back
         # on the normal REST handlers
         if request.method == "GET":
-            html = await self.exception_controller.definition.view_route(
+            html = await self.exception_controller.definition.view_route(  # type: ignore
                 exception=str(exc),
                 stack="".join(format_exception(exc)),
                 parsed_exception=self.exception_controller.traceback_parser.parse_exception(

--- a/mountaineer/app_manager.py
+++ b/mountaineer/app_manager.py
@@ -15,7 +15,6 @@ from mountaineer.client_builder.builder import ClientBuilder
 from mountaineer.client_compiler.compile import ClientCompiler
 from mountaineer.controllers.exception_controller import (
     ExceptionController,
-    get_formatted_traceback,
 )
 from mountaineer.webservice import UvicornThread
 
@@ -153,11 +152,12 @@ class DevAppManager:
         # If we're receiving a GET request, show the exception. Otherwise fall back
         # on the normal REST handlers
         if request.method == "GET":
-            print(get_formatted_traceback(exc))
-
             html = await self.exception_controller.definition.view_route(
                 exception=str(exc),
                 stack="".join(format_exception(exc)),
+                parsed_exception=self.exception_controller.traceback_parser.parse_exception(
+                    exc
+                ),
             )
             return html
         else:

--- a/mountaineer/controllers/exception_controller.py
+++ b/mountaineer/controllers/exception_controller.py
@@ -1,3 +1,5 @@
+
+
 from mountaineer.controller import ControllerBase
 from mountaineer.paths import ManagedViewPath
 from mountaineer.render import LinkAttribute, Metadata, RenderBase

--- a/mountaineer/controllers/exception_controller.py
+++ b/mountaineer/controllers/exception_controller.py
@@ -1,6 +1,5 @@
-
-
 from mountaineer.controller import ControllerBase
+from mountaineer.controllers.traceback import ExceptionParser, ParsedException
 from mountaineer.paths import ManagedViewPath
 from mountaineer.render import LinkAttribute, Metadata, RenderBase
 from mountaineer.views import get_core_view_path
@@ -9,6 +8,10 @@ from mountaineer.views import get_core_view_path
 class ExceptionRender(RenderBase):
     exception: str
     stack: str | None
+
+    # CSS that should be injected into the page to properly view the exceptions
+    formatting_style: str
+    parsed_exception: ParsedException
 
 
 class ExceptionController(ControllerBase):
@@ -24,12 +27,23 @@ class ExceptionController(ControllerBase):
         / "core/exception/page.tsx"
     )
 
-    def render(self, exception: str, stack: str) -> ExceptionRender:
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.traceback_parser = ExceptionParser()
+
+    def render(
+        self, exception: str, stack: str, parsed_exception: ParsedException
+    ) -> ExceptionRender:
+        # Reverse the frames so they show with more specific errors at the top of the page
+        parsed_exception.frames.reverse()
+
         # Exceptions can't be passed through as API types, so parents should pre-convert them to
         # strings before rendering
         return ExceptionRender(
             exception=exception,
             stack=stack,
+            formatting_style=self.traceback_parser.get_style_defs(),
+            parsed_exception=parsed_exception,
             metadata=Metadata(
                 title=f"Exception: {exception}",
                 links=[LinkAttribute(rel="stylesheet", href="/static/core_main.css")],

--- a/mountaineer/controllers/traceback.py
+++ b/mountaineer/controllers/traceback.py
@@ -1,8 +1,8 @@
-# NOTE: Only import on dev
 import inspect
 import linecache
 import traceback
 from pathlib import Path
+from uuid import UUID, uuid4
 
 from pydantic import BaseModel
 from pygments import highlight
@@ -12,6 +12,7 @@ from pygments.util import ClassNotFound
 
 
 class ExceptionFrame(BaseModel):
+    id: UUID
     file_name: str
     line_number: int
     function_name: str
@@ -106,6 +107,7 @@ class ExceptionParser:
 
             frames.append(
                 ExceptionFrame(
+                    id=uuid4(),
                     file_name=self.get_package_path(filename),
                     line_number=lineno or -1,
                     function_name=function,
@@ -122,7 +124,7 @@ class ExceptionParser:
 
     def get_style_defs(self) -> str:
         """Get CSS style definitions for syntax highlighting"""
-        return self.formatter.get_style_defs() # type: ignore
+        return self.formatter.get_style_defs()  # type: ignore
 
     def get_package_path(self, filepath: str) -> str:
         """

--- a/mountaineer/controllers/traceback.py
+++ b/mountaineer/controllers/traceback.py
@@ -2,34 +2,34 @@
 import inspect
 import linecache
 import traceback
-from dataclasses import dataclass
-from typing import Dict, List
+from pathlib import Path
 
+from pydantic import BaseModel
 from pygments import highlight
 from pygments.formatters import HtmlFormatter
 from pygments.lexers import PythonLexer, guess_lexer_for_filename
 from pygments.util import ClassNotFound
 
 
-@dataclass
-class ExceptionFrame:
+class ExceptionFrame(BaseModel):
     file_name: str
     line_number: int
     function_name: str
+    local_values: dict[str, str]
     code_context: str
-    local_values: Dict[str, str]
+    start_line_number: int
+    end_line_number: int
 
 
-@dataclass
-class ParsedException:
+class ParsedException(BaseModel):
     exc_type: str
     exc_value: str
-    frames: List[ExceptionFrame]
+    frames: list[ExceptionFrame]
 
 
 class ExceptionParser:
     def __init__(self):
-        self.formatter = HtmlFormatter(style="monokai")
+        self.formatter = HtmlFormatter(style="github-dark")
         self.python_lexer = PythonLexer()
 
     def _get_lexer(self, filename: str, code: str):
@@ -38,15 +38,31 @@ class ExceptionParser:
         except ClassNotFound:
             return self.python_lexer
 
-    def _get_context(self, filename: str, lineno: int, context_lines: int = 5) -> str:
+    def _get_context(
+        self, filename: str, lineno: int, context_lines: int = 5
+    ) -> tuple[str, int, int]:
+        """
+        Get the code context and starting line number for the given error location.
+
+        :param filename: Path to the source file
+        :param lineno: Line number where the error occurred
+        :param context_lines: Number of lines to show before and after the error
+
+        """
+        start_line = max(lineno - context_lines, 1)  # Don't go below line 1
+        end_line = lineno + context_lines + 1
+
         lines = []
-        for i in range(lineno - context_lines, lineno + context_lines + 1):
+        for i in range(start_line, end_line):
             line = linecache.getline(filename, i)
             if line:
                 lines.append(line)
         code = "".join(lines)
+
         lexer = self._get_lexer(filename, code)
-        return highlight(code, lexer, self.formatter)
+        highlighted = highlight(code, lexer, self.formatter)
+
+        return highlighted, start_line, end_line
 
     def _format_value(self, value: object) -> str:
         try:
@@ -84,15 +100,19 @@ class ExceptionParser:
                     if not key.startswith("__"):
                         locals_dict[key] = self._format_value(value)
 
-            code_context = self._get_context(filename, lineno)
+            code_context, start_line, end_line = self._get_context(
+                filename, lineno or -1
+            )
 
             frames.append(
                 ExceptionFrame(
-                    file_name=filename,
-                    line_number=lineno,
+                    file_name=self.get_package_path(filename),
+                    line_number=lineno or -1,
                     function_name=function,
                     code_context=code_context,
                     local_values=locals_dict,
+                    start_line_number=start_line,
+                    end_line_number=end_line,
                 )
             )
 
@@ -102,4 +122,39 @@ class ExceptionParser:
 
     def get_style_defs(self) -> str:
         """Get CSS style definitions for syntax highlighting"""
-        return self.formatter.get_style_defs()
+        return self.formatter.get_style_defs() # type: ignore
+
+    def get_package_path(self, filepath: str) -> str:
+        """
+        Extract the relevant package path from a full system path.
+
+        Args:
+            filepath: Full system path to a Python file
+
+        Returns:
+            Shortened path relative to closest parent package
+        """
+        path = Path(filepath)
+
+        # Find closest parent directory with __init__.py
+        current = path.parent
+        package_root = None
+
+        while True:
+            if (current / "__init__.py").exists():
+                package_root = current
+                current = current.parent
+            else:
+                break
+
+        if package_root is None:
+            # No package found, use filename only
+            return path.name
+
+        # Get relative path from package root
+        try:
+            rel_path = path.relative_to(package_root.parent)
+            return str(rel_path)
+        except ValueError:
+            # Fallback to filename if relative_to fails
+            return path.name

--- a/mountaineer/controllers/traceback.py
+++ b/mountaineer/controllers/traceback.py
@@ -1,0 +1,105 @@
+# NOTE: Only import on dev
+import inspect
+import linecache
+import traceback
+from dataclasses import dataclass
+from typing import Dict, List
+
+from pygments import highlight
+from pygments.formatters import HtmlFormatter
+from pygments.lexers import PythonLexer, guess_lexer_for_filename
+from pygments.util import ClassNotFound
+
+
+@dataclass
+class ExceptionFrame:
+    file_name: str
+    line_number: int
+    function_name: str
+    code_context: str
+    local_values: Dict[str, str]
+
+
+@dataclass
+class ParsedException:
+    exc_type: str
+    exc_value: str
+    frames: List[ExceptionFrame]
+
+
+class ExceptionParser:
+    def __init__(self):
+        self.formatter = HtmlFormatter(style="monokai")
+        self.python_lexer = PythonLexer()
+
+    def _get_lexer(self, filename: str, code: str):
+        try:
+            return guess_lexer_for_filename(filename, code)
+        except ClassNotFound:
+            return self.python_lexer
+
+    def _get_context(self, filename: str, lineno: int, context_lines: int = 5) -> str:
+        lines = []
+        for i in range(lineno - context_lines, lineno + context_lines + 1):
+            line = linecache.getline(filename, i)
+            if line:
+                lines.append(line)
+        code = "".join(lines)
+        lexer = self._get_lexer(filename, code)
+        return highlight(code, lexer, self.formatter)
+
+    def _format_value(self, value: object) -> str:
+        try:
+            if inspect.isclass(value) or inspect.isfunction(value):
+                return str(value)
+            formatted = highlight(repr(value), self.python_lexer, self.formatter)
+            return formatted
+        except Exception:
+            return str(value)
+
+    def parse_exception(self, exc: BaseException) -> ParsedException:
+        frames = []
+        tb = traceback.extract_tb(exc.__traceback__)
+
+        for frame_summary in tb:
+            filename = frame_summary.filename
+            lineno = frame_summary.lineno
+            function = frame_summary.name
+
+            # Get locals from the frame
+            frame = None
+            tb_frame = exc.__traceback__
+            while tb_frame is not None:
+                if (
+                    tb_frame.tb_frame.f_code.co_filename == filename
+                    and tb_frame.tb_lineno == lineno
+                ):
+                    frame = tb_frame.tb_frame
+                    break
+                tb_frame = tb_frame.tb_next
+
+            locals_dict = {}
+            if frame is not None:
+                for key, value in frame.f_locals.items():
+                    if not key.startswith("__"):
+                        locals_dict[key] = self._format_value(value)
+
+            code_context = self._get_context(filename, lineno)
+
+            frames.append(
+                ExceptionFrame(
+                    file_name=filename,
+                    line_number=lineno,
+                    function_name=function,
+                    code_context=code_context,
+                    local_values=locals_dict,
+                )
+            )
+
+        return ParsedException(
+            exc_type=exc.__class__.__name__, exc_value=str(exc), frames=frames
+        )
+
+    def get_style_defs(self) -> str:
+        """Get CSS style definitions for syntax highlighting"""
+        return self.formatter.get_style_defs()

--- a/mountaineer/views/core/exception/page.tsx
+++ b/mountaineer/views/core/exception/page.tsx
@@ -3,11 +3,24 @@ import { useServer } from "./_server/useServer";
 
 const Page = () => {
   const serverState = useServer();
+  const timestamp = new Date().toISOString();
 
   return (
-    <div className="mx-auto max-w-3xl whitespace-pre-wrap rounded bg-red-50 p-4 text-red-700 ring-1 ring-inset ring-red-600/20">
-      <div className="font-bold">{serverState.exception}</div>
-      <div className="mt-4">{serverState.stack}</div>
+    <div className="mx-20 space-y-6 rounded-lg bg-zinc-50 p-8 shadow-lg ring-1 ring-zinc-200">
+      <div className="space-y-2">
+        <div className="text-sm text-zinc-500 font-mono">
+          Timestamp: {timestamp}
+          <br />
+          Environment: {process.env.NODE_ENV}
+        </div>
+        <h1 className="font-mono text-xl font-semibold text-zinc-800">
+          {serverState.exception}
+        </h1>
+      </div>
+
+      <pre className="mt-6 overflow-auto rounded bg-zinc-900 p-4 font-mono text-sm text-zinc-200">
+        {serverState.stack}
+      </pre>
     </div>
   );
 };

--- a/mountaineer/views/core/exception/page.tsx
+++ b/mountaineer/views/core/exception/page.tsx
@@ -6,22 +6,79 @@ const Page = () => {
   const timestamp = new Date().toISOString();
 
   return (
-    <div className="mx-20 space-y-6 rounded-lg bg-zinc-50 p-8 shadow-lg ring-1 ring-zinc-200">
-      <div className="space-y-2">
-        <div className="text-sm text-zinc-500 font-mono">
-          Timestamp: {timestamp}
-          <br />
-          Environment: {process.env.NODE_ENV}
+    <>
+      <style>{serverState.formatting_style}</style>
+      <style>{`
+        .highlight pre {
+          line-height: inherit !important;
+          }
+        `}</style>
+      <div className="mx-20 space-y-6 rounded-lg p-8">
+        <div className="space-y-2">
+          <div className="text-sm text-zinc-500 font-mono">
+            Timestamp: {timestamp}
+            <br />
+            Environment: {process.env.NODE_ENV}
+          </div>
+          <h1 className="font-mono text-xl font-semibold text-zinc-800">
+            {serverState.exception}
+          </h1>
         </div>
-        <h1 className="font-mono text-xl font-semibold text-zinc-800">
-          {serverState.exception}
-        </h1>
-      </div>
+        <div className="space-y-4">
+          <div className="flex items-center space-x-1 text-red-600 font-semibold">
+            <span>{serverState.parsed_exception.exc_type}:</span>
+            <span>{serverState.parsed_exception.exc_value}</span>
+          </div>
 
-      <pre className="mt-6 overflow-auto rounded bg-zinc-900 p-4 font-mono text-sm text-zinc-200">
-        {serverState.stack}
-      </pre>
-    </div>
+          {serverState.parsed_exception.frames.map((frame, index) => (
+            <div
+              key={index}
+              className="border rounded-lg overflow-hidden bg-white"
+            >
+              {/* File header */}
+              <div className="bg-gray-100 px-4 py-2 border-b flex justify-between items-center">
+                <div className="font-mono text-sm text-gray-700">
+                  {frame.file_name}:{frame.line_number}
+                </div>
+                <span className="px-3 py-1 bg-blue-500 text-white rounded text-sm">
+                  {frame.function_name}
+                </span>
+              </div>
+
+              {/* Code section */}
+              <div className="flex">
+                {/* Line numbers */}
+                <div className="py-4 px-3 text-right font-mono text-sm bg-gray-50 text-gray-500 select-none border-r">
+                  {Array.from(
+                    {
+                      length: frame.end_line_number - frame.start_line_number,
+                    },
+                    (_, i) => (
+                      <div
+                        key={i}
+                        className={`leading-6 ${
+                          frame.start_line_number + i === frame.line_number
+                            ? "bg-red-100 text-red-600 font-semibold px-2 -mx-2"
+                            : ""
+                        }`}
+                      >
+                        {frame.start_line_number + i}
+                      </div>
+                    ),
+                  )}
+                </div>
+
+                {/* Code content */}
+                <div
+                  className="flex-1 p-4 overflow-x-auto font-mono text-sm bg-gray-800 !leading-6"
+                  dangerouslySetInnerHTML={{ __html: frame.code_context }}
+                />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </>
   );
 };
 

--- a/mountaineer/views/core/exception/page.tsx
+++ b/mountaineer/views/core/exception/page.tsx
@@ -1,8 +1,9 @@
-import React from "react";
+import React, { useState } from "react";
 import { useServer } from "./_server/useServer";
 
 const Page = () => {
   const serverState = useServer();
+  const [showFrame, setShowFrame] = useState<string | null>(null);
   const timestamp = new Date().toISOString();
 
   return (
@@ -13,7 +14,7 @@ const Page = () => {
           line-height: inherit !important;
           }
         `}</style>
-      <div className="mx-20 space-y-6 rounded-lg p-8">
+      <div className="md:mx-20 space-y-6 rounded-lg p-8">
         <div className="space-y-2">
           <div className="text-sm text-zinc-500 font-mono">
             Timestamp: {timestamp}
@@ -31,49 +32,98 @@ const Page = () => {
           </div>
 
           {serverState.parsed_exception.frames.map((frame, index) => (
-            <div
-              key={index}
-              className="border rounded-lg overflow-hidden bg-white"
-            >
-              {/* File header */}
-              <div className="bg-gray-100 px-4 py-2 border-b flex justify-between items-center">
-                <div className="font-mono text-sm text-gray-700">
-                  {frame.file_name}:{frame.line_number}
+            <div key={frame.id}>
+              <div className="border rounded-lg overflow-hidden bg-white">
+                {/* File header */}
+                <div className="bg-gray-100 px-4 py-2 border-b flex justify-between items-center">
+                  <div className="font-mono text-sm text-gray-700">
+                    {frame.file_name}:{frame.line_number}
+                  </div>
+                  <button
+                    onClick={() => {
+                      if (showFrame !== frame.id) {
+                        setShowFrame(frame.id);
+                      } else {
+                        setShowFrame(null);
+                      }
+                    }}
+                    className="px-3 py-1 bg-blue-500 hover:bg-blue-600 transition-colors text-white rounded text-sm"
+                  >
+                    {frame.function_name}
+                  </button>
                 </div>
-                <span className="px-3 py-1 bg-blue-500 text-white rounded text-sm">
-                  {frame.function_name}
-                </span>
+
+                {/* Code section */}
+                <div className="flex">
+                  {/* Line numbers */}
+                  <div className="py-4 px-3 text-right font-mono text-sm bg-gray-50 text-gray-500 select-none border-r">
+                    {Array.from(
+                      {
+                        length: frame.end_line_number - frame.start_line_number,
+                      },
+                      (_, i) => (
+                        <div
+                          key={i}
+                          className={`leading-6 ${
+                            frame.start_line_number + i === frame.line_number
+                              ? "bg-red-100 text-red-600 font-semibold px-2 -mx-2"
+                              : ""
+                          }`}
+                        >
+                          {frame.start_line_number + i}
+                        </div>
+                      ),
+                    )}
+                  </div>
+
+                  {/* Code content */}
+                  <div
+                    className="flex-1 p-4 overflow-x-auto font-mono text-sm bg-gray-800 !leading-6"
+                    dangerouslySetInnerHTML={{ __html: frame.code_context }}
+                  />
+                </div>
               </div>
 
-              {/* Code section */}
-              <div className="flex">
-                {/* Line numbers */}
-                <div className="py-4 px-3 text-right font-mono text-sm bg-gray-50 text-gray-500 select-none border-r">
-                  {Array.from(
-                    {
-                      length: frame.end_line_number - frame.start_line_number,
-                    },
-                    (_, i) => (
-                      <div
-                        key={i}
-                        className={`leading-6 ${
-                          frame.start_line_number + i === frame.line_number
-                            ? "bg-red-100 text-red-600 font-semibold px-2 -mx-2"
-                            : ""
-                        }`}
+              {/* Local variables */}
+              {showFrame === frame.id && (
+                <div className="mt-4 rounded-lg overflow-hidden border border-gray-200 shadow-sm mb-12">
+                  <div className="bg-gray-100 p-4 font-mono text-sm font-bold text-gray-700 border-b flex items-center">
+                    <div className="grow">Local Variables</div>
+                    <button
+                      onClick={() => setShowFrame(null)}
+                      className="py-1 px-2 -m-2 hover:bg-gray-500/10 rounded"
+                    >
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        strokeWidth={1.5}
+                        stroke="currentColor"
+                        className="size-6"
                       >
-                        {frame.start_line_number + i}
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          d="M6 18 18 6M6 6l12 12"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                  <div className="divide-y divide-gray-200">
+                    {Object.entries(frame.local_values).map(([key, html]) => (
+                      <div key={key} className="flex">
+                        <div className="w-48 shrink-0 bg-gray-50 p-4 font-mono text-sm text-gray-600 border-r">
+                          {key}
+                        </div>
+                        <div
+                          className="flex-1 p-4 overflow-x-auto font-mono text-sm bg-gray-700"
+                          dangerouslySetInnerHTML={{ __html: html }}
+                        />
                       </div>
-                    ),
-                  )}
+                    ))}
+                  </div>
                 </div>
-
-                {/* Code content */}
-                <div
-                  className="flex-1 p-4 overflow-x-auto font-mono text-sm bg-gray-800 !leading-6"
-                  dangerouslySetInnerHTML={{ __html: frame.code_context }}
-                />
-              </div>
+              )}
             </div>
           ))}
         </div>

--- a/mountaineer/views/core/layout.tsx
+++ b/mountaineer/views/core/layout.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode } from "react";
 
 const Layout = ({ children }: { children: ReactNode }) => {
-  return <div className="p-4">{children}</div>;
+  return <div className="p-4 bg-zinc-50">{children}</div>;
 };
 
 export default Layout;

--- a/poetry.lock
+++ b/poetry.lock
@@ -1128,6 +1128,17 @@ slack = ["slack-sdk"]
 telegram = ["requests"]
 
 [[package]]
+name = "types-docutils"
+version = "0.21.0.20241005"
+description = "Typing stubs for docutils"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "types-docutils-0.21.0.20241005.tar.gz", hash = "sha256:48f804a2b50da3a1b1681c4ca1b6184416a6e4129e302d15c44e9d97c59b3365"},
+    {file = "types_docutils-0.21.0.20241005-py3-none-any.whl", hash = "sha256:4d9021422f2f3fca8b0726fb8949395f66a06c0d951479eb3b1387d75b134430"},
+]
+
+[[package]]
 name = "types-psycopg2"
 version = "2.9.21.20240311"
 description = "Typing stubs for psycopg2"
@@ -1137,6 +1148,21 @@ files = [
     {file = "types-psycopg2-2.9.21.20240311.tar.gz", hash = "sha256:722945dffa6a729bebc660f14137f37edfcead5a2c15eb234212a7d017ee8072"},
     {file = "types_psycopg2-2.9.21.20240311-py3-none-any.whl", hash = "sha256:2e137ae2b516ee0dbaab6f555086b6cfb723ba4389d67f551b0336adf4efcf1b"},
 ]
+
+[[package]]
+name = "types-pygments"
+version = "2.18.0.20240506"
+description = "Typing stubs for Pygments"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "types-Pygments-2.18.0.20240506.tar.gz", hash = "sha256:4b4c37812c87bbde687dbf27adf5bac593745a321e57f678dbc311571ba2ac9d"},
+    {file = "types_Pygments-2.18.0.20240506-py3-none-any.whl", hash = "sha256:11c90bc1737c9af55e5569558b88df7c2233e12325cb516215f722271444e91d"},
+]
+
+[package.dependencies]
+types-docutils = "*"
+types-setuptools = "*"
 
 [[package]]
 name = "types-setuptools"
@@ -1476,4 +1502,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "88748acc66822fad7ff3e70686f9036c179ef9394d32b3a44513176eaf5b0800"
+content-hash = "34906a1f5b0b9683a3c9e995b234a8c0459bb0e0e23caa795f01793c3b0bc94f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ pyright = "^1.1.352"
 tqdm = "^4.66.2"
 toml = "^0.10.2"
 types-toml = "^0.10.8.20240310"
+types-pygments = "^2.18.0.20240506"
 
 [build-system]
 requires = ["maturin>=1.3.0"]


### PR DESCRIPTION
This PR introduces an in-browser debugging workflow for Python exceptions. Our new exception parser lives in `controllers.hotreload` and is responsible for chunking out exceptions from different files and marking them up with syntax highlighting. This was inspired by the super useful traceback interface that we use in the backend from [rich](https://github.com/Textualize/rich/tree/master).

In addition to a simple stack trace, we also:
- Chunk out more context for each frame within the stack
- Parse the local variables that are still attached to the frame. To dig into what context caused the error, you can click on the function name to reveal the variable window.

<img width="1326" alt="Screenshot 2024-11-22 at 1 17 44 PM" src="https://github.com/user-attachments/assets/7f8f6db8-a8d9-4e52-94d3-480b454cef55">

<img width="1326" alt="Screenshot 2024-11-22 at 1 17 46 PM" src="https://github.com/user-attachments/assets/cd1588ce-7d15-4a95-8e5b-ce5b2ffa6642">
