### PR TITLE
Automatically add sha to static artifacts

### DIFF
--- a/mountaineer/__tests__/client_builder/test_builder.py
+++ b/mountaineer/__tests__/client_builder/test_builder.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel
 
 from mountaineer.actions import sideeffect
 from mountaineer.app import AppController
-from mountaineer.client_builder.builder import ClientBuilder
+from mountaineer.client_builder.builder import APIBuilder
 from mountaineer.controller import ControllerBase
 from mountaineer.controller_layout import LayoutControllerBase
 from mountaineer.render import RenderBase
@@ -60,30 +60,30 @@ def simple_app_controller(
 
 @pytest.fixture
 def builder(simple_app_controller: AppController):
-    return ClientBuilder(simple_app_controller)
+    return APIBuilder(simple_app_controller)
 
 
-def test_generate_static_files(builder: ClientBuilder):
+def test_generate_static_files(builder: APIBuilder):
     builder.generate_static_files()
 
 
-def test_generate_model_definitions(builder: ClientBuilder):
+def test_generate_model_definitions(builder: APIBuilder):
     builder.generate_model_definitions()
 
 
-def test_generate_action_definitions(builder: ClientBuilder):
+def test_generate_action_definitions(builder: APIBuilder):
     builder.generate_action_definitions()
 
 
-def test_generate_view_definitions(builder: ClientBuilder):
+def test_generate_view_definitions(builder: APIBuilder):
     builder.generate_link_shortcuts()
 
 
-def test_generate_link_aggregator(builder: ClientBuilder):
+def test_generate_link_aggregator(builder: APIBuilder):
     builder.generate_link_aggregator()
 
 
-def test_generate_link_aggregator_ignores_layout(builder: ClientBuilder):
+def test_generate_link_aggregator_ignores_layout(builder: APIBuilder):
     class ExampleLayout(LayoutControllerBase):
         view_path = "/test.tsx"
 
@@ -100,12 +100,12 @@ def test_generate_link_aggregator_ignores_layout(builder: ClientBuilder):
     assert "ExampleDetailControllerGetLinks" in global_links
 
 
-def test_generate_view_servers(builder: ClientBuilder):
+def test_generate_view_servers(builder: APIBuilder):
     builder.generate_view_servers()
 
 
 @pytest.mark.parametrize("empty_links", [True, False])
-def test_generate_index_file_ignores_empty(builder: ClientBuilder, empty_links: bool):
+def test_generate_index_file_ignores_empty(builder: APIBuilder, empty_links: bool):
     # Create some stub files. We simulate a case where the links file
     # is created but empty
     file_contents = "import React from 'react';\n"
@@ -138,13 +138,13 @@ def test_generate_index_file_ignores_empty(builder: ClientBuilder, empty_links: 
         ]
 
 
-def test_cache_is_outdated_no_cache(builder: ClientBuilder):
+def test_cache_is_outdated_no_cache(builder: APIBuilder):
     # No cache
     builder.build_cache = None
     assert builder.cache_is_outdated() is True
 
 
-def test_cache_is_outdated_no_existing_data(builder: ClientBuilder, tmp_path: Path):
+def test_cache_is_outdated_no_existing_data(builder: APIBuilder, tmp_path: Path):
     builder.build_cache = tmp_path
 
     assert builder.cache_is_outdated() is True
@@ -159,7 +159,7 @@ def test_cache_is_outdated_no_existing_data(builder: ClientBuilder, tmp_path: Pa
 
 
 def test_cache_is_outdated_existing_data(
-    builder: ClientBuilder,
+    builder: APIBuilder,
     tmp_path: Path,
     home_controller: ExampleHomeController,
     detail_controller: ExampleDetailController,
@@ -198,7 +198,7 @@ def test_cache_is_outdated_existing_data(
 
 
 def test_cache_is_outdated_url_change(
-    builder: ClientBuilder,
+    builder: APIBuilder,
     tmp_path: Path,
     home_controller: ExampleHomeController,
     detail_controller: ExampleDetailController,
@@ -243,7 +243,7 @@ def test_cache_is_outdated_url_change(
 
 
 def test_validate_unique_paths_exact_definition(
-    builder: ClientBuilder,
+    builder: APIBuilder,
 ):
     """
     Two controllers can't manage the same view path.
@@ -267,7 +267,7 @@ def test_validate_unique_paths_exact_definition(
 
 
 def test_validate_unique_paths_conflicting_layout(
-    builder: ClientBuilder,
+    builder: APIBuilder,
 ):
     """
     Layouts need to be placed in their own directory. Even if the literal paths
@@ -291,7 +291,7 @@ def test_validate_unique_paths_conflicting_layout(
 
 
 def test_generate_controller_schema_sideeffect_required_attributes(
-    builder: ClientBuilder,
+    builder: APIBuilder,
 ):
     """
     Ensure that we treat @sideeffect and @passthrough return models like

--- a/mountaineer/__tests__/client_compiler/test_compile.py
+++ b/mountaineer/__tests__/client_compiler/test_compile.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+
+from mountaineer.app import AppController
+from mountaineer.client_compiler.compile import ClientCompiler
+
+
+def test_build_static_metadata(tmpdir: Path):
+    app = AppController(view_root=tmpdir)
+    compiler = ClientCompiler(app=app)
+
+    # Write test files to the view path to determine if we're able
+    # to parse the whole file tree
+    static_dir = compiler.view_root.get_managed_static_dir()
+
+    (static_dir / "test_css.css").write_text("CSS_TEXT")
+
+    (static_dir / "nested").mkdir(exist_ok=True)
+    (static_dir / "nested" / "test_nested.css").write_text("CSS_TEXT")
+
+    # File contents are the same - shas should be the same as well
+    metadata = compiler._build_static_metadata()
+    assert "test_css.css" in metadata.static_artifact_shas
+    assert "nested/test_nested.css" in metadata.static_artifact_shas
+    assert (
+        metadata.static_artifact_shas["test_css.css"]
+        == metadata.static_artifact_shas["nested/test_nested.css"]
+    )

--- a/mountaineer/app.py
+++ b/mountaineer/app.py
@@ -26,6 +26,7 @@ from mountaineer.actions import (
 from mountaineer.actions.fields import FunctionMetadata
 from mountaineer.annotation_helpers import MountaineerUnsetValue
 from mountaineer.client_compiler.base import APIBuilderBase
+from mountaineer.client_compiler.build_metadata import BuildMetadata
 from mountaineer.config import ConfigBase
 from mountaineer.controller import ControllerBase
 from mountaineer.controller_layout import LayoutControllerBase
@@ -214,7 +215,8 @@ class AppController:
             render_overhead_by_controller = {}
             render_output = {}
             for node in direct_hierarchy:
-                # Must be a layout-only component
+                # If not set, must be a layout-only component. In this case we don't
+                # need to do any rendering of internal data
                 if not node.controller:
                     continue
 
@@ -359,7 +361,7 @@ class AppController:
         # This allows each view to avoid having to find these on disk, as well as gives
         # a proactive error if any view will be unable to render when their script files
         # are missing
-        if self.config and self.config.ENVIRONMENT != "development":
+        if self.development_enabled:
             controller.resolve_paths(self.view_root, force=True)
             if not controller.bundled_scripts:
                 raise ValueError(
@@ -596,11 +598,15 @@ class AppController:
             metadata = page_metadata.metadata
             if not metadata.ignore_global_metadata and self.global_metadata:
                 metadata = metadata.merge(self.global_metadata)
-            header_str = "\n".join(metadata.build_header())
+            header_str = "\n".join(
+                metadata.build_header(build_metadata=self.get_build_metadata())
+            )
         else:
             if self.global_metadata:
                 metadata = self.global_metadata
-                header_str = "\n".join(metadata.build_header())
+                header_str = "\n".join(
+                    metadata.build_header(build_metadata=self.get_build_metadata())
+                )
             else:
                 header_str = ""
 
@@ -969,3 +975,27 @@ class AppController:
             if controller_definition.controller == controller:
                 return controller_definition
         raise ValueError(f"Controller {controller} not found")
+
+    def get_build_metadata(self):
+        """
+        Will cache the build metadata in production but not in development, since
+        we expect production developments will compile their metadata once and then
+        use it for all endpoints.
+
+        """
+        if not self.development_enabled:
+            # Determine if we've already cached the build
+            if hasattr(self, "_build_metadata"):
+                return getattr(self, "_build_metadata")
+
+        metadata_path = self.view_root.get_managed_metadata_dir() / "metadata.json"
+        if not metadata_path.exists():
+            return None
+        self._build_metadata = BuildMetadata.model_validate_json(
+            metadata_path.read_text()
+        )
+        return self._build_metadata
+
+    @property
+    def development_enabled(self):
+        return self.config and self.config.ENVIRONMENT != "development"

--- a/mountaineer/app.py
+++ b/mountaineer/app.py
@@ -25,7 +25,7 @@ from mountaineer.actions import (
 )
 from mountaineer.actions.fields import FunctionMetadata
 from mountaineer.annotation_helpers import MountaineerUnsetValue
-from mountaineer.client_compiler.base import ClientBuilderBase
+from mountaineer.client_compiler.base import APIBuilderBase
 from mountaineer.config import ConfigBase
 from mountaineer.controller import ControllerBase
 from mountaineer.controller_layout import LayoutControllerBase
@@ -93,7 +93,7 @@ class AppController:
 
     """
 
-    builders: list[ClientBuilderBase]
+    builders: list[APIBuilderBase]
     global_metadata: Metadata | None
 
     def __init__(
@@ -103,7 +103,7 @@ class AppController:
         version: str = "0.1.0",
         view_root: Path | None = None,
         global_metadata: Metadata | None = None,
-        custom_builders: list[ClientBuilderBase] | None = None,
+        custom_builders: list[APIBuilderBase] | None = None,
         config: ConfigBase | None = None,
         fastapi_args: dict[str, Any] | None = None,
     ):

--- a/mountaineer/app_manager.py
+++ b/mountaineer/app_manager.py
@@ -11,7 +11,7 @@ from types import ModuleType
 from fastapi import Request
 
 from mountaineer.app import AppController
-from mountaineer.client_builder.builder import ClientBuilder
+from mountaineer.client_builder.builder import APIBuilder
 from mountaineer.client_compiler.compile import ClientCompiler
 from mountaineer.controllers.exception_controller import (
     ExceptionController,
@@ -55,7 +55,7 @@ class DevAppManager:
         self.mount_exceptions(app_controller)
 
         global_build_cache = Path(mkdtemp())
-        self.js_compiler = ClientBuilder(
+        self.js_compiler = APIBuilder(
             app_controller,
             live_reload_port=live_reload_port,
             build_cache=global_build_cache,

--- a/mountaineer/cli.py
+++ b/mountaineer/cli.py
@@ -16,7 +16,7 @@ from mountaineer.app_manager import (
     find_packages_with_prefix,
     package_path_to_module,
 )
-from mountaineer.client_builder.builder import ClientBuilder
+from mountaineer.client_builder.builder import APIBuilder
 from mountaineer.console import CONSOLE
 from mountaineer.constants import KNOWN_JS_EXTENSIONS
 from mountaineer.hotreload import HotReloader
@@ -58,7 +58,7 @@ def handle_watch(
     global_build_cache = Path(mkdtemp())
 
     app_manager = DevAppManager.from_webcontroller(webcontroller)
-    js_compiler = ClientBuilder(
+    js_compiler = APIBuilder(
         app_manager.app_controller,
         live_reload_port=None,
         build_cache=global_build_cache,

--- a/mountaineer/client_builder/builder.py
+++ b/mountaineer/client_builder/builder.py
@@ -45,7 +45,7 @@ class RenderSpec:
     spec: dict[Any, Any] | None
 
 
-class ClientBuilder:
+class APIBuilder:
     """
     Main entrypoint for building the auto-generated typescript code. This includes
     the server provided API used by useServer.

--- a/mountaineer/client_compiler/base.py
+++ b/mountaineer/client_compiler/base.py
@@ -19,7 +19,7 @@ class ClientBundleMetadata:
     live_reload_port: int | None = None
 
 
-class ClientBuilderBase(ABC):
+class APIBuilderBase(ABC):
     """
     Base class for client builders. When mounted to an AppController, these build plugins
     will be called for every file defined in the view/app directory. It's up to the plugin

--- a/mountaineer/client_compiler/build_metadata.py
+++ b/mountaineer/client_compiler/build_metadata.py
@@ -1,0 +1,11 @@
+from pydantic import BaseModel
+
+
+class BuildMetadata(BaseModel):
+    """
+    Metadata added during compile_time that should be maintained in the
+    bundle for production hosting.
+
+    """
+
+    static_artifact_shas: dict[str, str]

--- a/mountaineer/client_compiler/compile.py
+++ b/mountaineer/client_compiler/compile.py
@@ -4,25 +4,14 @@ from shutil import move as shutil_move
 from tempfile import mkdtemp
 from time import monotonic_ns
 
-from pydantic import BaseModel
-
 from mountaineer.app import AppController
 from mountaineer.client_compiler.base import ClientBundleMetadata
+from mountaineer.client_compiler.build_metadata import BuildMetadata
 from mountaineer.client_compiler.exceptions import BuildProcessException
 from mountaineer.console import CONSOLE
 from mountaineer.io import gather_with_concurrency
 from mountaineer.logging import LOGGER
 from mountaineer.paths import ManagedViewPath
-
-
-class ClientCompilerMetadata(BaseModel):
-    """
-    Metadata added during compile_time that should be maintained in the
-    bundle for production hosting.
-
-    """
-
-    static_artifact_shas: dict[str, str]
 
 
 class ClientCompiler:
@@ -105,7 +94,7 @@ class ClientCompiler:
         # should get the md5 hash of the content for our archive
         metadata = self._build_static_metadata()
         (self.view_root.get_managed_metadata_dir() / "metadata.json").write_text(
-            metadata.dump_json()
+            metadata.model_dump_json()
         )
 
     def _init_builders(self):
@@ -217,4 +206,4 @@ class ClientCompiler:
                     file_contents
                 ).hexdigest()
 
-        return ClientCompilerMetadata(static_artifact_shas=static_artifact_shas)
+        return BuildMetadata(static_artifact_shas=static_artifact_shas)

--- a/mountaineer/client_compiler/postcss.py
+++ b/mountaineer/client_compiler/postcss.py
@@ -7,14 +7,14 @@ from time import monotonic_ns
 
 from rich.progress import Progress, SpinnerColumn, TimeElapsedColumn
 
-from mountaineer.client_compiler.base import ClientBuilderBase
+from mountaineer.client_compiler.base import APIBuilderBase
 from mountaineer.client_compiler.exceptions import BuildProcessException
 from mountaineer.console import CONSOLE
 from mountaineer.logging import LOGGER
 from mountaineer.paths import ManagedViewPath
 
 
-class PostCSSBundler(ClientBuilderBase):
+class PostCSSBundler(APIBuilderBase):
     """
     Support PostCSS processing for CSS files.
 

--- a/mountaineer/hotreload.py
+++ b/mountaineer/hotreload.py
@@ -10,9 +10,9 @@ from importlib.abc import SourceLoader
 from pathlib import Path
 from types import ModuleType
 
-from mountaineer.logging import setup_logger
+from mountaineer.logging import setup_internal_logger
 
-logger = setup_logger(__name__)
+logger = setup_internal_logger(__name__)
 
 
 @dataclass

--- a/mountaineer/logging.py
+++ b/mountaineer/logging.py
@@ -81,8 +81,18 @@ def log_time_duration(message: str):
     LOGGER.debug(f"{message} : Took {(monotonic_ns() - start)/1e9:.2f}s")
 
 
-# Our global logger should only surface warnings and above by default
-LOGGER = setup_logger(
-    __name__,
-    log_level=VERBOSITY_MAPPING[environ.get("MOUNTAINEER_LOG_LEVEL", "WARNING")],
-)
+def setup_internal_logger(name: str):
+    """ "
+    Our global logger should only surface warnings and above by default.
+
+    To adjust Mountaineer logging, set the MOUNTAINEER_LOG_LEVEL environment
+    variable in your local session. By default it is set to WARNING and above.
+
+    """
+    return setup_logger(
+        name,
+        log_level=VERBOSITY_MAPPING[environ.get("MOUNTAINEER_LOG_LEVEL", "WARNING")],
+    )
+
+
+LOGGER = setup_internal_logger(__name__)

--- a/mountaineer/paths.py
+++ b/mountaineer/paths.py
@@ -114,6 +114,20 @@ class ManagedViewPath(type(Path())):  # type: ignore
             path.mkdir(exist_ok=True)
         return path
 
+    def get_managed_metadata_dir(
+        self, tmp_build: bool = False, create_dir: bool = True
+    ):
+        # Only root paths can have SSR directories
+        if not self.is_root_link:
+            raise ValueError(
+                "Cannot get SSR directory from a non-root linked view path"
+            )
+        path = self.get_managed_dir_common("_metadata", create_dir=create_dir)
+        if tmp_build:
+            path = path / "tmp"
+            path.mkdir(exist_ok=True)
+        return path
+
     def get_managed_dir_common(
         self,
         managed_dir: str,


### PR DESCRIPTION
Websites typically want aggressive caching policies on their static directory, since support files like css/js only change during a deployment of a new version. While it's possible to handle this in other ways (ie. 304 Not Modified) it's cleaner to handle this at the framework level. The new logic in this PR will analyze the _static folder at build time, cache the current version of the file sha, and inject this into any `LinkAttributes` that import this file.

Closes out https://github.com/piercefreeman/mountaineer/issues/133