### PR TITLE
Pin maturin to use metadata 2.3

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1502,4 +1502,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "34906a1f5b0b9683a3c9e995b234a8c0459bb0e0e23caa795f01793c3b0bc94f"
+content-hash = "0598ebbf3c38b117643e2504e034e35c5e64599db7aadfd76957fe33141bc999"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,10 @@ mypy = "^1.8.0"
 pytest = "^7.4.4"
 ruff = "^0.1.14"
 types-setuptools = "^69.0.0.20240125"
-maturin = "^1.4.0"
+
+# Pin for maturin until the latest pypi distribution action supports
+# metadata 2.4: https://github.com/PyO3/maturin/issues/2335
+maturin = "<1.7.6"
 types-tqdm = "^4.66.0.20240106"
 pytest-asyncio = "^0.23.4"
 pyinstrument = "^4.6.2"
@@ -44,7 +47,9 @@ types-toml = "^0.10.8.20240310"
 types-pygments = "^2.18.0.20240506"
 
 [build-system]
-requires = ["maturin>=1.3.0"]
+# Pin for maturin until the latest pypi distribution action supports
+# metadata 2.4: https://github.com/PyO3/maturin/issues/2335
+requires = ["maturin>=1.3.0,<1.7.6"]
 build-backend = "maturin"
 
 [tool.mypy]


### PR DESCRIPTION
Our wheel publishing is currently failing with:

```
Checking dist/mountaineer-0.8.0.dev3-cp310-cp310-macosx_10_12_x86_64.whl: ERROR    InvalidDistribution: Metadata is missing required fields: Name,        
         Version.                                                               
         Make sure the distribution includes the files where those fields are   
         specified, and is using a supported Metadata-Version: 1.0, 1.1, 1.2,   
         2.0, 2.1, 2.2, 2.3.
```

This was caused by maturin's bump to 1.7.6, which now creates wheels that use metadata 2.4. Twine doesn't yet support this format so throws an error upon validation.

Pinned maturin ticket: https://github.com/PyO3/maturin/issues/2335

Our CI pipeline automatically pulls the latest maturin version by inspecting any constraints placed within pypi - currently we just had any version `maturin>=1.3.0` so CI was picking up the latest release before our own local development was:

https://github.com/PyO3/maturin-action/blob/bf4a58861cd84d5897c28635f47999d9882cdf33/src/index.ts#L352

This PR locks the maturin version to just below 1.7.6 until twine supports validation of higher numbered packages.