### PR TITLE
Structure 422 unprocessable entities & support typehinted headers

### DIFF
--- a/mountaineer/__tests__/test_app.py
+++ b/mountaineer/__tests__/test_app.py
@@ -15,7 +15,11 @@ from mountaineer.app import AppController, ControllerDefinition
 from mountaineer.config import ConfigBase
 from mountaineer.controller import ControllerBase
 from mountaineer.controller_layout import LayoutControllerBase
-from mountaineer.exceptions import APIException, RequestValidationError
+from mountaineer.exceptions import (
+    APIException,
+    RequestValidationError,
+    RequestValidationFailure,
+)
 from mountaineer.render import Metadata, RenderBase
 
 
@@ -325,6 +329,7 @@ async def test_parse_validation_exception():
     exception = exc_info.value
     assert len(exception.internal_model.errors) == 1  # type: ignore
     error = exception.internal_model.errors[0]  # type: ignore
+    assert isinstance(error, RequestValidationFailure)
 
     # Verify the error is parsed correctly
     assert error.error_type == "int_parsing"

--- a/mountaineer/__tests__/test_app.py
+++ b/mountaineer/__tests__/test_app.py
@@ -4,16 +4,18 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-from fastapi import APIRouter, FastAPI, status
+from fastapi import APIRouter, FastAPI, Request, status
+from fastapi.exceptions import RequestValidationError as RequestValidationErrorRaw
 from fastapi.responses import RedirectResponse
 from fastapi.routing import APIRoute
 from fastapi.testclient import TestClient
+from pydantic import BaseModel, ValidationError
 
 from mountaineer.app import AppController, ControllerDefinition
 from mountaineer.config import ConfigBase
 from mountaineer.controller import ControllerBase
 from mountaineer.controller_layout import LayoutControllerBase
-from mountaineer.exceptions import APIException
+from mountaineer.exceptions import APIException, RequestValidationError
 from mountaineer.render import Metadata, RenderBase
 
 
@@ -285,3 +287,47 @@ def test_explicit_response_metadata():
         response = client.get("/redirect", follow_redirects=False)
         assert response.status_code == status.HTTP_307_TEMPORARY_REDIRECT
         assert response.headers["location"] == "/"
+
+
+@pytest.mark.asyncio
+async def test_parse_validation_exception():
+    """
+    Test that FastAPI validation errors are correctly parsed into our RequestValidationError format.
+    """
+
+    class TestModel(BaseModel):
+        age: int
+
+    app_controller = AppController(view_root=Path(""))
+
+    # Create a test request with invalid data
+    request = Request(
+        scope={
+            "type": "http",
+            "method": "POST",
+            "path": "/",
+            "headers": [],
+        }
+    )
+
+    # Create a validation error by trying to validate invalid data
+    raw_error: RequestValidationErrorRaw | None = None
+    try:
+        TestModel.model_validate({"age": "not_a_number"})
+    except ValidationError as e:
+        raw_error = RequestValidationErrorRaw(errors=e.errors())
+
+    # Test the parsing
+    assert raw_error
+    with pytest.raises(RequestValidationError) as exc_info:
+        await app_controller._parse_validation_exception(request, raw_error)
+
+    exception = exc_info.value
+    assert len(exception.internal_model.errors) == 1  # type: ignore
+    error = exception.internal_model.errors[0]  # type: ignore
+
+    # Verify the error is parsed correctly
+    assert error.error_type == "int_parsing"
+    assert error.location == ["age"]
+    assert "input should be a valid integer" in error.message.lower()
+    assert error.value_input == "not_a_number"

--- a/mountaineer/actions/fields.py
+++ b/mountaineer/actions/fields.py
@@ -34,7 +34,7 @@ from pydantic import BaseModel, Field, create_model
 from pydantic.fields import FieldInfo
 
 from mountaineer.annotation_helpers import MountaineerUnsetValue
-from mountaineer.exceptions import APIException
+from mountaineer.exceptions import APIException, RequestValidationError
 from mountaineer.render import FieldClassDefinition, Metadata, RenderBase, RenderNull
 
 if sys.version_info >= (3, 11):
@@ -112,9 +112,7 @@ class FunctionMetadata(BaseModel):
     passthrough_model: Type[
         BaseModel
     ] | None | MountaineerUnsetValue = MountaineerUnsetValue()
-    exception_models: list[
-        Type[APIException]
-    ] | None | MountaineerUnsetValue = MountaineerUnsetValue()
+    exception_models: list[Type[APIException]] = [RequestValidationError]
     media_type: str | None | MountaineerUnsetValue = MountaineerUnsetValue()
     is_raw_response: bool = False
 

--- a/mountaineer/actions/passthrough_dec.py
+++ b/mountaineer/actions/passthrough_dec.py
@@ -173,7 +173,7 @@ def passthrough(*args, **kwargs):  # type: ignore
 
             metadata = init_function_metadata(inner, FunctionActionType.PASSTHROUGH)
             metadata.passthrough_model = passthrough_model
-            metadata.exception_models = exception_models
+            metadata.exception_models += exception_models or []
             metadata.is_raw_response = raw_response or False
             metadata.media_type = (
                 STREAM_EVENT_TYPE

--- a/mountaineer/actions/sideeffect_dec.py
+++ b/mountaineer/actions/sideeffect_dec.py
@@ -235,7 +235,7 @@ def sideeffect(*args, **kwargs):  # type: ignore
             metadata = init_function_metadata(inner, FunctionActionType.SIDEEFFECT)
             metadata.reload_states = reload
             metadata.passthrough_model = passthrough_model
-            metadata.exception_models = exception_models
+            metadata.exception_models += exception_models or []
             metadata.media_type = None  # Use the default json response type
 
             inner.original = create_original_fn(func)  # type: ignore

--- a/mountaineer/client_builder/parser.py
+++ b/mountaineer/client_builder/parser.py
@@ -206,6 +206,9 @@ class ControllerWrapper(CoreWrapper):
             elif isinstance(item, ExceptionWrapper):
                 exceptions.append(item)
 
+                for field in item.value_models:
+                    yield field.value
+
             elif isinstance(item, TypeDefinition):
                 yield from item.children
 
@@ -668,13 +671,7 @@ class ControllerParser:
                 is_streaming_response=metadata.media_type == STREAM_EVENT_TYPE,
                 exceptions=[
                     self._parse_exception(exception)
-                    for exception in (
-                        (metadata.exception_models or [])
-                        if not isinstance(
-                            metadata.exception_models, MountaineerUnsetValue
-                        )
-                        else []
-                    )
+                    for exception in metadata.exception_models
                 ],
                 action_type=metadata.action_type,
                 controller_to_url=metadata.controller_mounts,

--- a/mountaineer/client_builder/parser.py
+++ b/mountaineer/client_builder/parser.py
@@ -24,7 +24,6 @@ from mountaineer.actions.fields import (
     FunctionMetadata,
     get_function_metadata,
 )
-from mountaineer.annotation_helpers import MountaineerUnsetValue
 from mountaineer.client_builder.types import TypeDefinition, TypeParser
 from mountaineer.constants import STREAM_EVENT_TYPE
 from mountaineer.controller import (

--- a/mountaineer/client_builder/parser.py
+++ b/mountaineer/client_builder/parser.py
@@ -107,6 +107,17 @@ class ActionWrapper:
     # This will store a mapping of each controller to the url that the action is mounted to
     controller_to_url: dict[Type[ControllerBase], str]
 
+    def has_required_params(self):
+        return (
+            (any([param.required for param in self.params]) if self.params else False)
+            or (
+                any([header.required for header in self.headers])
+                if self.headers
+                else False
+            )
+            or self.request_body is not None
+        )
+
 
 @dataclass
 class ControllerWrapper(CoreWrapper):

--- a/mountaineer/exceptions.py
+++ b/mountaineer/exceptions.py
@@ -122,3 +122,21 @@ class APIException(HTTPException, metaclass=InternalModelMeta):
     # versus being statically checked
     def __init__(self, **kwargs: Any):
         super().__init__(**kwargs)
+
+
+class RequestValidationFailure(BaseModel):
+    error_type: str
+    location: list[str]
+    message: str
+    value_input: Any
+
+
+class RequestValidationError(APIException):
+    """
+    Exception to be raised when a Pydantic model or url parameters fails to validate.
+
+    """
+
+    status_code: int = 422
+    detail: str = "Request validation failed"
+    errors: list[RequestValidationFailure]

--- a/mountaineer/static/api.ts
+++ b/mountaineer/static/api.ts
@@ -19,7 +19,8 @@ interface FetchParams {
   method: string;
   url: string;
   path?: Record<string, string | number>;
-  query?: Record<string, string | number>;
+  query?: Record<string, string | number | undefined>;
+  headers?: Record<string, string | number | undefined>;
   errors?: Record<
     number,
     new (statusCode: number, body: any) => FetchErrorBase<any>
@@ -70,15 +71,27 @@ export const __request = async (params: FetchParams) => {
 
   // Fill query parameters
   Object.entries(params.query || {}).forEach(([key, value], i) => {
+    if (value === undefined) {
+      return;
+    }
     filledUrl = `${filledUrl}${i === 0 ? "?" : "&"}${key}=${value}`;
+  });
+
+  // Fill headers
+  const headers = {
+    ...(contentType && { "Content-Type": contentType }),
+  };
+  Object.entries(params.headers || {}).forEach(([key, value]) => {
+    if (value === undefined) {
+      return;
+    }
+    headers[key] = value.toString();
   });
 
   try {
     const response = await fetch(filledUrl, {
       method: params.method,
-      headers: {
-        ...(contentType && { "Content-Type": contentType }),
-      },
+      headers,
       body: payloadBody,
       signal: params.signal,
     });

--- a/mountaineer/static/api.ts
+++ b/mountaineer/static/api.ts
@@ -37,10 +37,12 @@ interface FetchParams {
   signal?: AbortSignal;
 }
 
-// Helper function to convert various types to string for URL parameters
 export const convertToUrlString = (
   value: UrlParamValue | UrlParam,
 ): string | undefined => {
+  /*
+   * Helper function to convert various types to string for URL parameters
+   */
   if (value === null || value === undefined) {
     return undefined;
   }
@@ -52,10 +54,12 @@ export const convertToUrlString = (
   return String(value);
 };
 
-// Helper function to process URL parameters
 export const processUrlParams = (
   params: Record<string, UrlParam>,
 ): URLSearchParams => {
+  /*
+   * Helper function to process URL parameters
+   */
   const searchParams = new URLSearchParams();
 
   for (const [key, value] of Object.entries(params)) {
@@ -98,6 +102,13 @@ export const handleOutputFormat = async (
 };
 
 export const __request = async (params: FetchParams) => {
+  /*
+   * Core function that handles all the logic for issuing actions to the server. Interally
+   * this mostly wraps the fetch API, but adds some additional functionality to:
+   * - Automatically handle JSON serialization and deserialization
+   * - Handle dynamic URL parameter conventions
+   * - Parse error responses and serialize them into exceptions
+   */
   let contentType: string | undefined = params.mediaType || "application/json";
   let payloadBody: string | FormData | undefined = undefined;
 

--- a/mountaineer/static/api.ts
+++ b/mountaineer/static/api.ts
@@ -3,6 +3,11 @@
  * to each component project during schema generation.
  */
 
+// Type for values that can be converted to strings for URL parameters
+export type UrlParamValue = string | number | boolean | Date | null | undefined;
+export type UrlParamArray = Array<string | number | boolean | Date>;
+export type UrlParam = UrlParamValue | UrlParamArray;
+
 export class FetchErrorBase<T> extends Error {
   statusCode: number;
   body: T;
@@ -18,9 +23,9 @@ export class FetchErrorBase<T> extends Error {
 interface FetchParams {
   method: string;
   url: string;
-  path?: Record<string, string | number>;
-  query?: Record<string, string | number | undefined>;
-  headers?: Record<string, string | number | undefined>;
+  path?: Record<string, UrlParamValue>;
+  query?: Record<string, UrlParam>;
+  headers?: Record<string, UrlParam>;
   errors?: Record<
     number,
     new (statusCode: number, body: any) => FetchErrorBase<any>
@@ -32,7 +37,56 @@ interface FetchParams {
   signal?: AbortSignal;
 }
 
-const handleOutputFormat = async (response: Response, format?: string) => {
+// Helper function to convert various types to string for URL parameters
+export const convertToUrlString = (
+  value: UrlParamValue | UrlParam,
+): string | undefined => {
+  if (value === null || value === undefined) {
+    return undefined;
+  }
+
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  return String(value);
+};
+
+// Helper function to process URL parameters
+export const processUrlParams = (
+  params: Record<string, UrlParam>,
+): URLSearchParams => {
+  const searchParams = new URLSearchParams();
+
+  for (const [key, value] of Object.entries(params)) {
+    if (value === null || value === undefined) {
+      continue;
+    }
+
+    if (Array.isArray(value)) {
+      // Handle array values
+      value.forEach((item) => {
+        const strValue = convertToUrlString(item);
+        if (strValue !== undefined) {
+          searchParams.append(key, strValue);
+        }
+      });
+    } else {
+      // Handle single values
+      const strValue = convertToUrlString(value);
+      if (strValue !== undefined) {
+        searchParams.append(key, strValue);
+      }
+    }
+  }
+
+  return searchParams;
+};
+
+export const handleOutputFormat = async (
+  response: Response,
+  format?: string,
+) => {
   if (format === "text") {
     return await response.text();
   } else if (format == "raw") {
@@ -62,34 +116,43 @@ export const __request = async (params: FetchParams) => {
     }
   }
 
-  let filledUrl = params.url;
+  // Process URL and path parameters
+  let url = new URL(params.url);
 
   // Fill path parameters
   for (const [key, value] of Object.entries(params.path || {})) {
-    filledUrl = filledUrl.replace(`{${key}}`, value.toString());
+    const strValue = convertToUrlString(value);
+    if (strValue === undefined) {
+      throw new Error(`Missing required path parameter ${key}`);
+    }
+    url.pathname = decodeURIComponent(url.pathname).replace(
+      `{${key}}`,
+      strValue,
+    );
   }
 
-  // Fill query parameters
-  Object.entries(params.query || {}).forEach(([key, value], i) => {
-    if (value === undefined) {
-      return;
-    }
-    filledUrl = `${filledUrl}${i === 0 ? "?" : "&"}${key}=${value}`;
-  });
+  // Process and append query parameters
+  if (params.query) {
+    const searchParams = processUrlParams(params.query);
+    url.search = searchParams.toString();
+  }
 
   // Fill headers
-  const headers = {
+  const headers: Record<string, string> = {
     ...(contentType && { "Content-Type": contentType }),
   };
-  Object.entries(params.headers || {}).forEach(([key, value]) => {
-    if (value === undefined) {
-      return;
+
+  if (params.headers) {
+    for (const [key, value] of Object.entries(params.headers)) {
+      const strValue = convertToUrlString(value);
+      if (strValue !== undefined) {
+        headers[key] = strValue;
+      }
     }
-    headers[key] = value.toString();
-  });
+  }
 
   try {
-    const response = await fetch(filledUrl, {
+    const response = await fetch(url.toString(), {
       method: params.method,
       headers,
       body: payloadBody,
@@ -213,43 +276,31 @@ export function applySideEffect<
 
 interface GetLinkParams {
   rawUrl: string;
-  queryParameters: Record<string, string>;
-  pathParameters: Record<string, string>;
+  queryParameters: Record<string, UrlParam>;
+  pathParameters: Record<string, UrlParamValue>;
 }
 
 export const __getLink = (params: GetLinkParams) => {
-  // Format the query parameters in raw JS, since our SSR environment doesn't  have
-  // access to the URLSearchParams API.
-  const parsedParams = Object.entries(params.queryParameters).reduce(
-    (acc, [key, value]) => {
-      if (value === undefined) {
-        return acc;
-      }
+  // Format the URL using the standard URL API
+  const url = new URL(params.rawUrl);
 
-      // If we've been given an array, we want separate key-value pairs for each element
-      if (Array.isArray(value)) {
-        for (const element of value) {
-          acc.push(`${key}=${element}`);
-        }
-      } else {
-        acc.push(`${key}=${value}`);
-      }
-      return acc;
-    },
-    [] as string[],
-  );
-  const paramString = parsedParams.join("&");
-
-  // Now fill in the path parameters
-  let url = params.rawUrl;
+  // Fill path parameters
   for (const [key, value] of Object.entries(params.pathParameters)) {
-    if (value === undefined) {
+    const strValue = convertToUrlString(value);
+    if (strValue === undefined) {
       throw new Error(`Missing required path parameter ${key}`);
     }
-    url = url.replace(`{${key}}`, value);
+    url.pathname = decodeURIComponent(url.pathname).replace(
+      `{${key}}`,
+      strValue,
+    );
   }
-  if (paramString) {
-    url = `${url}?${paramString}`;
+
+  // Process query parameters
+  if (params.queryParameters) {
+    const searchParams = processUrlParams(params.queryParameters);
+    url.search = searchParams.toString();
   }
-  return url;
+
+  return decodeURIComponent(url.toString());
 };


### PR DESCRIPTION
If a client action request fails to validate the method signature, the FastAPI server layer will raise a `RequestValidationError` with metadata about what failed to validate. This PR makes this error response more explicit by adding it automatically to the `@sideeffect` and `@passthrough` decorators, which in turn generates the definitions for use in controller models.