### PR TITLE
Pass fallback origin to JS URL

### DIFF
--- a/mountaineer/__tests__/static/harness/jest.config.js
+++ b/mountaineer/__tests__/static/harness/jest.config.js
@@ -1,4 +1,4 @@
 module.exports = {
   preset: "ts-jest",
-  testEnvironment: "node",
+  testEnvironment: "jsdom",
 };

--- a/mountaineer/__tests__/static/harness/package.json
+++ b/mountaineer/__tests__/static/harness/package.json
@@ -11,6 +11,7 @@
   "devDependencies": {
     "@types/jest": "^29.5.13",
     "jest": "^29.7.0",
-    "ts-jest": "^29.2.5"
+    "ts-jest": "^29.2.5",
+    "jest-environment-jsdom": "^29.7.0"
   }
 }

--- a/mountaineer/static/api.ts
+++ b/mountaineer/static/api.ts
@@ -128,7 +128,7 @@ export const __request = async (params: FetchParams) => {
   }
 
   // Process URL and path parameters
-  let url = new URL(params.url);
+  let url = new URL(params.url, window.location.href);
 
   // Fill path parameters
   for (const [key, value] of Object.entries(params.path || {})) {
@@ -293,7 +293,7 @@ interface GetLinkParams {
 
 export const __getLink = (params: GetLinkParams) => {
   // Format the URL using the standard URL API
-  const url = new URL(params.rawUrl);
+  const url = new URL(params.rawUrl, window.location.href);
 
   // Fill path parameters
   for (const [key, value] of Object.entries(params.pathParameters)) {


### PR DESCRIPTION
API actions use relative urls to access the main web service's API consistently across different hosts (local, dev, prod, etc). This is incompatible with the single parameter URL object construction because it only doesn't automatically parse the window's current location. We fix this in this PR by explicitly passing the window root to new url constructors so it should automatically fallback when no host is found in our relative action queries.