### PR TITLE
refactor: switched AppController from a class to a simplified dataclass

### DIFF
--- a/mountaineer/__tests__/fixtures/ci_webapp/ci_webapp/app.py
+++ b/mountaineer/__tests__/fixtures/ci_webapp/ci_webapp/app.py
@@ -12,9 +12,7 @@ controller = AppController(
     global_metadata=Metadata(
         links=[LinkAttribute(rel="stylesheet", href="/static/app_main.css")]
     ),
-    custom_builders=[
-        PostCSSBundler(),
-    ],
+    builders=[PostCSSBundler()],
     config=AppConfig(),
 )
 controller.register(HomeController())

--- a/mountaineer/__tests__/test_app.py
+++ b/mountaineer/__tests__/test_app.py
@@ -112,7 +112,7 @@ def test_view_root_from_config(tmp_path: Path):
         assert mock_resolve_package_path.call_args[0] == ("test_webapp",)
 
 
-def test_passthrough_fastapi_args():
+def test_passthrough_custom_fastapi():
     did_run_lifespan = False
 
     @asynccontextmanager
@@ -121,7 +121,7 @@ def test_passthrough_fastapi_args():
         did_run_lifespan = True
         yield
 
-    app = AppController(view_root=Path(""), fastapi_args=dict(lifespan=app_lifespan))
+    app = AppController(view_root=Path(""), app=FastAPI(lifespan=app_lifespan))
 
     with TestClient(app.app):
         assert did_run_lifespan

--- a/mountaineer/__tests__/test_app_manager.py
+++ b/mountaineer/__tests__/test_app_manager.py
@@ -207,7 +207,7 @@ async def test_handle_dev_exception(manager: DevAppManager):
     assert test_exception
 
     # Force un-mount so we can mount again
-    manager.app_controller.controllers = [
+    manager.app_controller.controllers[:] = [
         controller
         for controller in manager.app_controller.controllers
         if controller.controller.__class__.__name__

--- a/mountaineer/app_manager.py
+++ b/mountaineer/app_manager.py
@@ -113,10 +113,6 @@ class DevAppManager:
         if self.webservice_thread is not None:
             self.webservice_thread.stop()
 
-        # Inject the live reload port so it's picked up even
-        # when the app changes
-        self.app_controller.live_reload_port = self.live_reload_port or 0
-
         self.webservice_thread = UvicornThread(
             name="Dev webserver",
             emoticon="🚀",

--- a/mountaineer/client_builder/types.py
+++ b/mountaineer/client_builder/types.py
@@ -1,4 +1,4 @@
-from abc import ABC, abstractmethod, abstractproperty
+from abc import ABC, abstractmethod
 from types import UnionType
 from typing import (
     Any,
@@ -32,7 +32,8 @@ def is_none_type(field_type: Any):
 class TypeDefinition(ABC):
     """Base class for all type definitions"""
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def children(self) -> list[Any]:
         """Return a list of all types this definition wraps"""
         raise NotImplementedError


### PR DESCRIPTION
Hey @piercefreeman,

I noticed that that the `AppController` was a `dataclasses.dataclass` with some extra steps, so i figured it would be make it one in name, not just practice.

Also, this change gives users the ability to directly create an `FastAPI` instance outside of the `controller`. In working with `mountaineer` for the past day or so, I found myself customizing fastapi a lot, so at least it my mind it makes sense to pull the functionality out of mountaineer.  Also, this allows users to remove/replace `main.py` since the `app` will already be exposed.


```python
app = FastAPI(....)
app.add_middleware(....)

controller = AppController(app=app, ...)
```