### PR TITLE
Skip updating poetry section if not available

### DIFF
--- a/.github/scripts/__tests__/test_update_version.py
+++ b/.github/scripts/__tests__/test_update_version.py
@@ -1,9 +1,9 @@
 from contextlib import contextmanager
 from os import chdir
 from pathlib import Path
-from re import sub
 
 import pytest
+import toml
 
 from scripts.update_version import (
     format_cargo_version,
@@ -58,20 +58,17 @@ def test_update_version_rust(tmp_path: Path):
     with change_pwd(tmp_path):
         update_version_rust("0.2.0")
 
-    assert sub(r"\s+", "", cargo_path.read_text()) == sub(
-        r"\s+",
-        "",
-        """
-        [package]
-        name = "mountaineer"
-        version = "0.2.0"
-        edition = "2021"
-
-        [dependencies]
-        v8 = "0.89.0"
-        deno_core_icudata = "0.73.0"
-        """,
-    )
+    assert toml.loads(cargo_path.read_text()) == {
+        "package": {
+            "name": "mountaineer",
+            "version": "0.2.0",
+            "edition": "2021",
+        },
+        "dependencies": {
+            "v8": "0.89.0",
+            "deno_core_icudata": "0.73.0",
+        },
+    }
 
 
 @pytest.mark.parametrize(
@@ -109,73 +106,23 @@ def test_update_version_python(tmp_path: Path):
     with change_pwd(tmp_path):
         update_version_python("0.2.0")
 
-    assert sub(r"\s+", "", pyproject_path.read_text()) == sub(
-        r"\s+",
-        "",
-        """
-        [tool.poetry]
-        name = "mountaineer"
-        version = "0.2.0"
-        description = ""
-        readme = "README.md"
-
-        [tool.poetry.dependencies]
-        fastapi = "^0.68.0"
-
-        [tool.poetry.dependencies.uvicorn]
-        extras = ["standard",]
-        version = "^0.27.0.post1"
-        """,
-    )
-
-
-def test_update_version_python_with_project_version(tmp_path: Path):
-    pyproject_text = """
-        [tool.poetry]
-        name = "mountaineer"
-        version = "0.1.0"
-        description = ""
-        readme = "README.md"
-
-        [project]
-        name = "mountaineer"
-        version = "0.1.0"
-        description = ""
-
-        [tool.poetry.dependencies]
-        uvicorn = { extras = ["standard"], version = "^0.27.0.post1" }
-        fastapi = "^0.68.0"
-        """
-
-    pyproject_path = tmp_path / "pyproject.toml"
-    pyproject_path.write_text(pyproject_text)
-
-    with change_pwd(tmp_path):
-        update_version_python("0.2.0")
-
-    assert sub(r"\s+", "", pyproject_path.read_text()) == sub(
-        r"\s+",
-        "",
-        """
-        [tool.poetry]
-        name = "mountaineer"
-        version = "0.2.0"
-        description = ""
-        readme = "README.md"
-
-        [project]
-        name = "mountaineer"
-        version = "0.2.0"
-        description = ""
-
-        [tool.poetry.dependencies]
-        fastapi = "^0.68.0"
-
-        [tool.poetry.dependencies.uvicorn]
-        extras = ["standard",]
-        version = "^0.27.0.post1"
-        """,
-    )
+    assert toml.loads(pyproject_path.read_text()) == {
+        "tool": {
+            "poetry": {
+                "name": "mountaineer",
+                "version": "0.2.0",
+                "description": "",
+                "readme": "README.md",
+                "dependencies": {
+                    "uvicorn": {
+                        "extras": ["standard"],
+                        "version": "^0.27.0.post1",
+                    },
+                    "fastapi": "^0.68.0",
+                },
+            },
+        },
+    }
 
 
 def test_update_version_python_with_project_version(tmp_path: Path):
@@ -202,29 +149,28 @@ def test_update_version_python_with_project_version(tmp_path: Path):
     with change_pwd(tmp_path):
         update_version_python("0.2.0")
 
-    assert sub(r"\s+", "", pyproject_path.read_text()) == sub(
-        r"\s+",
-        "",
-        """
-        [tool.poetry]
-        name = "mountaineer"
-        version = "0.2.0"
-        description = ""
-        readme = "README.md"
-
-        [project]
-        name = "mountaineer"
-        version = "0.2.0"
-        description = ""
-
-        [tool.poetry.dependencies]
-        fastapi = "^0.68.0"
-
-        [tool.poetry.dependencies.uvicorn]
-        extras = ["standard",]
-        version = "^0.27.0.post1"
-        """,
-    )
+    assert toml.loads(pyproject_path.read_text()) == {
+        "tool": {
+            "poetry": {
+                "name": "mountaineer",
+                "version": "0.2.0",
+                "description": "",
+                "readme": "README.md",
+                "dependencies": {
+                    "uvicorn": {
+                        "extras": ["standard"],
+                        "version": "^0.27.0.post1",
+                    },
+                    "fastapi": "^0.68.0",
+                },
+            },
+        },
+        "project": {
+            "name": "mountaineer",
+            "version": "0.2.0",
+            "description": "",
+        },
+    }
 
 
 def test_update_version_python_only_project(tmp_path: Path):
@@ -241,16 +187,13 @@ def test_update_version_python_only_project(tmp_path: Path):
     with change_pwd(tmp_path):
         update_version_python("0.2.0")
 
-    assert sub(r"\s+", "", pyproject_path.read_text()) == sub(
-        r"\s+",
-        "",
-        """
-        [project]
-        name = "mountaineer"
-        version = "0.2.0"
-        description = ""
-        """,
-    )
+    assert toml.loads(pyproject_path.read_text()) == {
+        "project": {
+            "name": "mountaineer",
+            "version": "0.2.0",
+            "description": "",
+        },
+    }
 
 
 def test_update_version_python_only_poetry(tmp_path: Path):
@@ -267,16 +210,15 @@ def test_update_version_python_only_poetry(tmp_path: Path):
     with change_pwd(tmp_path):
         update_version_python("0.2.0")
 
-    assert sub(r"\s+", "", pyproject_path.read_text()) == sub(
-        r"\s+",
-        "",
-        """
-        [tool.poetry]
-        name = "mountaineer"
-        version = "0.2.0"
-        description = ""
-        """,
-    )
+    assert toml.loads(pyproject_path.read_text()) == {
+        "tool": {
+            "poetry": {
+                "name": "mountaineer",
+                "version": "0.2.0",
+                "description": "",
+            },
+        },
+    }
 
 
 def test_update_version_python_no_version_sections(tmp_path: Path, capsys):
@@ -297,12 +239,9 @@ def test_update_version_python_no_version_sections(tmp_path: Path, capsys):
     assert "Neither [tool.poetry] nor [project] sections found" in captured.out
 
     # Verify the file wasn't modified
-    assert sub(r"\s+", "", pyproject_path.read_text()) == sub(
-        r"\s+",
-        "",
-        """
-        [build-system]
-        requires = ["poetry-core"]
-        build-backend = "poetry.core.masonry.build"
-        """,
-    )
+    assert toml.loads(pyproject_path.read_text()) == {
+        "build-system": {
+            "requires": ["poetry-core"],
+            "build-backend": "poetry.core.masonry.build",
+        },
+    }

--- a/.github/scripts/__tests__/test_update_version.py
+++ b/.github/scripts/__tests__/test_update_version.py
@@ -176,3 +176,133 @@ def test_update_version_python_with_project_version(tmp_path: Path):
         version = "^0.27.0.post1"
         """,
     )
+
+
+def test_update_version_python_with_project_version(tmp_path: Path):
+    pyproject_text = """
+        [tool.poetry]
+        name = "mountaineer"
+        version = "0.1.0"
+        description = ""
+        readme = "README.md"
+
+        [project]
+        name = "mountaineer"
+        version = "0.1.0"
+        description = ""
+
+        [tool.poetry.dependencies]
+        uvicorn = { extras = ["standard"], version = "^0.27.0.post1" }
+        fastapi = "^0.68.0"
+        """
+
+    pyproject_path = tmp_path / "pyproject.toml"
+    pyproject_path.write_text(pyproject_text)
+
+    with change_pwd(tmp_path):
+        update_version_python("0.2.0")
+
+    assert sub(r"\s+", "", pyproject_path.read_text()) == sub(
+        r"\s+",
+        "",
+        """
+        [tool.poetry]
+        name = "mountaineer"
+        version = "0.2.0"
+        description = ""
+        readme = "README.md"
+
+        [project]
+        name = "mountaineer"
+        version = "0.2.0"
+        description = ""
+
+        [tool.poetry.dependencies]
+        fastapi = "^0.68.0"
+
+        [tool.poetry.dependencies.uvicorn]
+        extras = ["standard",]
+        version = "^0.27.0.post1"
+        """,
+    )
+
+
+def test_update_version_python_only_project(tmp_path: Path):
+    pyproject_text = """
+        [project]
+        name = "mountaineer"
+        version = "0.1.0"
+        description = ""
+        """
+
+    pyproject_path = tmp_path / "pyproject.toml"
+    pyproject_path.write_text(pyproject_text)
+
+    with change_pwd(tmp_path):
+        update_version_python("0.2.0")
+
+    assert sub(r"\s+", "", pyproject_path.read_text()) == sub(
+        r"\s+",
+        "",
+        """
+        [project]
+        name = "mountaineer"
+        version = "0.2.0"
+        description = ""
+        """,
+    )
+
+
+def test_update_version_python_only_poetry(tmp_path: Path):
+    pyproject_text = """
+        [tool.poetry]
+        name = "mountaineer"
+        version = "0.1.0"
+        description = ""
+        """
+
+    pyproject_path = tmp_path / "pyproject.toml"
+    pyproject_path.write_text(pyproject_text)
+
+    with change_pwd(tmp_path):
+        update_version_python("0.2.0")
+
+    assert sub(r"\s+", "", pyproject_path.read_text()) == sub(
+        r"\s+",
+        "",
+        """
+        [tool.poetry]
+        name = "mountaineer"
+        version = "0.2.0"
+        description = ""
+        """,
+    )
+
+
+def test_update_version_python_no_version_sections(tmp_path: Path, capsys):
+    pyproject_text = """
+        [build-system]
+        requires = ["poetry-core"]
+        build-backend = "poetry.core.masonry.build"
+        """
+
+    pyproject_path = tmp_path / "pyproject.toml"
+    pyproject_path.write_text(pyproject_text)
+
+    with change_pwd(tmp_path):
+        update_version_python("0.2.0")
+
+    # Verify the warning was printed
+    captured = capsys.readouterr()
+    assert "Neither [tool.poetry] nor [project] sections found" in captured.out
+
+    # Verify the file wasn't modified
+    assert sub(r"\s+", "", pyproject_path.read_text()) == sub(
+        r"\s+",
+        "",
+        """
+        [build-system]
+        requires = ["poetry-core"]
+        build-backend = "poetry.core.masonry.build"
+        """,
+    )

--- a/.github/scripts/update_version.py
+++ b/.github/scripts/update_version.py
@@ -52,7 +52,7 @@ def format_cargo_version(new_version: str) -> str:
 def update_version_python(new_version: str):
     pyproject_path = Path("pyproject.toml")
     if not pyproject_path.exists():
-        stdout.write("pyproject.toml not found, skipping version update")
+        print("pyproject.toml not found, skipping version update")  # noqa: T201
         return
 
     filedata = toml.loads(pyproject_path.read_text())
@@ -73,7 +73,9 @@ def update_version_python(new_version: str):
         updated = True
 
     if not updated:
-        stdout.write("Warning: Neither [tool.poetry] nor [project] sections found in pyproject.toml")
+        print(  # noqa: T201
+            "Warning: Neither [tool.poetry] nor [project] sections found in pyproject.toml"
+        )
         return
 
     pyproject_path.write_text(toml.dumps(filedata))

--- a/.github/scripts/update_version.py
+++ b/.github/scripts/update_version.py
@@ -60,14 +60,21 @@ def update_version_python(new_version: str):
     # Parse the new version to ensure it's valid and potentially reformat
     python_version = format_python_version(new_version)
 
-    if "tool" not in filedata or "poetry" not in filedata["tool"]:
-        raise ValueError("pyproject.toml is missing the [tool.poetry] section")
+    updated = False
 
-    filedata["tool"]["poetry"]["version"] = python_version
+    # Update poetry version if it exists
+    if "tool" in filedata and "poetry" in filedata["tool"]:
+        filedata["tool"]["poetry"]["version"] = python_version
+        updated = True
 
-    # Also update project.version if it exists
+    # Update project.version if it exists
     if "project" in filedata and "version" in filedata["project"]:
         filedata["project"]["version"] = python_version
+        updated = True
+
+    if not updated:
+        stdout.write("Warning: Neither [tool.poetry] nor [project] sections found in pyproject.toml")
+        return
 
     pyproject_path.write_text(toml.dumps(filedata))
 


### PR DESCRIPTION
We've assumed that all pyproject.toml file will include a poetry section during our automatic version bump. This might not be true for packages that switch to management by `uv`.