### PR TITLE
feat: optional layouts

### DIFF
--- a/docs/guides/structure/page.mdx
+++ b/docs/guides/structure/page.mdx
@@ -40,6 +40,8 @@ Every service file is nested under the `my_webapp` root package. This is just a 
 
 Nested routes are in nested folders. This folder acts as your React project and is where you can define requirements and build parameters in `package.json` and `tsconfig.json`.
 
+Mountaineer supports advanced layout organization patterns, including the ability to isolate layouts to specific sections of your application using the `(root)` folder pattern. For more details, see the [Layout Organization](../views/layout-organization) guide.
+
 ### Suggested Conventions
 
 `controllers` - A controller is the python logic that backs your frontend view. You can define controllers however you like: a flat folder, nesting folders, or via no folders at all mixed in with other code. For simplicity we recommend starting with a single flat controllers folder and refactoring into sub-folders as distinct ownership areas of your code emerge.

--- a/docs/guides/views/layout-organization.mdx
+++ b/docs/guides/views/layout-organization.mdx
@@ -1,0 +1,72 @@
+# Layout Organization
+
+Mountaineer supports flexible layout organization patterns inspired by Next.js. This guide explains how to structure your layouts for different scenarios.
+
+## Default Layout Structure
+
+By default, Mountaineer uses a cascading layout system where layouts apply to all pages in their directory and subdirectories:
+
+```
+views/
+└── app/
+    ├── layout.tsx         # Root layout (applies to all pages)
+    ├── home/
+    │   └── page.tsx       # Uses root layout
+    └── dashboard/
+        ├── layout.tsx     # Dashboard layout (applies to all dashboard pages)
+        ├── home/
+        │   └── page.tsx   # Uses both root and dashboard layouts
+        └── settings/
+            └── page.tsx   # Uses both root and dashboard layouts
+```
+
+In this structure, when rendering `dashboard/home/page.tsx`, the page will be wrapped by both the `dashboard/layout.tsx` and the root `app/layout.tsx`.
+
+## Optional Layout Structure with (root) Folder
+
+For more granular control over which layouts apply to which pages, you can use the optional (root) folder pattern. This allows you to isolate layouts to specific sections of your application:
+
+```
+views/
+└── app/
+    ├── (root)/            # Root group
+    │   ├── layout.tsx     # Layout only applies within this group
+    │   └── home/
+    │       └── page.tsx   # Uses the (root) layout
+    └── dashboard/         # Separate section not using the (root) layout
+        └── page.tsx       # Doesn't use any layout
+```
+
+In this structure:
+- The layout in `(root)/layout.tsx` only applies to pages within the `(root)` directory
+- Pages outside the `(root)` directory (like `dashboard/page.tsx`) don't inherit the root layout
+
+This pattern is useful when:
+- You want different sections of your app to have completely different layouts
+- You need to isolate layout changes to prevent them from affecting other parts of your application
+- You're building a multi-tenant application where each tenant needs its own layout
+
+## Nested Layout Groups
+
+You can also nest these layout groups for even more control:
+
+```
+views/
+└── app/
+    ├── (root)/
+    │   ├── layout.tsx
+    │   ├── home/
+    │   │   └── page.tsx   # Uses only the (root) layout
+    │   └── (admin)/
+    │       ├── layout.tsx # Admin layout
+    │       └── dashboard/
+    │           └── page.tsx # Uses both (root) and (admin) layouts
+    └── auth/
+        └── page.tsx       # Doesn't use any layout
+```
+
+## Implementation Details
+
+When Mountaineer encounters a folder name wrapped in parentheses like `(root)`, it treats it as a layout group. The parentheses in the folder name are just a convention to indicate that this folder is used for layout organization and doesn't affect the actual URL routing.
+
+This approach gives you the flexibility to organize your layouts in a way that matches your application's structure while maintaining clean separation between different sections. 

--- a/docs/guides/views/page.mdx
+++ b/docs/guides/views/page.mdx
@@ -172,6 +172,8 @@ views/
 
 When rendering `dashboard/home/page.tsx`, the view will be wrapped in the `app/dashboard/layout.tsx` layout alongside `app/layout.tsx`. These layout files will be automatically found by Mountaineer during the build process. They don't require any explicit declaration in your Python backend if you're just using them for styling.
 
+For more advanced layout organization, including isolating layouts to specific sections of your application using the `(root)` folder pattern, see the [Layout Organization](./layout-organization) guide.
+
 If you need more server side power and want to define them in Python, you can add a LayoutController that backs the layout.
 
 ### Layout Controllers


### PR DESCRIPTION
This pull request introduces the ability to disable layouts for specific controllers. The main use case for this new functionality is to allow the "index", "login", etc. pages to not rely on a global layout.

@piercefreeman Let me know if you think it would be better to have layout overriding instead