### PR TITLE
Fix nondeterministic crash on pku flags

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,8 @@ on:
     tags:
       - "**"
   pull_request: {}
+  pull_request_target:
+    types: [labeled]
 
 jobs:
   test:

--- a/docs/api/logging/page.mdx
+++ b/docs/api/logging/page.mdx
@@ -1,3 +1,19 @@
+# Logging
+
+Mountaineer bundles a `mountaineer.logging` module for service-level logs. To adjust
+the verbosity of Mountaineer's logs, set the `MOUNTAINEER_LOG_LEVEL` environment
+variable.
+
+```bash
+MOUNTAINEER_LOG_LEVEL=WARN mountaineer runserver
+```
+
+We also provide some helper functions to use our same logging convention in your
+own code. We optimize for structured logging, where your logs are outputted as a
+stream of JSON-line formatted logs so they can be quickly parsed by bash pipes or
+by logging aggregation tools.
+
+---
 
 ::: mountaineer.logging.setup_logger
 

--- a/mountaineer/logging.py
+++ b/mountaineer/logging.py
@@ -121,7 +121,7 @@ def log_time_duration(message: str):
 
 
 def setup_internal_logger(name: str):
-    """ "
+    """
     Our global logger should only surface warnings and above by default.
 
     To adjust Mountaineer logging, set the MOUNTAINEER_LOG_LEVEL environment

--- a/src/ssr.rs
+++ b/src/ssr.rs
@@ -336,8 +336,19 @@ pub fn run_ssr(js_string: String, hard_timeout: u64) -> Result<String, AppError>
 mod tests {
     use super::*;
 
+    // Initialize V8 platform once before running any tests
+    use std::sync::Once;
+    static INIT: Once = Once::new();
+
+    fn initialize() {
+        INIT.call_once(|| {
+            init_v8_platform();
+        });
+    }
+
     #[test]
     fn render_no_timeout() {
+        initialize();
         let js_string = r##"var SSR = { renderToString: () => "<html></html>" };"##.to_string();
         let hard_timeout = 0;
 
@@ -347,6 +358,7 @@ mod tests {
 
     #[test]
     fn render_with_timeout() {
+        initialize();
         let js_string = r##"var SSR = { renderToString: () => "<html></html>" };"##.to_string();
         let hard_timeout = 2000;
 
@@ -356,6 +368,7 @@ mod tests {
 
     #[test]
     fn check_ssr_struct_instance() {
+        initialize();
         let js = Ssr::new(
             r##"var SSR = {x: () => "<html></html>"};"##.to_string(),
             "SSR",
@@ -372,6 +385,7 @@ mod tests {
 
     #[test]
     fn check_exception() {
+        initialize();
         let js = Ssr::new(
             r##"
                 var SSR = {
@@ -392,6 +406,7 @@ mod tests {
 
     #[test]
     fn test_render_to_string() {
+        initialize();
         let js = Ssr::new(
             r##"
                 var SSR = {
@@ -407,10 +422,10 @@ mod tests {
 
     #[test]
     fn test_log_to_stdout() {
+        initialize();
         // Create a synthetic stdout that we can inspect
         let stdout = Arc::new(Mutex::new(Vec::new()));
 
-        init_v8_platform();
         let result = Ssr::render(
             r##"
                 var SSR = {
@@ -436,6 +451,7 @@ mod tests {
 
     #[test]
     fn test_timezone_succeeds() {
+        initialize();
         // More context:
         // https://github.com/denoland/rusty_v8/issues/1444
         // https://github.com/denoland/rusty_v8/pull/603


### PR DESCRIPTION
When V8 is initialized on a non-main thread on CPU architectures that have PKU enabled, rendering can occasionally crash during memory allocation:

```
Thread 36 "python" received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0x7fff69e006c0 (LWP 134254)]
0x00007ffff2f728b1 in v8::internal::FreeListManyCachedFastPathBase::Allocate(unsigned long, unsigned long*, v8::internal::AllocationOrigin) ()
```

When this happens a SIGSEGV is thrown in the V8 isolate itself, which is caught by neither Rust nor Python so the application exits with no further context about the issue.

The official workaround used by the Deno downstream is to always call the singleton initialization in the main process to avoid this issue from occurring:
https://github.com/denoland/rusty_v8/issues/1381