### PR TITLE
Update rust to align with python logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,6 +39,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -273,6 +288,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cc"
+version = "1.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
+dependencies = [
+ "shlex",
+]
+
+[[package]]
 name = "cexpr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -297,6 +321,20 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
+]
 
 [[package]]
 name = "ciborium"
@@ -390,6 +428,12 @@ dependencies = [
  "serde",
  "static_assertions",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cow-utils"
@@ -863,6 +907,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1134,6 +1201,7 @@ dependencies = [
 name = "mountaineer"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "criterion",
  "deno_core_icudata",
  "env_logger",
@@ -3080,6 +3148,21 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ walkdir = "2.5.0"
 
 log = "0.4"
 env_logger = "0.11"
+chrono = "0.4"
 
 # Not currently published to crates.io
 # https://github.com/rolldown/rolldown/issues/3227

--- a/src/bundle_common.rs
+++ b/src/bundle_common.rs
@@ -7,6 +7,7 @@ use std::fs;
 use std::path::Path;
 use tempfile::TempDir;
 use tokio::runtime::Runtime;
+use log::debug;
 
 #[derive(Debug)]
 pub enum OutputType {
@@ -209,11 +210,11 @@ pub fn bundle_common(
         })
         .collect();
     
-    println!("Output type: {:?}", output_type);
-    println!("Input items: {:?}", input_items);
-    println!("Define: {:?}", define);
-    println!("Resolve: {:?}", resolve);
-    println!("Bundle mode: {:?}", mode);
+    debug!("Output type: {:?}", output_type);
+    debug!("Input items: {:?}", input_items);
+    debug!("Define: {:?}", define);
+    debug!("Resolve: {:?}", resolve);
+    debug!("Bundle mode: {:?}", mode);
 
     // https://github.com/rolldown/rolldown/blob/cb5e05c8d9683fd5c190daaad939e5364d7060b2/crates/rolldown_common/src/inner_bundler_options/mod.rs#L41
     let bundler_options = BundlerOptions {
@@ -299,11 +300,11 @@ fn process_output_directory(
     let mut extras = HashMap::new();
 
     // Print all files in the output directory for debugging
-    println!("Files in output directory {}:", output_dir.display());
+    debug!("Files in output directory {}", output_dir.display());
     for entry in fs::read_dir(output_dir).map_err(BundleError::IoError)? {
         let entry = entry.map_err(BundleError::IoError)?;
         let path = entry.path();
-        println!("  - {}", path.display());
+        debug!("  - {}", path.display());
 
         // Skip if not a file
         if !path.is_file() {

--- a/src/bundle_independent.rs
+++ b/src/bundle_independent.rs
@@ -4,7 +4,7 @@ use std::io::Write;
 use std::path::PathBuf;
 use tempfile::TempDir;
 
-use crate::bundle_common::{BundleError, BundleMode, bundle_common};
+use crate::bundle_common::{bundle_common, BundleError, BundleMode};
 use crate::code_gen;
 
 /// Compile independent bundles using bundle_common.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,8 @@
 use errors::AppError;
+use log::debug;
 use pyo3::exceptions::{PyConnectionAbortedError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyString};
-use log::{debug, warn};
 
 mod bundle_common;
 mod bundle_independent;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ use errors::AppError;
 use pyo3::exceptions::{PyConnectionAbortedError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyString};
+use log::{debug, warn};
 
 mod bundle_common;
 mod bundle_independent;
@@ -86,11 +87,11 @@ fn mountaineer(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
          *   something wrong with the script
          */
         if cfg!(debug_assertions) {
-            println!("Running in debug mode");
+            debug!("Running in debug mode");
         }
 
-        // init only if we haven't done so already
-        let _ = env_logger::try_init();
+        // Initialize our logger with environment-based configuration
+        logging::init_logger();
 
         let result_value = ssr::run_ssr(js_string, hard_timeout);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,9 @@ impl BuildContextParams {
 
 #[pymodule]
 fn mountaineer(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
+    // Initialize our logger with environment-based configuration
+    logging::init_logger();
+
     m.add_class::<MapMetadata>()?;
     m.add_class::<BuildContextParams>()?;
 
@@ -89,9 +92,6 @@ fn mountaineer(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
         if cfg!(debug_assertions) {
             debug!("Running in debug mode");
         }
-
-        // Initialize our logger with environment-based configuration
-        logging::init_logger();
 
         let result_value = ssr::run_ssr(js_string, hard_timeout);
 
@@ -151,6 +151,9 @@ fn mountaineer(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
         if cfg!(debug_assertions) {
             println!("Running in debug mode");
         }
+
+        // Initialize our logger with environment-based configuration
+        logging::init_logger();
 
         bundle_independent::compile_independent_bundles(
             py,

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,8 +1,8 @@
+use env_logger::Builder;
+use log::LevelFilter;
+use std::env;
 use std::io::{self, Write};
 use std::sync::{Arc, Mutex};
-use log::LevelFilter;
-use env_logger::Builder;
-use std::env;
 
 pub struct StdoutWrapper(Arc<Mutex<dyn Write + Send + 'static>>);
 

--- a/src/ssr.rs
+++ b/src/ssr.rs
@@ -29,11 +29,11 @@
 use crate::errors::AppError;
 use crate::logging::StdoutWrapper;
 use crate::timeout;
+use log::debug;
 use std::collections::HashMap;
 use std::io::Write;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
-use log::{debug, info, warn};
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct Ssr<'a> {
@@ -317,7 +317,10 @@ pub fn run_ssr(js_string: String, hard_timeout: u64) -> Result<String, AppError>
     // Context: https://github.com/denoland/rusty_v8/issues/1381
     init_v8_platform();
 
-    debug!("SSR execution starting with hard timeout: {}ms", hard_timeout);
+    debug!(
+        "SSR execution starting with hard timeout: {}ms",
+        hard_timeout
+    );
 
     if hard_timeout > 0 {
         // Seems to return a timeout error even if it was some other type of error

--- a/src/ssr.rs
+++ b/src/ssr.rs
@@ -33,6 +33,7 @@ use std::collections::HashMap;
 use std::io::Write;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
+use log::{debug, info, warn};
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct Ssr<'a> {
@@ -316,11 +317,7 @@ pub fn run_ssr(js_string: String, hard_timeout: u64) -> Result<String, AppError>
     // Context: https://github.com/denoland/rusty_v8/issues/1381
     init_v8_platform();
 
-    println!("Hard timeout: {}", hard_timeout);
-
-    // Call inline, no timeout
-    // let js = Ssr::new(js_string, "SSR");
-    // return js.render_to_string(None);
+    debug!("SSR execution starting with hard timeout: {}ms", hard_timeout);
 
     if hard_timeout > 0 {
         // Seems to return a timeout error even if it was some other type of error


### PR DESCRIPTION
Our Python internal logger uses the `MOUNTAINEER_LOG_LEVEL` to determine the logging verbosity, but previously our rust logging was separate and had to be configured with build-time flags. This PR adds a logging configuration in rust that mirrors the Python configurations. It should be available globally for all py03 built functions.