### PR TITLE
Add uv support to CMA

### DIFF
--- a/create_mountaineer_app/create_mountaineer_app/__tests__/test_generation.py
+++ b/create_mountaineer_app/create_mountaineer_app/__tests__/test_generation.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+from create_mountaineer_app.enums import PackageManager
 from create_mountaineer_app.generation import ProjectMetadata, format_template
 from create_mountaineer_app.templates import get_template_path
 
@@ -9,8 +10,8 @@ def test_path_url_replacement():
         project_name="TEST_PROJECT_NAME",
         author_name="TEST_AUTHOR",
         author_email="TEST_EMAIL",
+        package_manager=PackageManager.POETRY,
         use_tailwind=True,
-        use_poetry=True,
         editor_config=None,
         create_stub_files=True,
         project_path=Path("fake-path"),

--- a/create_mountaineer_app/create_mountaineer_app/builder.py
+++ b/create_mountaineer_app/create_mountaineer_app/builder.py
@@ -2,8 +2,10 @@ from pathlib import Path
 
 from click import secho
 
+from create_mountaineer_app.enums import PackageManager
 from create_mountaineer_app.environments.base import EnvironmentBase
 from create_mountaineer_app.environments.poetry import PoetryEnvironment
+from create_mountaineer_app.environments.uv import UvEnvironment
 from create_mountaineer_app.environments.venv import VEnvEnvironment
 from create_mountaineer_app.external import (
     has_npm,
@@ -23,8 +25,10 @@ ALLOW_HIDDEN_FILES = {
 
 
 def environment_from_metadata(metadata: ProjectMetadata) -> EnvironmentBase:
-    if metadata.use_poetry:
+    if metadata.package_manager == PackageManager.POETRY:
         return PoetryEnvironment()
+    elif metadata.package_manager == PackageManager.UV:
+        return UvEnvironment()
     else:
         return VEnvEnvironment()
 

--- a/create_mountaineer_app/create_mountaineer_app/enums.py
+++ b/create_mountaineer_app/create_mountaineer_app/enums.py
@@ -1,0 +1,27 @@
+from dataclasses import dataclass
+from enum import Enum, StrEnum
+
+
+class PackageManager(StrEnum):
+    UV = "uv"
+    POETRY = "poetry"
+    VENV = "venv"
+
+
+@dataclass
+class EditorDescription:
+    name: str
+    path: str | None
+
+
+class EditorType(Enum):
+    VSCODE = EditorDescription(name="vscode", path="vscode")
+    VIM = EditorDescription(name="vim", path="vim")
+    ZED = EditorDescription(name="zed", path=None)
+
+    @classmethod
+    def from_name(cls, name: str) -> "EditorType":
+        for editor in cls:
+            if editor.value.name == name:
+                return editor
+        raise ValueError(f"Invalid editor type: {name}")

--- a/create_mountaineer_app/create_mountaineer_app/enums.py
+++ b/create_mountaineer_app/create_mountaineer_app/enums.py
@@ -1,8 +1,8 @@
 from dataclasses import dataclass
-from enum import Enum, StrEnum
+from enum import Enum
 
 
-class PackageManager(StrEnum):
+class PackageManager(str, Enum):
     UV = "uv"
     POETRY = "poetry"
     VENV = "venv"

--- a/create_mountaineer_app/create_mountaineer_app/environments/__init__.py
+++ b/create_mountaineer_app/create_mountaineer_app/environments/__init__.py
@@ -1,0 +1,6 @@
+from create_mountaineer_app.environments.base import EnvironmentBase
+from create_mountaineer_app.environments.poetry import PoetryEnvironment
+from create_mountaineer_app.environments.uv import UvEnvironment
+from create_mountaineer_app.environments.venv import VEnvEnvironment
+
+__all__ = ["EnvironmentBase", "PoetryEnvironment", "UvEnvironment", "VEnvEnvironment"]

--- a/create_mountaineer_app/create_mountaineer_app/environments/uv.py
+++ b/create_mountaineer_app/create_mountaineer_app/environments/uv.py
@@ -1,0 +1,101 @@
+import subprocess
+from os import environ
+from pathlib import Path
+
+from click import secho
+
+from create_mountaineer_app.environments.base import EnvironmentBase
+
+
+class UvEnvironment(EnvironmentBase):
+    """
+    Use uv as the Python package installer and environment manager.
+    uv is a modern, fast package installer and resolver written in Rust.
+    """
+
+    def __init__(self, venv_name: str = ".venv"):
+        super().__init__()
+        self.venv_name = venv_name
+        self.limited_scope_env = {
+            "PATH": environ["PATH"],
+            **self.global_env,
+        }
+
+    def has_provider(self) -> bool:
+        try:
+            # Attempt to get the version of uv to check if it's installed
+            subprocess.run(
+                ["uv", "--version"],
+                check=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            return True
+        except subprocess.CalledProcessError:
+            # uv is installed but there might be a problem with it
+            return True
+        except FileNotFoundError:
+            # uv is not installed
+            return False
+
+    def install_project(self, project_path: Path) -> None:
+        # Create a virtual environment using uv
+        venv_path = project_path / self.venv_name
+        subprocess.run(
+            ["uv", "venv", str(venv_path)],
+            check=True,
+            cwd=str(project_path),
+            env=self.limited_scope_env,
+        )
+
+        secho(f"Virtual environment created at: {venv_path}", fg="green")
+
+        # Install packages using uv pip
+        subprocess.run(
+            ["uv", "pip", "install", "-e", "."],
+            check=True,
+            cwd=project_path,
+            env={
+                "VIRTUAL_ENV": str(venv_path),
+                "PATH": f"{venv_path}/bin:{environ['PATH']}",
+                **self.global_env,
+            },
+        )
+
+        secho("Packages installed.", fg="green")
+
+    def install_provider(self) -> None:
+        """
+        Install uv using the official installation method:
+        > curl -LsSf https://astral.sh/uv/install.sh | sh
+
+        Raises an exception if the installation fails.
+        """
+        subprocess.run(
+            ["curl", "-LsSf", "https://astral.sh/uv/install.sh", "|", "sh"],
+            check=True,
+            shell=True,  # Required for pipe operation
+        )
+        secho("uv installed successfully.", fg="green")
+
+    def run_command(self, command: list[str], path: Path):
+        venv_path = path / self.venv_name
+        if not venv_path.exists():
+            raise ValueError(f"Virtual environment not found at: {venv_path}")
+
+        return subprocess.Popen(
+            command,
+            cwd=path,
+            env={
+                "VIRTUAL_ENV": str(venv_path),
+                "PATH": f"{venv_path}/bin:{environ['PATH']}",
+                **self.global_env,
+            },
+        )
+
+    def get_env_path(self, project_path: Path) -> str:
+        venv_path = project_path / self.venv_name
+        if not venv_path.exists():
+            raise ValueError(f"Virtual environment not found at: {venv_path}")
+
+        return str(venv_path)

--- a/create_mountaineer_app/create_mountaineer_app/generation.py
+++ b/create_mountaineer_app/create_mountaineer_app/generation.py
@@ -1,35 +1,16 @@
-from dataclasses import dataclass
-from enum import Enum
 from pathlib import Path
 
 from jinja2 import Template
 from pydantic import BaseModel
 
-
-@dataclass
-class EditorDescription:
-    name: str
-    path: str | None
-
-
-class EditorType(Enum):
-    VSCODE = EditorDescription(name="vscode", path="vscode")
-    VIM = EditorDescription(name="vim", path="vim")
-    ZED = EditorDescription(name="zed", path=None)
-
-    @classmethod
-    def from_name(cls, name: str) -> "EditorType":
-        for editor in cls:
-            if editor.value.name == name:
-                return editor
-        raise ValueError(f"Invalid editor type: {name}")
+from create_mountaineer_app.enums import EditorType, PackageManager
 
 
 class ProjectMetadata(BaseModel):
     project_name: str
     author_name: str
     author_email: str
-    use_poetry: bool
+    package_manager: PackageManager
     use_tailwind: bool
     editor_config: EditorType | None
     project_path: Path
@@ -50,6 +31,14 @@ class ProjectMetadata(BaseModel):
     # If specified, will install mountaineer in development mode pointing to a local path
     # This is useful for testing changes to mountaineer itself
     mountaineer_dev_path: Path | None = None
+
+    @property
+    def use_poetry(self) -> bool:
+        return self.package_manager == PackageManager.POETRY
+
+    @property
+    def use_uv(self) -> bool:
+        return self.package_manager == PackageManager.UV
 
 
 class TemplateOutput(BaseModel):

--- a/create_mountaineer_app/create_mountaineer_app/templates/project/pyproject.toml
+++ b/create_mountaineer_app/create_mountaineer_app/templates/project/pyproject.toml
@@ -39,3 +39,11 @@ venvPath = "{{venv_name}}"
 venv = "{{venv_name}}"
 {% endif %}
 
+{% if mountaineer_dev_path %}
+# Editable dependency for development is only supported by poetry and uv
+[tool.poetry.dependencies]
+mountaineer = { path = "{{ mountaineer_dev_path }}", develop = true }
+
+[tool.uv.sources]
+mountaineer = { path = "{{ mountaineer_dev_path }}", editable = true }
+{% endif %}


### PR DESCRIPTION
Add support for managing mountaineer projects generated by CMA with `uv`. Like the poetry and venv installers, this will ensure the local environment has the manager installed & then install the dependencies during setup.