### PR TITLE
Include .env template in CMA

### DIFF
--- a/create_mountaineer_app/README.md
+++ b/create_mountaineer_app/README.md
@@ -1,4 +1,4 @@
-![Mountaineer Header](https://raw.githubusercontent.com/piercefreeman/mountaineer/main/docs/media/header.png)
+![Mountaineer Header](https://raw.githubusercontent.com/piercefreeman/mountaineer/main/media/header.png)
 
 # Project Template
 

--- a/create_mountaineer_app/pyproject.toml
+++ b/create_mountaineer_app/pyproject.toml
@@ -21,6 +21,11 @@ create-mountaineer-app = 'create_mountaineer_app.cli:main'
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.hatch.build.force-include]
+# Workaround or CI sometimes not respecting our .gitignore inclusion rule
+# to allow the template .env but disallow other .env files
+"create_mountaineer_app/templates/project/.env" = "create_mountaineer_app/templates/project/.env"
+
 [dependency-groups]
 dev = [
     "mypy>=1.15.0",


### PR DESCRIPTION
Somewhere in our build pipeline changes (likely the switch the hatchling as the build backend for CMA), we started excluding the default generated .env when users request a default database integration. This PR restores that file to allow the first run to succeed as expected.