### PR TITLE
Hardset paths for postcss location

### DIFF
--- a/mountaineer/__tests__/client_compiler/test_postcss.py
+++ b/mountaineer/__tests__/client_compiler/test_postcss.py
@@ -1,3 +1,7 @@
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import AsyncMock, MagicMock, patch
+
 import pytest
 
 from mountaineer.client_compiler.postcss import PostCSSBundler
@@ -30,3 +34,65 @@ def test_get_style_output_name(view_path: str, expected_output_name: str):
 
     bundler = PostCSSBundler()
     assert bundler.get_style_output_name(view_root / view_path) == expected_output_name
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "css_path_str",
+    [
+        "styles.css",  # Standard case
+        "components/nested/styles.css",  # Nested case
+        "styles.scss",  # File with different extension
+    ],
+)
+async def test_process_css_uses_absolute_paths(css_path_str: str):
+    # Setup test data and paths
+    package_root = ManagedViewPath.from_view_root("/fake/root")
+    view_root = ManagedViewPath.from_view_root("/fake/root/views")
+    css_path = view_root / css_path_str
+
+    # Setup bundler with metadata
+    bundler = PostCSSBundler()
+    bundler.metadata = MagicMock()
+    bundler.metadata.package_root_link = package_root
+
+    # Create cli_path for the mock
+    cli_path = Path("/fake/root/views/node_modules/.bin/postcss")
+
+    # Mock the process result
+    mock_process = AsyncMock()
+    mock_process.communicate.return_value = (b"", b"")
+    mock_process.returncode = 0
+
+    with (
+        TemporaryDirectory() as temp_dir_name,
+        patch.object(bundler, "postcss_is_installed", return_value=(True, cli_path)),
+        patch("asyncio.create_subprocess_exec", return_value=mock_process) as mock_exec,
+        patch("tempfile.TemporaryDirectory") as mock_temp_dir,
+    ):
+        temp_dir_path = Path(temp_dir_name)
+        mock_temp_dir.return_value.__enter__.return_value = str(temp_dir_path)
+
+        # Mock output file
+        with patch.object(Path, "read_text", return_value="processed CSS"):
+            # Call the method
+            result = await bundler.process_css(css_path)
+
+            # Verify the result
+            assert result == "processed CSS"
+
+            # Verify subprocess was called with absolute paths
+            mock_exec.assert_called_once()
+            args, kwargs = mock_exec.call_args
+
+            # Check command has absolute paths
+            assert str(cli_path.absolute()) == args[0]
+            assert str(css_path.absolute()) == args[1]
+            assert "-o" == args[2]
+
+            # Check that env params are set
+            assert kwargs.get("cwd") == css_path.get_root_link().absolute()
+
+            env = kwargs.get("env", {})
+            assert "NODE_PATH" in env
+            assert str(package_root.absolute() / "node_modules") == env["NODE_PATH"]

--- a/mountaineer/client_compiler/postcss.py
+++ b/mountaineer/client_compiler/postcss.py
@@ -91,18 +91,25 @@ class PostCSSBundler(APIBuilderBase):
             temp_dir_path = Path(temp_dir_name)
             output_path = temp_dir_path / "output.css"
 
-            command = [str(cli_path), str(css_path), "-o", str(output_path)]
+            command = [
+                str(cli_path.absolute()),
+                str(css_path.absolute()),
+                "-o",
+                str(output_path.absolute()),
+            ]
             process = await asyncio.create_subprocess_exec(
                 *command,
                 stdout=PIPE,
                 stderr=PIPE,
                 # postcss won't find the config file if we don't set the cwd
                 # we assume this is in each view's root directory
-                cwd=css_path.get_root_link(),
+                cwd=css_path.get_root_link().absolute(),
                 env={
                     **environ,
                     # We expect the main package root will be the one with node modules installed
-                    "NODE_PATH": str(self.metadata.package_root_link / "node_modules"),
+                    "NODE_PATH": str(
+                        self.metadata.package_root_link.absolute() / "node_modules"
+                    ),
                 },
             )
 


### PR DESCRIPTION
Some environments don't pick up on our relative directories pointing to postcss. This PR updates these paths to absolute and adds basic (non-integration) tests verifying this behavior.