### PR TITLE
Only build client, non-plugin dependencies

### DIFF
--- a/create_mountaineer_app/create_mountaineer_app/templates/project/[project_name]/views/package.json
+++ b/create_mountaineer_app/create_mountaineer_app/templates/project/[project_name]/views/package.json
@@ -9,17 +9,16 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    {% if use_tailwind %}
-    "postcss-cli": "^11.0.0",
-    "tailwindcss": "^4.1.6",
-    {% endif %}
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
     "@types/react": "^19.0.10",
-    "autoprefixer": "^10.4.17",
+    {% if use_tailwind %}
+    "tailwindcss": "^4.1.6",
+    "@tailwindcss/postcss": "^4.1.6",
+    {% endif %}
     "postcss": "^8.4.33",
-    "tailwindcss": "^3.4.1"
+    "postcss-cli": "^11.0.0"
   }
 }

--- a/mountaineer/app.py
+++ b/mountaineer/app.py
@@ -326,6 +326,8 @@ class AppController:
 
             # This should find our precompiled static and ssr files
             controller._scripts_prefix = f"/static_plugins/{plugin.name}"
+            controller._build_enabled = False
+
             controller.resolve_paths(plugin.view_root, force=True)
 
             if not controller._ssr_path or not controller._bundled_scripts:

--- a/mountaineer/controller.py
+++ b/mountaineer/controller.py
@@ -101,6 +101,11 @@ class ControllerBase(ABC, Generic[RenderInput]):
     Prefix for the static resolution endpoint of the bundled scripts.
     """
 
+    _build_enabled: bool = True
+    """
+    Whether the frontend build pipeline is enabled for this controller.
+    """
+
     _definition: Optional["ControllerDefinition"] = None
     """
     Upon registration, the AppController will mount a wrapper


### PR DESCRIPTION
We don't want to re-build controllers that are part of plugins, since we have already enforced that they're bundled with the appropriate code on .register. Re-building will create excessive artifact noise and maybe require dependencies that we don't have installed locally.