### PR TITLE
Fix SetOf.update_children writing to wrong attribute

### DIFF
--- a/mountaineer/client_builder/types.py
+++ b/mountaineer/client_builder/types.py
@@ -129,7 +129,8 @@ class SetOf(TypeDefinition):
         return [self.type]
 
     def update_children(self, children):
-        self.types = tuple(children)
+        assert len(children) == 1
+        self.type = children[0]
 
 
 class LiteralOf(TypeDefinition):


### PR DESCRIPTION
- `SetOf.update_children` was writing to `self.types` (non-existent attribute) instead of `self.type`, silently preventing inner type resolution for `Set` fields containing Pydantic models
- This was a copy-paste error from `TupleOf`, which correctly uses the plural `self.types`
- Added a length assertion to match the `ListOf` pattern