### PR TITLE
Fix shared exception constructors

### DIFF
--- a/.github/pyproject.toml
+++ b/.github/pyproject.toml
@@ -25,6 +25,9 @@ warn_return_any = true
 warn_unused_configs = true
 check_untyped_defs = true
 
+[tool.pytest.ini_options]
+pythonpath = ["."]
+
 [tool.ruff.lint]
 # Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
 # Disable print statements

--- a/create_mountaineer_app/pyproject.toml
+++ b/create_mountaineer_app/pyproject.toml
@@ -60,3 +60,4 @@ select = ["E4", "E7", "E9", "F", "I001", "T201"]
 markers = ["integration_tests: run longer-running integration tests"]
 # Default pytest runs shouldn't execute the integration tests
 addopts = "-m 'not integration_tests' --ignore=create_mountaineer_app/templates"
+asyncio_default_fixture_loop_scope = "function"

--- a/mountaineer/client_builder/builder.py
+++ b/mountaineer/client_builder/builder.py
@@ -6,6 +6,7 @@ from mountaineer.client_builder.aliases import AliasManager
 from mountaineer.client_builder.file_generators.base import ParsedController
 from mountaineer.client_builder.file_generators.globals import (
     GlobalControllerGenerator,
+    GlobalExceptionGenerator,
     GlobalLinkGenerator,
 )
 from mountaineer.client_builder.file_generators.locals import (
@@ -117,12 +118,19 @@ class APIBuilder:
             ],
             managed_path=global_root / "controllers.ts",
         )
+        global_exception_generator = GlobalExceptionGenerator(
+            controller_wrappers=[
+                controller.wrapper for controller in parsed_controllers
+            ],
+            managed_path=global_root / "exceptions.ts",
+        )
         global_link_generator = GlobalLinkGenerator(
             parsed_controllers=parsed_controllers,
             managed_path=global_root / "links.ts",
         )
 
         global_controller_generator.build()
+        global_exception_generator.build()
         global_link_generator.build()
 
     def _generate_local_files(self, parsed_controllers: list[ParsedController]):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,8 @@ combine-as-imports = true
 markers = ["integration_tests: run longer-running integration tests"]
 # Default pytest runs shouldn't execute the integration tests
 addopts = "-m 'not integration_tests'"
+testpaths = ["mountaineer/__tests__"]
+asyncio_default_fixture_loop_scope = "function"
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
Fixes #196
- Adds a new `GlobalExceptionGenerator` that emits a single `_server/exceptions.ts` with shared runtime exception classes, so all controllers reference the same constructor
- Updates `LocalActionGenerator` to import and re-export from the global module instead of defining its own exception classes per controller

- Fix `make test-scripts` failing with `ModuleNotFoundError: No module named 'scripts'`
- Fix root `uv run pytest` collecting tests from subprojects and Jinja2 templates
- Silence pytest-asyncio deprecation warnings across all subprojects
