### PR TITLE
Add mountaineer lint CLI command with actionable feedback

### DIFF
--- a/docs/api/cli/page.mdx
+++ b/docs/api/cli/page.mdx
@@ -15,6 +15,14 @@ by the browser. It also ahead-of-time generates the server code that will be run
 You'll want to do it before deploying your application into production - but since a full build can take up
 to 10s, `handle_runserver` provides a better workflow for daily development.
 
+::: mountaineer.cli.handle_lint
+
+You can run the bundled lint pipeline from the root package:
+
+```bash
+uv run mountaineer lint
+```
+
 ## Global Env
 
 Our development server (used in `runserver` and `watch`) rely on forking processes to keep your

--- a/mountaineer/__tests__/test_entrypoint.py
+++ b/mountaineer/__tests__/test_entrypoint.py
@@ -1,0 +1,39 @@
+from click.testing import CliRunner
+
+from mountaineer.entrypoint import main
+
+
+def test_lint_command_invokes_handle_lint(monkeypatch):
+    captured: dict[str, object] = {}
+
+    def fake_handle_lint(*, paths, fix, fast):
+        captured["paths"] = paths
+        captured["fix"] = fix
+        captured["fast"] = fast
+        return 0
+
+    monkeypatch.setattr("mountaineer.entrypoint.handle_lint", fake_handle_lint)
+
+    result = CliRunner().invoke(
+        main,
+        ["lint", "--path", "mountaineer", "--path", "create_mountaineer_app", "--fix", "--fast"],
+    )
+
+    assert result.exit_code == 0
+    assert captured == {
+        "paths": ["mountaineer", "create_mountaineer_app"],
+        "fix": True,
+        "fast": True,
+    }
+
+
+def test_lint_command_propagates_nonzero_exit(monkeypatch):
+    def fake_handle_lint(*, paths, fix, fast):
+        _ = (paths, fix, fast)
+        return 2
+
+    monkeypatch.setattr("mountaineer.entrypoint.handle_lint", fake_handle_lint)
+
+    result = CliRunner().invoke(main, ["lint"])
+
+    assert result.exit_code == 2

--- a/mountaineer/__tests__/test_lint.py
+++ b/mountaineer/__tests__/test_lint.py
@@ -1,0 +1,115 @@
+from pathlib import Path
+from subprocess import CompletedProcess
+
+from mountaineer.cli import _extract_lint_diagnostics, handle_lint
+
+
+def test_handle_lint_fast_runs_only_ruff(monkeypatch):
+    commands: list[list[str]] = []
+
+    def fake_run(command, cwd, capture_output, text, check):
+        _ = (cwd, capture_output, text, check)
+        commands.append(command)
+        return CompletedProcess(command, 0, stdout="", stderr="")
+
+    monkeypatch.setattr("mountaineer.cli.subprocess.run", fake_run)
+
+    return_code = handle_lint(paths=["mountaineer"], fast=True)
+
+    assert return_code == 0
+    assert commands == [["ruff", "check", "mountaineer"]]
+
+
+def test_handle_lint_fix_runs_fix_then_full_pipeline(monkeypatch):
+    commands: list[list[str]] = []
+
+    def fake_run(command, cwd, capture_output, text, check):
+        _ = (cwd, capture_output, text, check)
+        commands.append(command)
+        return CompletedProcess(command, 0, stdout="", stderr="")
+
+    monkeypatch.setattr("mountaineer.cli.subprocess.run", fake_run)
+
+    return_code = handle_lint(paths=["mountaineer"], fix=True)
+
+    assert return_code == 0
+    assert commands == [
+        ["ruff", "check", "--fix", "mountaineer"],
+        ["ruff", "check", "mountaineer"],
+        ["pyright", "mountaineer"],
+        ["mypy", "mountaineer"],
+    ]
+
+
+def test_handle_lint_returns_failure_when_checker_fails(monkeypatch):
+    def fake_run(command, cwd, capture_output, text, check):
+        _ = (cwd, capture_output, text, check)
+        if command[0] == "mypy":
+            return CompletedProcess(
+                command,
+                1,
+                stdout="mountaineer/foo.py:10: error: Incompatible types in assignment [assignment]\n",
+                stderr="",
+            )
+        return CompletedProcess(command, 0, stdout="", stderr="")
+
+    monkeypatch.setattr("mountaineer.cli.subprocess.run", fake_run)
+
+    return_code = handle_lint(paths=["mountaineer"])
+
+    assert return_code == 1
+
+
+def test_handle_lint_missing_tool_is_reported_as_failure(monkeypatch):
+    def fake_run(command, cwd, capture_output, text, check):
+        _ = (cwd, capture_output, text, check)
+        if command[0] == "pyright":
+            raise FileNotFoundError("pyright")
+        return CompletedProcess(command, 0, stdout="", stderr="")
+
+    monkeypatch.setattr("mountaineer.cli.subprocess.run", fake_run)
+
+    return_code = handle_lint(paths=[str(Path("mountaineer"))])
+
+    assert return_code == 1
+
+
+def test_handle_lint_default_targets_package_dirs(tmp_path: Path, monkeypatch):
+    package_dir = tmp_path / "example_pkg"
+    package_dir.mkdir()
+    (package_dir / "__init__.py").write_text("")
+
+    venv_dir = tmp_path / ".venv"
+    venv_dir.mkdir()
+    (venv_dir / "__init__.py").write_text("")
+
+    commands: list[list[str]] = []
+
+    def fake_run(command, cwd, capture_output, text, check):
+        _ = (cwd, capture_output, text, check)
+        commands.append(command)
+        return CompletedProcess(command, 0, stdout="", stderr="")
+
+    monkeypatch.setattr("mountaineer.cli.subprocess.run", fake_run)
+
+    return_code = handle_lint(fast=True, cwd=tmp_path)
+
+    assert return_code == 0
+    assert commands == [["ruff", "check", "example_pkg"]]
+
+
+def test_extract_lint_diagnostics_pyright_deduplicates_supporting_lines():
+    output = "\n".join(
+        [
+            "/tmp/example.py",
+            "/tmp/example.py:3:14 - error: Type \"Literal['bad']\" is not assignable to declared type \"int\"",
+            "  \"Literal['bad']\" is not assignable to \"int\" (reportAssignmentType)",
+            "1 error, 0 warnings, 0 informations",
+        ]
+    )
+
+    diagnostics = _extract_lint_diagnostics("pyright", output)
+
+    assert diagnostics == [
+        "/tmp/example.py:3:14 - error: Type \"Literal['bad']\" is not assignable to declared type \"int\""
+    ]

--- a/mountaineer/cli.py
+++ b/mountaineer/cli.py
@@ -1,7 +1,11 @@
+import re
+import subprocess
 import traceback
 from contextlib import contextmanager
+from dataclasses import dataclass
 from multiprocessing import get_start_method, set_start_method
 from os import getenv
+from pathlib import Path
 from time import time
 from typing import Any, Callable, Coroutine
 
@@ -449,3 +453,228 @@ def get_mountaineer_isolated_env(package: str):
 
     with isolate_imports(package, ignored_modules=ignored_modules) as environment:
         yield environment
+
+
+@dataclass
+class LintToolResult:
+    name: str
+    command: list[str]
+    return_code: int
+    stdout: str
+    stderr: str
+    duration_seconds: float
+
+
+def _run_lint_tool(
+    name: str,
+    command: list[str],
+    cwd: Path | None,
+) -> LintToolResult:
+    """
+    Execute a lint tool command and collect normalized output.
+
+    """
+    start = time()
+    try:
+        result = subprocess.run(
+            command,
+            cwd=str(cwd) if cwd else None,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        return LintToolResult(
+            name=name,
+            command=command,
+            return_code=result.returncode,
+            stdout=result.stdout or "",
+            stderr=result.stderr or "",
+            duration_seconds=time() - start,
+        )
+    except FileNotFoundError as error:
+        return LintToolResult(
+            name=name,
+            command=command,
+            return_code=127,
+            stdout="",
+            stderr=str(error),
+            duration_seconds=time() - start,
+        )
+
+
+def _extract_lint_diagnostics(tool_name: str, output: str, limit: int = 3) -> list[str]:
+    """
+    Parse a tool output stream into up to `limit` concise diagnostics.
+
+    """
+    diagnostics: list[str] = []
+    seen: set[str] = set()
+    lines = output.splitlines()
+
+    patterns = {
+        "ruff": re.compile(r"^(.+?):(\d+):(\d+): ([A-Z]\d+) (.+)$"),
+        "pyright": re.compile(r"^(.+?):(\d+):(\d+) - (error|warning): (.+)$"),
+        "mypy": re.compile(r"^(.+?):(\d+): (error|note): (.+)$"),
+    }
+    pattern = patterns.get(tool_name)
+
+    if pattern:
+        for line in lines:
+            stripped = line.strip()
+            if not stripped or not pattern.match(stripped):
+                continue
+            if stripped in seen:
+                continue
+            diagnostics.append(stripped)
+            seen.add(stripped)
+            if len(diagnostics) >= limit:
+                return diagnostics
+        if diagnostics:
+            return diagnostics
+
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped in seen:
+            continue
+        diagnostics.append(stripped)
+        seen.add(stripped)
+        if len(diagnostics) >= limit:
+            break
+
+    return diagnostics
+
+
+def _get_lint_hint(tool_name: str, diagnostic: str) -> str:
+    """
+    Provide action-oriented guidance for common linter errors.
+
+    """
+    normalized = diagnostic.lower()
+
+    if tool_name == "ruff":
+        if "f401" in diagnostic or "unused import" in normalized:
+            return "Remove the unused import, or use it explicitly."
+        if "i001" in diagnostic or "import block is un-sorted" in normalized:
+            return "Run `ruff check --fix` to sort imports consistently."
+        if "t201" in diagnostic:
+            return "Replace `print(...)` with structured logging or remove debug output."
+        return "Run `ruff check --fix` first, then re-run lint to confirm."
+
+    if tool_name in {"pyright", "mypy"}:
+        if "incompatible" in normalized or "cannot assign" in normalized:
+            return "Align value and annotation types, or widen the annotation."
+        if "has no attribute" in normalized:
+            return "Verify object type narrowing and imported symbols before access."
+        if "not defined" in normalized:
+            return "Import or define the symbol in the current module scope."
+        return "Review the type signature and add/adjust annotations to satisfy the checker."
+
+    return "Address the reported issue and rerun lint."
+
+
+def _print_lint_feedback(result: LintToolResult):
+    if result.return_code == 0:
+        return
+
+    if result.return_code == 127:
+        CONSOLE.print(f"[bold yellow]{result.name} guidance[/bold yellow]")
+        CONSOLE.print(f"- `{result.name}` command was not found in the active environment.")
+        CONSOLE.print(
+            f"  likely fix: add `{result.name}` to dev dependencies, then rerun `mountaineer lint`."
+        )
+        return
+
+    combined_output = result.stdout.strip() or result.stderr.strip()
+    if not combined_output:
+        return
+
+    diagnostics = _extract_lint_diagnostics(result.name, combined_output)
+    if not diagnostics:
+        return
+
+    CONSOLE.print(f"[bold yellow]{result.name} guidance[/bold yellow]")
+    for diagnostic in diagnostics:
+        CONSOLE.print(f"- {diagnostic}")
+        CONSOLE.print(f"  likely fix: {_get_lint_hint(result.name, diagnostic)}")
+
+
+def _resolve_default_lint_paths(cwd: Path | None) -> list[str]:
+    """
+    Infer useful default lint targets from package-like directories in cwd.
+
+    This avoids accidentally linting virtual environments when invoked without
+    explicit `--path` arguments.
+
+    """
+    base_path = (cwd or Path.cwd()).resolve()
+    package_paths: list[str] = []
+
+    for child in sorted(base_path.iterdir(), key=lambda path: path.name):
+        if not child.is_dir():
+            continue
+        if child.name.startswith("."):
+            continue
+        if (child / "__init__.py").exists():
+            package_paths.append(child.name)
+
+    return package_paths if package_paths else ["."]
+
+
+def handle_lint(
+    *,
+    paths: list[str] | None = None,
+    fix: bool = False,
+    fast: bool = False,
+    cwd: Path | None = None,
+) -> int:
+    """
+    Run static analysis tools with actionable feedback in a single command.
+
+    :param paths: Optional target paths. Defaults to current directory.
+    :param fix: Apply Ruff autofixes before the regular lint pass.
+    :param fast: Only run Ruff checks.
+    :param cwd: Working directory for running linter commands.
+
+    """
+    target_paths = paths if paths else _resolve_default_lint_paths(cwd)
+    lint_plan: list[tuple[str, list[str]]] = []
+
+    if fix:
+        lint_plan.append(("ruff", ["ruff", "check", "--fix", *target_paths]))
+    lint_plan.append(("ruff", ["ruff", "check", *target_paths]))
+
+    if not fast:
+        lint_plan.extend(
+            [
+                ("pyright", ["pyright", *target_paths]),
+                ("mypy", ["mypy", *target_paths]),
+            ]
+        )
+
+    CONSOLE.print(
+        f"[bold blue]Running lint pipeline[/bold blue] (targets: {', '.join(target_paths)})"
+    )
+
+    results: list[LintToolResult] = []
+    for tool_name, command in lint_plan:
+        result = _run_lint_tool(tool_name, command, cwd)
+        results.append(result)
+
+        status = "[green]PASS[/green]" if result.return_code == 0 else "[red]FAIL[/red]"
+        CONSOLE.print(
+            f"{status} {tool_name} ({result.duration_seconds:.2f}s): {' '.join(command)}"
+        )
+
+        if result.return_code != 0:
+            _print_lint_feedback(result)
+
+    failed_results = [result for result in results if result.return_code != 0]
+    if failed_results:
+        failed_tools = ", ".join(sorted({result.name for result in failed_results}))
+        CONSOLE.print(f"[bold red]Lint failed[/bold red] ({failed_tools})")
+        return 1
+
+    CONSOLE.print("[bold green]Lint passed[/bold green]")
+    return 0

--- a/mountaineer/entrypoint.py
+++ b/mountaineer/entrypoint.py
@@ -1,0 +1,36 @@
+from click import group, option
+
+from mountaineer.cli import handle_lint
+
+
+@group()
+def main():
+    """
+    Mountaineer framework command group.
+
+    """
+
+
+@main.command()
+@option(
+    "--path",
+    "paths",
+    multiple=True,
+    help="Optional path(s) to lint. Can be passed multiple times.",
+)
+@option(
+    "--fix",
+    is_flag=True,
+    default=False,
+    help="Apply Ruff autofixes before running checks.",
+)
+@option(
+    "--fast",
+    is_flag=True,
+    default=False,
+    help="Run only Ruff checks.",
+)
+def lint(paths: tuple[str, ...], fix: bool, fast: bool):
+    exit_code = handle_lint(paths=list(paths), fix=fix, fast=fast)
+    if exit_code != 0:
+        raise SystemExit(exit_code)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "mountaineer-exceptions>=0.1.1",
     #"mountaineer-exceptions",
 ]
+
 exclude = [
     "fixtures",
     "ci_webapp",
@@ -34,6 +35,9 @@ exclude = [
     "docs_website",
     "benchmarking",
 ]
+
+[project.scripts]
+mountaineer = "mountaineer.entrypoint:main"
 
 [build-system]
 requires = ["maturin>=1.0,<2.0"]


### PR DESCRIPTION
## Summary
- add a dedicated `mountaineer` click entrypoint with a new `lint` command
- implement `handle_lint` pipeline support for `ruff`, `pyright`, and `mypy` with timing + pass/fail output
- add actionable guidance parsing for common diagnostics and dedupe noisy repeated lines (notably pyright)
- support `--path` (multi), `--fix`, and `--fast` flags
- default lint target selection now avoids hidden dirs and focuses on package directories to prevent accidental `.venv` linting
- document the new CLI command in API docs

## Tests
- `uv run pytest mountaineer/__tests__/test_lint.py mountaineer/__tests__/test_entrypoint.py`
- `uv run pytest mountaineer/__tests__`
- `cd create_mountaineer_app && uv run pytest`
- manual CLI checks:
  - `uv run mountaineer --help`
  - `uv run mountaineer lint --help`
  - `uv run mountaineer lint --fast --path mountaineer/__tests__/test_entrypoint.py`
  - `uv run mountaineer lint --path mountaineer/__tests__/test_lint.py`
  - `uv run mountaineer lint --fast`
  - `uv run mountaineer lint --fix --fast --path /tmp/...` (verified both failing non-fixable and passing fixable cases)

Closes #219
