### PR TITLE
Add use-client support

### DIFF
--- a/docs/guides/views/page.mdx
+++ b/docs/guides/views/page.mdx
@@ -286,3 +286,17 @@ A common convention is importing all your view paths with absolute paths (like `
   "exclude": ["node_modules"]
 }
 ```
+
+## Client-Only Modules
+
+If a component depends on browser-only APIs or third-party libraries that cannot execute during SSR, add the exact directive below at the top of the file:
+
+```tsx
+'use client';
+```
+
+Mountaineer will scan the import graph during bundling. If a page, layout, or imported local module contains `'use client'`, that module becomes a client boundary.
+
+Mountaineer treats these as client boundaries during bundling. The server bundle never executes the marked module. During SSR the boundary renders its `children` passthrough or `null`, and after hydration the browser swaps in the real client component. That preserves SSR for the surrounding tree without importing browser-only packages into the server bundle.
+
+The recommended pattern is to wrap browser-only libraries in a small local component marked with `'use client'`, then import that wrapper from your page or layout. Modules marked `'use client'` should export React components rather than shared utilities.

--- a/mountaineer/graph/cache.py
+++ b/mountaineer/graph/cache.py
@@ -68,17 +68,19 @@ class ControllerDevCache(ControllerCacheBase):
         LOGGER.debug(
             f"Compiling client-side bundle for {definition.controller.__class__.__name__}: {view_paths}"
         )
-        script_payloads, _ = mountaineer_rs.compile_independent_bundles(
-            view_paths,
-            str(config.node_modules_path.resolve().absolute()),
-            "development",
-            config.live_reload_port,
-            str(get_static_path("live_reload.ts").resolve().absolute()),
-            False,
-            tsconfig_path,
+        script_payloads, client_sourcemap_payloads = (
+            mountaineer_rs.compile_independent_bundles(
+                view_paths,
+                str(config.node_modules_path.resolve().absolute()),
+                "development",
+                config.live_reload_port,
+                str(get_static_path("live_reload.ts").resolve().absolute()),
+                False,
+                tsconfig_path,
+            )
         )
         cached_client_script = cast(str, script_payloads[0])
-        cached_client_sourcemap = cast(str | None, sourcemap_payloads[0])
+        cached_client_sourcemap = cast(str | None, client_sourcemap_payloads[0])
 
         return ControllerDevCache(
             cached_server_script=cached_server_script,

--- a/src/bundle_common.rs
+++ b/src/bundle_common.rs
@@ -1,16 +1,19 @@
 use indexmap::IndexMap;
 use log::debug;
 use rolldown::{
-    Bundler, BundlerOptions, InputItem, ModuleType, OutputFormat, RawMinifyOptions, ResolveOptions,
-    SourceMapType, TsConfig,
+    plugin::__inner::SharedPluginable, Bundler, BundlerOptions, InputItem, ModuleType,
+    OutputFormat, RawMinifyOptions, ResolveOptions, SourceMapType, TsConfig,
 };
 use rustc_hash::FxHasher;
 use std::collections::HashMap;
 use std::fs;
 use std::hash::BuildHasherDefault;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use tempfile::TempDir;
 use tokio::runtime::Runtime;
+
+use crate::use_client::UseClientPlugin;
 
 #[derive(Debug)]
 pub enum OutputType {
@@ -261,7 +264,9 @@ pub fn bundle_common(
     };
 
     // Create the bundler instance.
-    let mut bundler = Bundler::new(bundler_options)
+    let plugins: Vec<SharedPluginable> = vec![Arc::new(UseClientPlugin::new(is_ssr))];
+
+    let mut bundler = Bundler::with_plugins(bundler_options, plugins)
         .map_err(|err| BundleError::BundlingError(format!("Failed to create bundler: {err:?}")))?;
 
     let rt = Runtime::new().map_err(|e| BundleError::BundlingError(e.to_string()))?;

--- a/src/bundle_common.rs
+++ b/src/bundle_common.rs
@@ -357,8 +357,15 @@ fn process_output_directory(
             _ => BundleError::IoError(e),
         })?;
 
-        // Read the source map if it exists
-        let map_path = path.with_extension("js.map");
+        // Read the sibling source map if it exists, preserving the asset extension
+        let map_path = path.with_file_name(format!(
+            "{}.map",
+            path.file_name()
+                .ok_or_else(|| {
+                    BundleError::OutputError(format!("Invalid filename: {}", path.display()))
+                })?
+                .to_string_lossy()
+        ));
         let map = if map_path.exists() {
             Some(fs::read_to_string(&map_path).map_err(BundleError::IoError)?)
         } else {
@@ -368,23 +375,23 @@ fn process_output_directory(
         // Create bundle result
         let bundle_result = BundleResult { script, map };
 
-        // Check if this is an entrypoint file
+        let extension = path
+            .extension()
+            .map(|ext| format!(".{}", ext.to_string_lossy()))
+            .unwrap_or_default();
+
+        // Check if this is an entrypoint JavaScript file
         let is_entrypoint = entrypoint_paths.iter().any(|ep| {
             Path::new(ep)
                 .file_stem()
                 .map(|s| s.to_string_lossy().to_string())
                 .is_some_and(|s| s == file_stem)
-        });
+        }) && extension == ".js";
 
         // Add to appropriate map
         if is_entrypoint {
             entrypoints.insert(file_stem.to_string(), bundle_result);
         } else {
-            // Get the file extension
-            let extension = path
-                .extension()
-                .map(|ext| format!(".{}", ext.to_string_lossy()))
-                .unwrap_or_default();
             extras.insert(format!("{file_stem}{extension}"), bundle_result);
         }
     }
@@ -928,11 +935,18 @@ mod tests {
             result.err()
         );
 
-        // Verify we got some output (rolldown may extract CSS to separate file)
         let bundles = result.unwrap();
         assert!(
-            !bundles.entrypoints.is_empty() || !bundles.extras.is_empty(),
-            "Client bundle should produce output"
+            bundles.entrypoints.contains_key("client"),
+            "Client bundle should keep the JavaScript entrypoint even when CSS is emitted"
         );
+        let bundle_result = bundles.entrypoints.get("client").unwrap();
+        assert!(bundle_result.script.contains("Client Component"));
+        assert!(
+            bundles.extras.contains_key("client.css"),
+            "Extracted CSS should be returned as an extra asset"
+        );
+        let css_bundle = bundles.extras.get("client.css").unwrap();
+        assert!(css_bundle.script.contains(".client { color: green; }"));
     }
 }

--- a/src/bundle_independent.rs
+++ b/src/bundle_independent.rs
@@ -187,6 +187,7 @@ fn create_entrypoint(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::errors::AppError;
     use crate::ssr::run_ssr;
     use std::fs;
     use tempfile::TempDir;
@@ -336,10 +337,23 @@ mod tests {
         Ok(dir.join("node_modules").to_string_lossy().to_string())
     }
 
-    fn create_use_client_fixture(
+    fn create_browser_dependency_fixture(
         dir: &Path,
+        mark_use_client: bool,
     ) -> Result<(Vec<String>, String, String), std::io::Error> {
         let node_modules_path = create_react_test_runtime(dir)?;
+        create_test_file(
+            dir,
+            "node_modules/browser-only-lib/index.js",
+            r#"
+            const marker = document.createElement('canvas').nodeName;
+
+            export default function browserValue() {
+                return marker;
+            }
+            "#,
+        )?;
+
         let live_reload_path = create_test_file(
             dir,
             "live_reload.ts",
@@ -358,17 +372,29 @@ mod tests {
             "#,
         )?;
 
-        let _client_boundary_path = create_test_file(
-            dir,
-            "client-graph.jsx",
+        let directive = if mark_use_client { "'use client';\n" } else { "" };
+        let client_graph_source = format!(
             r#"
-            'use client';
-            import React from 'react';
+            {directive}import React from 'react';
+            import getBrowserMarker from './client-inner';
 
-            const browserMarker = window.__CLIENT_ONLY_MARKER__ ?? 'CLIENT_ONLY_GRAPH';
+            export default function Graph({{ children }}) {{
+                const browserMarker = getBrowserMarker();
+                return <section data-graph={{browserMarker}}>{{children}}</section>;
+            }}
+            "#
+        );
+        let _client_boundary_path =
+            create_test_file(dir, "client-graph.jsx", &client_graph_source)?;
 
-            export default function Graph({ children }) {
-                return <section data-graph={browserMarker}>{children}</section>;
+        create_test_file(
+            dir,
+            "client-inner.js",
+            r#"
+            import browserValue from 'browser-only-lib';
+
+            export default function getBrowserMarker() {
+                return browserValue();
             }
             "#,
         )?;
@@ -527,7 +553,7 @@ mod tests {
     fn test_use_client_ssr_pipeline_renders_children_only() {
         let temp_dir = TempDir::new().expect("Failed to create temp directory");
         let (path_group, node_modules_path, live_reload_path) =
-            create_use_client_fixture(temp_dir.path())
+            create_browser_dependency_fixture(temp_dir.path(), true)
                 .expect("Failed to create use-client fixture");
 
         let (compiled_script, sourcemap) = compile_fixture_bundle(
@@ -548,8 +574,8 @@ mod tests {
             "SSR bundle should include the client boundary passthrough stub"
         );
         assert!(
-            !compiled_script.contains("CLIENT_ONLY_GRAPH"),
-            "SSR bundle should not include the browser-only client module body"
+            !compiled_script.contains("document.createElement"),
+            "SSR bundle should not include poisoned browser-only dependencies"
         );
 
         let html = run_ssr(compiled_script, 0).expect("SSR bundle should render");
@@ -563,7 +589,7 @@ mod tests {
     fn test_use_client_client_pipeline_keeps_browser_module() {
         let temp_dir = TempDir::new().expect("Failed to create temp directory");
         let (path_group, node_modules_path, live_reload_path) =
-            create_use_client_fixture(temp_dir.path())
+            create_browser_dependency_fixture(temp_dir.path(), true)
                 .expect("Failed to create use-client fixture");
 
         let (compiled_script, sourcemap) = compile_fixture_bundle(
@@ -588,8 +614,40 @@ mod tests {
             "Client bundle should preserve SSR children until the client boundary mounts"
         );
         assert!(
-            compiled_script.contains("CLIENT_ONLY_GRAPH"),
-            "Client bundle should include the browser-only client module implementation"
+            compiled_script.contains("document.createElement"),
+            "Client bundle should include the browser-only dependency graph"
         );
+    }
+
+    #[test]
+    fn test_browser_only_dependency_without_use_client_fails_ssr() {
+        let temp_dir = TempDir::new().expect("Failed to create temp directory");
+        let (path_group, node_modules_path, live_reload_path) =
+            create_browser_dependency_fixture(temp_dir.path(), false)
+                .expect("Failed to create browser dependency fixture");
+
+        let (compiled_script, _sourcemap) = compile_fixture_bundle(
+            &temp_dir,
+            &path_group,
+            &node_modules_path,
+            &live_reload_path,
+            true,
+        )
+        .expect("SSR bundle compilation should succeed");
+
+        assert!(
+            compiled_script.contains("document.createElement"),
+            "Control bundle should include the poisoned dependency when no boundary is present"
+        );
+
+        let error = run_ssr(compiled_script, 0).expect_err(
+            "SSR should fail without a 'use client' boundary around browser-only dependencies",
+        );
+
+        assert!(matches!(
+            error,
+            AppError::V8ExceptionError(ref message)
+                if message.contains("document is not defined")
+        ));
     }
 }

--- a/src/bundle_independent.rs
+++ b/src/bundle_independent.rs
@@ -187,6 +187,272 @@ fn create_entrypoint(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ssr::run_ssr;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn create_test_file(
+        dir: &Path,
+        relative_path: &str,
+        content: &str,
+    ) -> Result<String, std::io::Error> {
+        let file_path = dir.join(relative_path);
+        if let Some(parent) = file_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+
+        let mut file = File::create(&file_path)?;
+        file.write_all(content.as_bytes())?;
+        Ok(file_path.to_string_lossy().to_string())
+    }
+
+    fn create_react_test_runtime(dir: &Path) -> Result<String, std::io::Error> {
+        create_test_file(
+            dir,
+            "node_modules/react/index.js",
+            r#"
+            export const Fragment = Symbol.for('fragment');
+
+            export function createElement(type, props, ...children) {
+                const normalizedChildren =
+                    children.length === 0
+                        ? undefined
+                        : children.length === 1
+                            ? children[0]
+                            : children;
+
+                return {
+                    type,
+                    props: {
+                        ...(props ?? {}),
+                        children: normalizedChildren,
+                    },
+                };
+            }
+
+            export function useEffect() {}
+
+            export function useState(initialValue) {
+                return [initialValue, () => {}];
+            }
+
+            const React = {
+                Fragment,
+                createElement,
+                useEffect,
+                useState,
+            };
+
+            export default React;
+            "#,
+        )?;
+
+        create_test_file(
+            dir,
+            "node_modules/react/jsx-runtime.js",
+            r#"
+            export const Fragment = Symbol.for('fragment');
+
+            function makeElement(type, props, key) {
+                return {
+                    type,
+                    key,
+                    props: props ?? {},
+                };
+            }
+
+            export function jsx(type, props, key) {
+                return makeElement(type, props, key);
+            }
+
+            export function jsxs(type, props, key) {
+                return makeElement(type, props, key);
+            }
+
+            export function jsxDEV(type, props, key) {
+                return makeElement(type, props, key);
+            }
+            "#,
+        )?;
+
+        create_test_file(
+            dir,
+            "node_modules/react/jsx-dev-runtime.js",
+            r#"
+            export * from './jsx-runtime.js';
+            "#,
+        )?;
+
+        create_test_file(
+            dir,
+            "node_modules/react-dom/client.js",
+            r#"
+            export function hydrateRoot() {
+                return null;
+            }
+            "#,
+        )?;
+
+        create_test_file(
+            dir,
+            "node_modules/react-dom/server.edge.js",
+            r#"
+            function escapeAttribute(value) {
+                return String(value).replace(/"/g, '&quot;');
+            }
+
+            function renderNode(node) {
+                if (node == null || node === false || node === true) {
+                    return '';
+                }
+
+                if (Array.isArray(node)) {
+                    return node.map(renderNode).join('');
+                }
+
+                if (typeof node === 'string' || typeof node === 'number') {
+                    return String(node);
+                }
+
+                if (typeof node.type === 'function') {
+                    return renderNode(node.type(node.props ?? {}));
+                }
+
+                const { children, ...attrs } = node.props ?? {};
+                const renderedAttrs = Object.entries(attrs)
+                    .filter(([, value]) => value !== false && value != null)
+                    .map(([key, value]) => ` ${key}="${escapeAttribute(value)}"`)
+                    .join('');
+
+                return `<${node.type}${renderedAttrs}>${renderNode(children)}</${node.type}>`;
+            }
+
+            export function renderToString(element) {
+                return renderNode(element);
+            }
+            "#,
+        )?;
+
+        Ok(dir.join("node_modules").to_string_lossy().to_string())
+    }
+
+    fn create_use_client_fixture(
+        dir: &Path,
+    ) -> Result<(Vec<String>, String, String), std::io::Error> {
+        let node_modules_path = create_react_test_runtime(dir)?;
+        let live_reload_path = create_test_file(
+            dir,
+            "live_reload.ts",
+            "export default function mountLiveReload() {}\n",
+        )?;
+
+        let layout_path = create_test_file(
+            dir,
+            "layout.jsx",
+            r#"
+            import React from 'react';
+
+            export default function Layout({ children }) {
+                return <main data-layout="shell">{children}</main>;
+            }
+            "#,
+        )?;
+
+        let _client_boundary_path = create_test_file(
+            dir,
+            "client-graph.jsx",
+            r#"
+            'use client';
+            import React from 'react';
+
+            const browserMarker = window.__CLIENT_ONLY_MARKER__ ?? 'CLIENT_ONLY_GRAPH';
+
+            export default function Graph({ children }) {
+                return <section data-graph={browserMarker}>{children}</section>;
+            }
+            "#,
+        )?;
+
+        let page_path = create_test_file(
+            dir,
+            "page.jsx",
+            r#"
+            import React from 'react';
+            import Graph from './client-graph';
+
+            export default function Page() {
+                return (
+                    <Graph>
+                        <span>Server Child</span>
+                    </Graph>
+                );
+            }
+            "#,
+        )?;
+
+        Ok((
+            vec![layout_path, page_path],
+            node_modules_path,
+            live_reload_path,
+        ))
+    }
+
+    fn compile_fixture_bundle(
+        temp_dir: &TempDir,
+        path_group: &[String],
+        node_modules_path: &str,
+        live_reload_path: &str,
+        is_ssr: bool,
+    ) -> Result<(String, String), String> {
+        validate_absolute_paths(path_group)?;
+
+        let entrypoint_path = temp_dir.path().join(if is_ssr {
+            "entrypoint-ssr.jsx"
+        } else {
+            "entrypoint-client.jsx"
+        });
+        let mut file = File::create(&entrypoint_path).map_err(|err| err.to_string())?;
+        let entrypoint_content = code_gen::build_entrypoint(path_group, is_ssr, live_reload_path);
+
+        file.write_all(entrypoint_content.as_bytes())
+            .map_err(|err| err.to_string())?;
+
+        let bundle_results = bundle_common(
+            vec![entrypoint_path.to_string_lossy().to_string()],
+            if is_ssr {
+                BundleMode::SingleServer
+            } else {
+                BundleMode::SingleClient
+            },
+            "development".to_string(),
+            node_modules_path.to_string(),
+            None,
+            None,
+            false,
+        )
+        .map_err(|err| err.to_string())?;
+
+        if bundle_results.entrypoints.len() != 1 {
+            return Err(format!(
+                "Expected 1 bundle result, got {}",
+                bundle_results.entrypoints.len()
+            ));
+        }
+
+        let (_, bundle_result) = bundle_results.entrypoints.into_iter().next().unwrap();
+        let mut compiled_file = bundle_result.script;
+        let sourcemap_file = bundle_result.map.unwrap_or_default();
+
+        if is_ssr {
+            if !compiled_file.starts_with("(function(") {
+                return Err("Compiled SSR bundle did not match expected IIFE format".to_string());
+            }
+
+            compiled_file = format!("var SSR = (() => {{\nreturn {compiled_file}\n}})();");
+        }
+
+        Ok((compiled_file, sourcemap_file))
+    }
 
     fn win_paths() -> Vec<String> {
         vec![
@@ -255,5 +521,75 @@ mod tests {
 
         let result = validate_absolute_paths(&empty_paths);
         assert!(result.is_ok(), "Should succeed with empty paths");
+    }
+
+    #[test]
+    fn test_use_client_ssr_pipeline_renders_children_only() {
+        let temp_dir = TempDir::new().expect("Failed to create temp directory");
+        let (path_group, node_modules_path, live_reload_path) =
+            create_use_client_fixture(temp_dir.path())
+                .expect("Failed to create use-client fixture");
+
+        let (compiled_script, sourcemap) = compile_fixture_bundle(
+            &temp_dir,
+            &path_group,
+            &node_modules_path,
+            &live_reload_path,
+            true,
+        )
+        .expect("SSR bundle compilation should succeed");
+
+        assert!(
+            !sourcemap.is_empty(),
+            "Expected SSR pipeline to produce a sourcemap"
+        );
+        assert!(
+            compiled_script.contains("props.children ?? null"),
+            "SSR bundle should include the client boundary passthrough stub"
+        );
+        assert!(
+            !compiled_script.contains("CLIENT_ONLY_GRAPH"),
+            "SSR bundle should not include the browser-only client module body"
+        );
+
+        let html = run_ssr(compiled_script, 0).expect("SSR bundle should render");
+        assert_eq!(
+            html,
+            r#"<main data-layout="shell"><span>Server Child</span></main>"#
+        );
+    }
+
+    #[test]
+    fn test_use_client_client_pipeline_keeps_browser_module() {
+        let temp_dir = TempDir::new().expect("Failed to create temp directory");
+        let (path_group, node_modules_path, live_reload_path) =
+            create_use_client_fixture(temp_dir.path())
+                .expect("Failed to create use-client fixture");
+
+        let (compiled_script, sourcemap) = compile_fixture_bundle(
+            &temp_dir,
+            &path_group,
+            &node_modules_path,
+            &live_reload_path,
+            false,
+        )
+        .expect("Client bundle compilation should succeed");
+
+        assert!(
+            !sourcemap.is_empty(),
+            "Expected client pipeline to produce a sourcemap"
+        );
+        assert!(
+            compiled_script.contains("hydrateRoot"),
+            "Client bundle should hydrate the pre-rendered markup"
+        );
+        assert!(
+            compiled_script.contains("props.children ?? null"),
+            "Client bundle should preserve SSR children until the client boundary mounts"
+        );
+        assert!(
+            compiled_script.contains("CLIENT_ONLY_GRAPH"),
+            "Client bundle should include the browser-only client module implementation"
+        );
     }
 }

--- a/src/bundle_independent.rs
+++ b/src/bundle_independent.rs
@@ -372,7 +372,11 @@ mod tests {
             "#,
         )?;
 
-        let directive = if mark_use_client { "'use client';\n" } else { "" };
+        let directive = if mark_use_client {
+            "'use client';\n"
+        } else {
+            ""
+        };
         let client_graph_source = format!(
             r#"
             {directive}import React from 'react';

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ mod logging;
 mod source_map;
 mod ssr;
 mod timeout;
+mod use_client;
 
 #[macro_use]
 extern crate lazy_static;

--- a/src/ssr.rs
+++ b/src/ssr.rs
@@ -450,7 +450,7 @@ mod tests {
 
         assert_eq!(result, Ok("<html></html>".to_string()));
         assert_eq!(
-            String::from_utf8_lossy(&*result_vector),
+            String::from_utf8_lossy(&result_vector),
             "ssr console [log]: test log\n"
         );
     }

--- a/src/timeout.rs
+++ b/src/timeout.rs
@@ -76,12 +76,12 @@ mod tests {
         if n <= 3 {
             return true;
         }
-        if n % 2 == 0 || n % 3 == 0 {
+        if n.is_multiple_of(2) || n.is_multiple_of(3) {
             return false;
         }
         let mut i = 5;
         while i * i <= n {
-            if n % i == 0 || n % (i + 2) == 0 {
+            if n.is_multiple_of(i) || n.is_multiple_of(i + 2) {
                 return false;
             }
             i += 6;
@@ -93,9 +93,9 @@ mod tests {
     fn test_is_prime() {
         // The correctness of this function doesn't matter as much as the
         // fact that it is doing some CPU-bounded computation
-        assert_eq!(is_prime(2), true);
-        assert_eq!(is_prime(3), true);
-        assert_eq!(is_prime(4), false);
+        assert!(is_prime(2));
+        assert!(is_prime(3));
+        assert!(!is_prime(4));
     }
 
     #[test]
@@ -131,10 +131,8 @@ mod tests {
     #[test]
     fn test_run_thread_valid() {
         let start = std::time::Instant::now();
-        let result = run_thread_with_timeout(
-            || return Ok("returns instantly"),
-            Duration::from_millis(500),
-        );
+        let result =
+            run_thread_with_timeout(|| Ok("returns instantly"), Duration::from_millis(500));
 
         assert_eq!(result, Ok("returns instantly"));
         assert!(start.elapsed() < Duration::from_millis(500));

--- a/src/use_client.rs
+++ b/src/use_client.rs
@@ -67,11 +67,11 @@ impl UseClientPlugin {
         format!("{CLIENT_ACTUAL_PREFIX}{path}")
     }
 
-    fn parse_wrapper_virtual_id<'a>(id: &'a str) -> Option<&'a str> {
+    fn parse_wrapper_virtual_id(id: &str) -> Option<&str> {
         id.strip_prefix(CLIENT_WRAPPER_PREFIX)
     }
 
-    fn parse_actual_virtual_id<'a>(id: &'a str) -> Option<&'a str> {
+    fn parse_actual_virtual_id(id: &str) -> Option<&str> {
         id.strip_prefix(CLIENT_ACTUAL_PREFIX)
     }
 

--- a/src/use_client.rs
+++ b/src/use_client.rs
@@ -1,0 +1,447 @@
+use regex::Regex;
+use rolldown::plugin::{
+    HookLoadArgs, HookLoadOutput, HookLoadReturn, HookResolveIdArgs, HookResolveIdOutput,
+    HookResolveIdReturn, HookUsage, Plugin, PluginContext, PluginHookMeta, PluginOrder,
+};
+use rolldown::ModuleType;
+use std::borrow::Cow;
+use std::collections::{BTreeSet, HashMap};
+use std::fs;
+use std::io::{Error as IoError, ErrorKind};
+use std::path::Path;
+use std::sync::Mutex;
+
+use crate::lexers::strip_js_comments;
+
+const CLIENT_WRAPPER_PREFIX: &str = "\0mountaineer-client-wrapper:";
+const CLIENT_ACTUAL_PREFIX: &str = "\0mountaineer-client-actual:";
+
+lazy_static! {
+    static ref EXPORT_DEFAULT_RE: Regex = Regex::new(r"(?m)^\s*export\s+default\b").unwrap();
+    static ref EXPORT_FUNCTION_RE: Regex =
+        Regex::new(r"(?m)^\s*export\s+(?:async\s+)?function\s+([A-Za-z_$][\w$]*)\b").unwrap();
+    static ref EXPORT_CLASS_RE: Regex =
+        Regex::new(r"(?m)^\s*export\s+class\s+([A-Za-z_$][\w$]*)\b").unwrap();
+    static ref EXPORT_VAR_RE: Regex =
+        Regex::new(r"(?m)^\s*export\s+(?:const|let|var)\s+([A-Za-z_$][\w$]*)\b").unwrap();
+    static ref EXPORT_NAMESPACE_RE: Regex =
+        Regex::new(r"(?m)^\s*export\s+\*\s+as\s+([A-Za-z_$][\w$]*)\s+from\b").unwrap();
+    static ref EXPORT_BLOCK_RE: Regex =
+        Regex::new(r#"(?m)^\s*export\s*\{([^}]*)\}\s*(?:from\s*['"][^'"]+['"])?\s*;?"#).unwrap();
+    static ref EXPORT_ALL_RE: Regex = Regex::new(r"(?m)^\s*export\s+\*\s+from\b").unwrap();
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct ExportSurface {
+    has_default: bool,
+    named: Vec<String>,
+}
+
+impl ExportSurface {
+    fn has_exports(&self) -> bool {
+        self.has_default || !self.named.is_empty()
+    }
+}
+
+#[derive(Debug)]
+pub struct UseClientPlugin {
+    is_ssr: bool,
+    client_module_cache: Mutex<HashMap<String, bool>>,
+    export_surface_cache: Mutex<HashMap<String, ExportSurface>>,
+}
+
+impl UseClientPlugin {
+    pub fn new(is_ssr: bool) -> Self {
+        Self {
+            is_ssr,
+            client_module_cache: Mutex::new(HashMap::new()),
+            export_surface_cache: Mutex::new(HashMap::new()),
+        }
+    }
+
+    fn wrapper_virtual_id(path: &str) -> String {
+        format!("{CLIENT_WRAPPER_PREFIX}{path}")
+    }
+
+    fn actual_virtual_id(path: &str) -> String {
+        format!("{CLIENT_ACTUAL_PREFIX}{path}")
+    }
+
+    fn parse_wrapper_virtual_id<'a>(id: &'a str) -> Option<&'a str> {
+        id.strip_prefix(CLIENT_WRAPPER_PREFIX)
+    }
+
+    fn parse_actual_virtual_id<'a>(id: &'a str) -> Option<&'a str> {
+        id.strip_prefix(CLIENT_ACTUAL_PREFIX)
+    }
+
+    fn is_local_source_file(path: &str) -> bool {
+        let path = Path::new(path);
+        if !path.is_absolute()
+            || path
+                .components()
+                .any(|component| component.as_os_str().to_string_lossy() == "node_modules")
+        {
+            return false;
+        }
+
+        matches!(
+            path.extension().and_then(|ext| ext.to_str()),
+            Some("js" | "jsx" | "ts" | "tsx")
+        )
+    }
+
+    fn is_client_boundary_path(&self, path: &str) -> Result<bool, IoError> {
+        if !Self::is_local_source_file(path) {
+            return Ok(false);
+        }
+
+        if let Some(cached) = self
+            .client_module_cache
+            .lock()
+            .expect("client module cache lock poisoned")
+            .get(path)
+            .copied()
+        {
+            return Ok(cached);
+        }
+
+        let source = fs::read_to_string(path)?;
+        let is_client = has_use_client_directive(&source);
+        self.client_module_cache
+            .lock()
+            .expect("client module cache lock poisoned")
+            .insert(path.to_string(), is_client);
+        Ok(is_client)
+    }
+
+    fn get_export_surface(&self, path: &str) -> Result<ExportSurface, IoError> {
+        if let Some(cached) = self
+            .export_surface_cache
+            .lock()
+            .expect("export surface cache lock poisoned")
+            .get(path)
+            .cloned()
+        {
+            return Ok(cached);
+        }
+
+        let source = fs::read_to_string(path)?;
+        let surface = parse_export_surface(&source)?;
+        self.export_surface_cache
+            .lock()
+            .expect("export surface cache lock poisoned")
+            .insert(path.to_string(), surface.clone());
+        Ok(surface)
+    }
+
+    fn module_type_from_path(path: &str) -> Option<ModuleType> {
+        match Path::new(path).extension().and_then(|ext| ext.to_str()) {
+            Some("js") => Some(ModuleType::Js),
+            Some("jsx") => Some(ModuleType::Jsx),
+            Some("ts") => Some(ModuleType::Ts),
+            Some("tsx") => Some(ModuleType::Tsx),
+            _ => None,
+        }
+    }
+
+    fn generate_boundary_module(&self, path: &str) -> Result<String, IoError> {
+        let surface = self.get_export_surface(path)?;
+        if self.is_ssr {
+            Ok(generate_ssr_boundary_module(&surface))
+        } else {
+            generate_client_boundary_module(path, &surface)
+        }
+    }
+}
+
+impl Plugin for UseClientPlugin {
+    fn name(&self) -> Cow<'static, str> {
+        "mountaineer:use-client".into()
+    }
+
+    fn register_hook_usage(&self) -> HookUsage {
+        HookUsage::ResolveId | HookUsage::Load
+    }
+
+    fn resolve_id_meta(&self) -> Option<PluginHookMeta> {
+        Some(PluginHookMeta {
+            order: Some(PluginOrder::Pre),
+        })
+    }
+
+    fn load_meta(&self) -> Option<PluginHookMeta> {
+        Some(PluginHookMeta {
+            order: Some(PluginOrder::Pre),
+        })
+    }
+
+    async fn resolve_id(
+        &self,
+        ctx: &PluginContext,
+        args: &HookResolveIdArgs<'_>,
+    ) -> HookResolveIdReturn {
+        if Self::parse_wrapper_virtual_id(args.specifier).is_some()
+            || Self::parse_actual_virtual_id(args.specifier).is_some()
+        {
+            return Ok(Some(HookResolveIdOutput::from_id(args.specifier)));
+        }
+
+        if let Some(importer) = args.importer {
+            if let Some(actual_importer_path) = Self::parse_actual_virtual_id(importer) {
+                let resolved = ctx
+                    .resolve(args.specifier, Some(actual_importer_path), None)
+                    .await
+                    .map_err(|err| IoError::other(err.to_string()))?
+                    .map_err(|err| IoError::other(err.to_string()))?;
+
+                if self.is_client_boundary_path(resolved.id.as_str())? {
+                    return Ok(Some(HookResolveIdOutput::from_id(Self::actual_virtual_id(
+                        resolved.id.as_str(),
+                    ))));
+                }
+
+                return Ok(Some(HookResolveIdOutput::from_resolved_id(resolved)));
+            }
+        }
+
+        let resolved = match ctx.resolve(args.specifier, args.importer, None).await {
+            Ok(Ok(resolved)) => resolved,
+            Ok(Err(_)) | Err(_) => return Ok(None),
+        };
+
+        if self.is_client_boundary_path(resolved.id.as_str())? {
+            return Ok(Some(HookResolveIdOutput::from_id(
+                Self::wrapper_virtual_id(resolved.id.as_str()),
+            )));
+        }
+
+        Ok(None)
+    }
+
+    async fn load(&self, _ctx: &PluginContext, args: &HookLoadArgs<'_>) -> HookLoadReturn {
+        if let Some(path) = Self::parse_wrapper_virtual_id(args.id) {
+            let code = self.generate_boundary_module(path)?;
+            return Ok(Some(HookLoadOutput {
+                code: code.into(),
+                module_type: Some(ModuleType::Js),
+                ..Default::default()
+            }));
+        }
+
+        if let Some(path) = Self::parse_actual_virtual_id(args.id) {
+            let code = fs::read_to_string(path)?;
+            return Ok(Some(HookLoadOutput {
+                code: code.into(),
+                module_type: Self::module_type_from_path(path),
+                ..Default::default()
+            }));
+        }
+
+        Ok(None)
+    }
+}
+
+fn has_use_client_directive(source: &str) -> bool {
+    let stripped = strip_js_comments(source, false);
+    let trimmed = stripped.trim_start_matches('\u{feff}').trim_start();
+
+    directive_matches(trimmed, "'use client'") || directive_matches(trimmed, "\"use client\"")
+}
+
+fn directive_matches(source: &str, directive: &str) -> bool {
+    let Some(remainder) = source.strip_prefix(directive) else {
+        return false;
+    };
+
+    remainder.is_empty() || matches!(remainder.chars().next(), Some(';' | '\n' | '\r'))
+}
+
+fn parse_export_surface(source: &str) -> Result<ExportSurface, IoError> {
+    let stripped = strip_js_comments(source, false);
+    if EXPORT_ALL_RE.is_match(&stripped) {
+        return Err(IoError::new(
+            ErrorKind::InvalidInput,
+            "Modules marked 'use client' cannot use `export * from ...`. Re-export explicit component names instead.",
+        ));
+    }
+
+    let mut named = BTreeSet::new();
+    let mut has_default = EXPORT_DEFAULT_RE.is_match(&stripped);
+
+    for regex in [
+        &*EXPORT_FUNCTION_RE,
+        &*EXPORT_CLASS_RE,
+        &*EXPORT_VAR_RE,
+        &*EXPORT_NAMESPACE_RE,
+    ] {
+        for captures in regex.captures_iter(&stripped) {
+            if let Some(name) = captures.get(1) {
+                named.insert(name.as_str().to_string());
+            }
+        }
+    }
+
+    for captures in EXPORT_BLOCK_RE.captures_iter(&stripped) {
+        let Some(block) = captures.get(1) else {
+            continue;
+        };
+
+        for segment in block.as_str().split(',') {
+            let segment = segment.trim();
+            if segment.is_empty() || segment.starts_with("type ") {
+                continue;
+            }
+
+            let export_name = segment
+                .split_once(" as ")
+                .map(|(_, alias)| alias.trim())
+                .unwrap_or(segment);
+
+            if export_name == "default" {
+                has_default = true;
+                continue;
+            }
+
+            if !is_valid_identifier(export_name) {
+                return Err(IoError::new(
+                    ErrorKind::InvalidInput,
+                    format!(
+                        "Unsupported export `{export_name}` in a module marked 'use client'. Re-export explicit identifier names only."
+                    ),
+                ));
+            }
+
+            named.insert(export_name.to_string());
+        }
+    }
+
+    Ok(ExportSurface {
+        has_default,
+        named: named.into_iter().collect(),
+    })
+}
+
+fn is_valid_identifier(value: &str) -> bool {
+    let mut chars = value.chars();
+    match chars.next() {
+        Some(ch) if ch == '_' || ch == '$' || ch.is_ascii_alphabetic() => {}
+        _ => return false,
+    }
+
+    chars.all(|ch| ch == '_' || ch == '$' || ch.is_ascii_alphanumeric())
+}
+
+fn generate_ssr_boundary_module(surface: &ExportSurface) -> String {
+    if !surface.has_exports() {
+        return String::new();
+    }
+
+    let mut output = String::from(
+        "const createClientBoundary = (exportName) => {\n  const Boundary = (props) => props.children ?? null;\n  Boundary.displayName = `ClientBoundary(${exportName})`;\n  return Boundary;\n};\n",
+    );
+
+    if surface.has_default {
+        output.push_str("export default createClientBoundary('default');\n");
+    }
+
+    for export_name in &surface.named {
+        output.push_str(&format!(
+            "export const {export_name} = createClientBoundary({});\n",
+            js_string_literal(export_name).expect("export names are valid string literals"),
+        ));
+    }
+
+    output
+}
+
+fn generate_client_boundary_module(path: &str, surface: &ExportSurface) -> Result<String, IoError> {
+    let actual_id = js_string_literal(&UseClientPlugin::actual_virtual_id(path))?;
+
+    if !surface.has_exports() {
+        return Ok(format!("import {};\n", actual_id));
+    }
+
+    let mut output = format!(
+        "import React, {{ useEffect, useState }} from 'react';\nimport * as actual from {};\nconst createClientBoundary = (Actual, exportName) => {{\n  const Boundary = (props) => {{\n    const [isMounted, setIsMounted] = useState(false);\n    useEffect(() => {{\n      setIsMounted(true);\n    }}, []);\n    if (!isMounted) {{\n      return props.children ?? null;\n    }}\n    return React.createElement(Actual, props);\n  }};\n  Boundary.displayName = `ClientBoundary(${{exportName}})`;\n  return Boundary;\n}};\n",
+        actual_id
+    );
+
+    if surface.has_default {
+        output.push_str("export default createClientBoundary(actual.default, 'default');\n");
+    }
+
+    for export_name in &surface.named {
+        output.push_str(&format!(
+            "export const {export_name} = createClientBoundary(actual.{export_name}, {});\n",
+            js_string_literal(export_name)?,
+        ));
+    }
+
+    Ok(output)
+}
+
+fn js_string_literal(value: &str) -> Result<String, IoError> {
+    serde_json::to_string(value).map_err(|err| IoError::new(ErrorKind::InvalidInput, err))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_has_use_client_directive_after_comments() {
+        let source = "/* comment */\n'use client';\nexport default function Page() {}";
+        assert!(has_use_client_directive(source));
+    }
+
+    #[test]
+    fn test_parse_export_surface_collects_default_and_named_exports() {
+        let source = r#"
+        'use client';
+
+        export default function Page() {}
+        export const Graph = () => null;
+        export async function Loader() {}
+        const Local = () => null;
+        export { Local as Alias };
+        export * as Namespace from './namespace';
+        "#;
+
+        let surface = parse_export_surface(source).unwrap();
+        assert!(surface.has_default);
+        assert_eq!(
+            surface.named,
+            vec![
+                "Alias".to_string(),
+                "Graph".to_string(),
+                "Loader".to_string(),
+                "Namespace".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_parse_export_surface_rejects_export_star() {
+        let source = "'use client';\nexport * from './client';";
+        let error = parse_export_surface(source).unwrap_err();
+        assert!(error.to_string().contains("export * from"));
+    }
+
+    #[test]
+    fn test_generate_boundary_modules_passthrough_children() {
+        let surface = ExportSurface {
+            has_default: true,
+            named: vec!["Graph".to_string()],
+        };
+
+        let ssr_output = generate_ssr_boundary_module(&surface);
+        assert!(ssr_output.contains("props.children ?? null"));
+
+        let client_output = generate_client_boundary_module("/tmp/client.tsx", &surface).unwrap();
+        assert!(client_output.contains("if (!isMounted)"));
+        assert!(client_output.contains("return props.children ?? null;"));
+        assert!(client_output.contains("actual.default"));
+        assert!(client_output.contains("actual.Graph"));
+    }
+}


### PR DESCRIPTION
The nextjs community has consolidated around the "use client" header to indicate that a file should avoid being SSR. This is often due to usage of client-only elements like document that wouldn't make sense to mock server side. We previously would error out in our SSR phase for these kind of files; this logic introduces similar use client support in order to skip hierarchy chains with use client and push them into the client side payload.

It's worth noting that this doesn't actually implement Next's logic 1:1... we don't have an explicit notion of a "use server" and we can't pass server components through to clients and expect them to still be server side rendered. But for the time being we think this is solid progress to allow projects to use frontend libraries that don't yet have server side rendering support.