### PR TITLE
Fix local Docker frontend dependencies

### DIFF
--- a/create_mountaineer_app/create_mountaineer_app/templates/project/Dockerfile.local
+++ b/create_mountaineer_app/create_mountaineer_app/templates/project/Dockerfile.local
@@ -31,9 +31,10 @@ COPY . .
 # Install Python dependencies (editable install for mounted code)
 RUN uv sync
 
-# Install frontend dependencies
+# Install frontend dependencies. If host node_modules entered the context, remove
+# it so native optional packages are resolved for the container architecture.
 WORKDIR /usr/src/app/{{project_name}}/views
-RUN npm install
+RUN rm -rf node_modules && npm install --include=optional
 
 WORKDIR /usr/src/app
 

--- a/create_mountaineer_app/create_mountaineer_app/templates/project/README.md
+++ b/create_mountaineer_app/create_mountaineer_app/templates/project/README.md
@@ -49,8 +49,9 @@ For local Docker-based development, the generated project includes `docker-compo
 
 ```bash
 docker compose up --build -d
-docker compose exec webapp uv run createdb
 ```
+
+For projects generated with stub MVC files, Postgres runs `bootstrap.sql` on first database boot to create the starter `detailitem` table and seed example rows.
 
 The `webapp` service preserves container-managed `{{project_name}}/views/node_modules` in an anonymous Docker volume so host-installed binaries do not leak into the container. If you change `Dockerfile.local`, frontend dependencies, or the Node/Tailwind/PostCSS toolchain, refresh that volume before restarting:
 

--- a/create_mountaineer_app/create_mountaineer_app/templates/project/bootstrap.sql
+++ b/create_mountaineer_app/create_mountaineer_app/templates/project/bootstrap.sql
@@ -1,0 +1,23 @@
+{% if create_stub_files %}
+-- Prefer bootstrapping application schema through Iceaxe with `uv run createdb`.
+-- This Docker init file is only here so first-time local development has
+-- starter data immediately after `docker compose up`.
+CREATE TABLE IF NOT EXISTS detailitem (
+    id SERIAL PRIMARY KEY,
+    description VARCHAR NOT NULL
+);
+
+INSERT INTO detailitem (id, description)
+VALUES
+    (1, 'Explore the generated Mountaineer app'),
+    (2, 'Edit this item from the detail page'),
+    (3, 'Add a new item from the home page')
+ON CONFLICT (id) DO NOTHING;
+
+SELECT setval(
+    pg_get_serial_sequence('detailitem', 'id'),
+    (SELECT MAX(id) FROM detailitem)
+);
+{% else %}
+-- No bootstrap data is needed without generated stub MVC files.
+{% endif %}

--- a/create_mountaineer_app/create_mountaineer_app/templates/project/docker-compose.yml
+++ b/create_mountaineer_app/create_mountaineer_app/templates/project/docker-compose.yml
@@ -35,6 +35,7 @@ services:
       - "{{postgres_port}}:5432"
     volumes:
       - {{project_name}}_postgres_data:/var/lib/postgresql
+      - ./bootstrap.sql:/docker-entrypoint-initdb.d/001-bootstrap.sql:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U {{project_name}} -d {{project_name}}_db"]
       interval: 5s

--- a/create_mountaineer_app/create_mountaineer_app/templates/project/docker-compose.yml
+++ b/create_mountaineer_app/create_mountaineer_app/templates/project/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       # Preserve container node_modules rather than using host binaries.
       - /usr/src/app/{{project_name}}/views/node_modules
     command:
-      - bash
+      - sh
       - -lc
       - exec uv run runserver --host 0.0.0.0 --port 5006
 


### PR DESCRIPTION
Fix two issues on CMA first run:

- postcss fails to install if docker local architecture is different from the host (like with M1 macs)
- bootstrap the database via a manual sql script (run by default by the postgres container) so there's initial state in the database and user don't need to look in the docs to run createdb