### PR TITLE
Add Determystic Python rules

### DIFF
--- a/.determystic/tests/fixtures_at_top.determystic
+++ b/.determystic/tests/fixtures_at_top.determystic
@@ -1,0 +1,201 @@
+import textwrap
+
+from validator import PytestFixturePlacementTraverser
+
+
+def validate(code: str):
+    return PytestFixturePlacementTraverser(textwrap.dedent(code).strip()).validate()
+
+
+def test_flags_fixture_when_it_is_below_test_code():
+    result = validate(
+        """
+        def test_result():
+            assert True
+
+        @pytest_asyncio.fixture
+        async def cached_result(cache: Cache) -> Result:
+            result = Result(value="ready")
+            await cache.store(result)
+            return result
+        """
+    )
+
+    assert not result.is_valid
+    assert len(result.issues) == 1
+    assert result.issues[0].line_number == 4
+    assert "Move pytest fixtures to the top" in result.issues[0].message
+    assert "@pytest_asyncio.fixture" in result.issues[0].code_snippet
+
+
+def test_flags_pytest_fixture_call_below_helper():
+    result = validate(
+        """
+        def make_value():
+            return object()
+
+        @pytest.fixture(scope="session")
+        def value():
+            return make_value()
+        """
+    )
+
+    assert not result.is_valid
+    assert result.issues[0].line_number == 4
+
+
+def test_flags_fixture_after_initial_fixture_block_has_ended():
+    result = validate(
+        """
+        @pytest.fixture
+        def first():
+            return 1
+
+        def test_first(first):
+            assert first == 1
+
+        @pytest.fixture
+        def second():
+            return 2
+        """
+    )
+
+    assert not result.is_valid
+    assert len(result.issues) == 1
+    assert result.issues[0].line_number == 8
+
+
+def test_flags_nested_fixture_because_it_is_not_top_level():
+    result = validate(
+        """
+        def helper():
+            @pytest.fixture
+            def nested():
+                return 1
+            return nested
+        """
+    )
+
+    assert not result.is_valid
+    assert result.issues[0].line_number == 2
+
+
+def test_allows_fixture_in_top_block_after_preamble():
+    result = validate(
+        '''
+        """Tests for value preparation."""
+        import pytest
+        import pytest_asyncio
+
+        DEFAULT_VALUE = "ready"
+
+        @pytest_asyncio.fixture
+        async def prepared_value():
+            return DEFAULT_VALUE
+
+        def test_value(prepared_value):
+            assert prepared_value
+        '''
+    )
+
+    assert result.is_valid
+    assert result.issues == []
+
+
+def test_allows_fixture_after_top_level_classes():
+    """Model/helper classes can live before shared fixtures."""
+    result = validate(
+        """
+        import pytest
+
+
+        class InputModel:
+            pass
+
+
+        class OutputModel:
+            pass
+
+
+        @pytest.fixture
+        def model_pair():
+            return InputModel(), OutputModel()
+
+
+        def test_model_pair(model_pair):
+            assert model_pair
+        """
+    )
+
+    assert result.is_valid
+    assert result.issues == []
+
+
+def test_flags_fixture_after_plain_helper_function():
+    """Plain helper functions still end the top fixture block."""
+    result = validate(
+        """
+        import pytest
+
+
+        def make_model():
+            return object()
+
+
+        @pytest.fixture
+        def model():
+            return make_model()
+        """
+    )
+
+    assert not result.is_valid
+    assert result.issues[0].line_number == 8
+
+
+def test_allows_multiple_top_fixtures_before_tests():
+    result = validate(
+        """
+        @pytest.fixture
+        def first():
+            return object()
+
+        @pytest_asyncio.fixture()
+        async def second():
+            return object()
+
+        def test_second(second):
+            assert second
+        """
+    )
+
+    assert result.is_valid
+
+
+def test_ignores_other_pytest_decorators():
+    result = validate(
+        """
+        def helper():
+            return 1
+
+        @pytest.mark.asyncio
+        async def test_async():
+            assert helper() == 1
+        """
+    )
+
+    assert result.is_valid
+
+
+def test_allows_imported_fixture_name_because_rule_targets_pytest_attribute_form():
+    result = validate(
+        """
+        def helper():
+            return 1
+
+        @fixture
+        def value():
+            return helper()
+        """
+    )
+
+    assert result.is_valid

--- a/.determystic/tests/future_annotations.determystic
+++ b/.determystic/tests/future_annotations.determystic
@@ -1,0 +1,99 @@
+from validator import NoFutureAnnotationsTraverser
+
+
+def validate(code: str):
+    return NoFutureAnnotationsTraverser(code).validate()
+
+
+def test_future_annotations_import_is_flagged():
+    result = validate("from __future__ import annotations\n")
+
+    assert result.is_valid is False
+    assert len(result.issues) == 1
+    assert result.issues[0].line_number == 1
+    assert "from __future__ import annotations" in result.issues[0].code_snippet
+    assert "__future__ import annotations" in result.issues[0].message
+
+
+def test_grouped_future_import_with_annotations_is_flagged():
+    result = validate("from __future__ import division, annotations\n")
+
+    assert result.is_valid is False
+    assert len(result.issues) == 1
+    assert result.issues[0].line_number == 1
+
+
+def test_multiline_future_annotations_import_is_flagged():
+    code = """from __future__ import (
+    annotations,
+)
+"""
+
+    result = validate(code)
+
+    assert result.is_valid is False
+    assert len(result.issues) == 1
+    assert result.issues[0].line_number == 1
+    assert "annotations" in result.issues[0].code_snippet
+
+
+def test_multiple_future_annotations_imports_report_all_occurrences():
+    code = """from __future__ import annotations
+from __future__ import annotations
+"""
+
+    result = validate(code)
+
+    assert result.is_valid is False
+    assert len(result.issues) == 2
+    assert [issue.line_number for issue in result.issues] == [1, 2]
+
+
+def test_other_future_import_is_allowed():
+    result = validate("from __future__ import division\n")
+
+    assert result.is_valid is True
+    assert result.issues == []
+
+
+def test_normal_type_annotations_without_future_import_are_allowed():
+    code = """def normalize(value: str | None) -> str:
+    return value or ""
+"""
+
+    result = validate(code)
+
+    assert result.is_valid is True
+    assert result.issues == []
+
+
+def test_comment_and_string_mentions_are_not_flagged():
+    code = '''# from __future__ import annotations
+text = "from __future__ import annotations"
+'''
+
+    result = validate(code)
+
+    assert result.is_valid is True
+    assert result.issues == []
+
+
+def test_regular_import_of_future_module_is_not_flagged():
+    result = validate("import __future__\n")
+
+    assert result.is_valid is True
+    assert result.issues == []
+
+
+def test_relative_module_named_future_is_not_flagged():
+    result = validate("from .__future__ import annotations\n")
+
+    assert result.is_valid is True
+    assert result.issues == []
+
+
+def test_unrelated_module_importing_annotations_name_is_not_flagged():
+    result = validate("from schema import annotations\n")
+
+    assert result.is_valid is True
+    assert result.issues == []

--- a/.determystic/tests/inline-simple-helpers.determystic
+++ b/.determystic/tests/inline-simple-helpers.determystic
@@ -1,0 +1,134 @@
+from validator import SingleUseTrivialHelperTraverser
+
+
+def validate(code: str):
+    return SingleUseTrivialHelperTraverser(code).validate()
+
+
+def test_flags_multi_statement_single_use_method():
+    code = """
+class RecordStore:
+    async def save(self, record):
+        cleaned = record.strip()
+        await self._write(cleaned)
+
+    async def _write(self, record):
+        request = WriteRequest(record=record)
+        operation = await self._client.write(request)
+        await operation.wait()
+"""
+    result = validate(code)
+
+    assert not result.is_valid
+    assert len(result.issues) == 1
+    assert result.issues[0].line_number == 7
+    assert "_write" in result.issues[0].message
+    assert "save" in result.issues[0].message
+    assert ">>>   7 |     async def _write" in result.issues[0].code_snippet
+
+
+def test_flags_trivial_single_use_module_helper():
+    code = """
+def import_file(data):
+    prepared = data.strip()
+    return _write_file(prepared)
+
+def _write_file(data):
+    return data.encode()
+"""
+    result = validate(code)
+
+    assert not result.is_valid
+    assert "_write_file" in result.issues[0].message
+
+
+def test_flags_trivial_single_use_method_helper():
+    code = """
+class Service:
+    def save(self, data):
+        value = data.strip()
+        return self._save(value)
+
+    def _save(self, value):
+        return value.encode()
+"""
+    result = validate(code)
+
+    assert not result.is_valid
+    assert "_save" in result.issues[0].message
+
+
+def test_allows_helper_used_by_more_than_one_caller():
+    code = """
+class Service:
+    def save_a(self, data):
+        return self._save(data)
+
+    def save_b(self, data):
+        return self._save(data)
+
+    def _save(self, data):
+        return data.encode()
+"""
+    assert validate(code).is_valid
+
+
+def test_allows_single_use_helper_when_caller_is_complex():
+    code = """
+class Service:
+    def save(self, data, should_prepare):
+        if should_prepare:
+            data = data.strip()
+        return self._save(data)
+
+    def _save(self, data):
+        return data.encode()
+"""
+    assert validate(code).is_valid
+
+
+def test_allows_single_use_helper_when_helper_is_complex():
+    code = """
+def save(data):
+    return _save(data)
+
+def _save(data):
+    if not data:
+        raise ValueError("missing data")
+    return data.encode()
+"""
+    assert validate(code).is_valid
+
+
+def test_allows_public_single_use_function():
+    code = """
+def save(data):
+    return write_file(data)
+
+def write_file(data):
+    return data.encode()
+"""
+    assert validate(code).is_valid
+
+
+def test_allows_dunder_method_single_use():
+    code = """
+class Box:
+    def build(self):
+        return self.__repr__()
+
+    def __repr__(self):
+        return "Box()"
+"""
+    assert validate(code).is_valid
+
+
+def test_ignores_private_helper_passed_as_callback_not_directly_called():
+    code = """
+def run():
+    return map(_clean, [" a "])
+
+def _clean(value):
+    return value.strip()
+"""
+    assert validate(code).is_valid

--- a/.determystic/validations/fixtures_at_top.determystic
+++ b/.determystic/validations/fixtures_at_top.determystic
@@ -1,0 +1,90 @@
+import ast
+
+from determystic.external import DeterministicTraverser
+
+
+class PytestFixturePlacementTraverser(DeterministicTraverser):
+    """Require pytest fixtures to live in the initial top-of-file block."""
+
+    FIXTURE_MODULES = {"pytest", "pytest_asyncio"}
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._allowed_fixture_nodes: set[int] = set()
+        self._reported_fixture_nodes: set[int] = set()
+
+    def visit_Module(self, node: ast.Module) -> None:
+        self._allowed_fixture_nodes = self._find_top_fixture_nodes(node.body)
+        self.generic_visit(node)
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._check_fixture_placement(node)
+        self.generic_visit(node)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self._check_fixture_placement(node)
+        self.generic_visit(node)
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        self._check_fixture_placement(node)
+        self.generic_visit(node)
+
+    def _find_top_fixture_nodes(self, body: list[ast.stmt]) -> set[int]:
+        allowed: set[int] = set()
+        seen_normal_code = False
+
+        for index, stmt in enumerate(body):
+            if not seen_normal_code and self._is_allowed_preamble(stmt, index):
+                continue
+
+            if self._fixture_decorator(stmt):
+                if not seen_normal_code:
+                    allowed.add(id(stmt))
+                continue
+
+            seen_normal_code = True
+
+        return allowed
+
+    def _check_fixture_placement(
+        self, node: ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef
+    ) -> None:
+        decorator = self._fixture_decorator(node)
+        if not decorator:
+            return
+        if id(node) in self._allowed_fixture_nodes:
+            return
+        if id(node) in self._reported_fixture_nodes:
+            return
+
+        self._reported_fixture_nodes.add(id(node))
+        self.add_error(
+            decorator,
+            "Move pytest fixtures to the top of the file before test/helper code.",
+        )
+
+    def _fixture_decorator(self, node: ast.AST) -> ast.AST | None:
+        decorators = getattr(node, "decorator_list", [])
+        for decorator in decorators:
+            expr = decorator.func if isinstance(decorator, ast.Call) else decorator
+            if (
+                isinstance(expr, ast.Attribute)
+                and expr.attr == "fixture"
+                and isinstance(expr.value, ast.Name)
+                and expr.value.id in self.FIXTURE_MODULES
+            ):
+                return decorator
+        return None
+
+    def _is_allowed_preamble(self, stmt: ast.stmt, index: int) -> bool:
+        if index == 0 and isinstance(stmt, ast.Expr) and isinstance(
+            stmt.value, ast.Constant
+        ) and isinstance(stmt.value.value, str):
+            return True
+        if isinstance(stmt, ast.ClassDef) and self._fixture_decorator(stmt) is None:
+            return True
+        preamble_types = (ast.Import, ast.ImportFrom, ast.Assign, ast.AnnAssign)
+        type_alias = getattr(ast, "TypeAlias", None)
+        if type_alias is not None:
+            preamble_types = (*preamble_types, type_alias)
+        return isinstance(stmt, preamble_types)

--- a/.determystic/validations/future_annotations.determystic
+++ b/.determystic/validations/future_annotations.determystic
@@ -1,0 +1,29 @@
+import ast
+
+from determystic.external import DeterministicTraverser
+
+
+class NoFutureAnnotationsTraverser(DeterministicTraverser):
+    """Reject `from __future__ import annotations` imports."""
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        """Flag postponed-annotation future imports."""
+        if self._imports_future_annotations(node):
+            self.add_error(
+                node,
+                (
+                    "Do not use 'from __future__ import annotations'; "
+                    "this project runs on a Python version where it is not needed."
+                ),
+            )
+
+        self.generic_visit(node)
+
+    @staticmethod
+    def _imports_future_annotations(node: ast.ImportFrom) -> bool:
+        """Return True for absolute `__future__.annotations` imports only."""
+        return (
+            node.level == 0
+            and node.module == "__future__"
+            and any(alias.name == "annotations" for alias in node.names)
+        )

--- a/.determystic/validations/inline-simple-helpers.determystic
+++ b/.determystic/validations/inline-simple-helpers.determystic
@@ -1,0 +1,139 @@
+import ast
+
+from determystic.external import DeterministicTraverser
+
+
+MAX_SIMPLE_STATEMENTS = 4
+COMPLEX_NODES = (
+    ast.If,
+    ast.For,
+    ast.AsyncFor,
+    ast.While,
+    ast.Try,
+    ast.With,
+    ast.AsyncWith,
+    ast.Match,
+    ast.ListComp,
+    ast.SetComp,
+    ast.DictComp,
+    ast.GeneratorExp,
+)
+
+
+class SingleUseTrivialHelperTraverser(DeterministicTraverser):
+    """Flag private helpers that only add indirection to one simple caller."""
+
+    def visit_Module(self, node: ast.Module) -> None:
+        module_helpers = {
+            item.name: item
+            for item in node.body
+            if isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and self._is_private_helper(item.name)
+        }
+
+        module_calls = self._collect_module_calls(node)
+        for name, helper in module_helpers.items():
+            calls = module_calls.get(name, [])
+            if self._should_flag(helper, calls):
+                self._add_helper_error(helper, calls[0][1])
+
+        for class_node in [item for item in node.body if isinstance(item, ast.ClassDef)]:
+            self._check_class_helpers(class_node)
+
+        self.generic_visit(node)
+
+    def _check_class_helpers(self, class_node: ast.ClassDef) -> None:
+        helpers = {
+            item.name: item
+            for item in class_node.body
+            if isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and self._is_private_helper(item.name)
+        }
+
+        calls = self._collect_self_calls(class_node)
+        for name, helper in helpers.items():
+            helper_calls = calls.get(name, [])
+            if self._should_flag(helper, helper_calls):
+                self._add_helper_error(helper, helper_calls[0][1])
+
+    def _should_flag(
+        self,
+        helper: ast.FunctionDef | ast.AsyncFunctionDef,
+        calls: list[tuple[ast.Call, ast.FunctionDef | ast.AsyncFunctionDef]],
+    ) -> bool:
+        if len(calls) != 1:
+            return False
+
+        caller = calls[0][1]
+        if caller is helper:
+            return False
+
+        return self._is_simple_function(helper) and self._is_simple_function(caller)
+
+    def _add_helper_error(
+        self,
+        helper: ast.FunctionDef | ast.AsyncFunctionDef,
+        caller: ast.FunctionDef | ast.AsyncFunctionDef,
+    ) -> None:
+        self.add_error(
+            helper,
+            (
+                f"Private helper '{helper.name}' is called only by simple "
+                f"'{caller.name}'; inline it unless the helper or caller grows "
+                "real branching, error handling, or reuse."
+            ),
+        )
+
+    def _is_private_helper(self, name: str) -> bool:
+        return name.startswith("_") and not (name.startswith("__") and name.endswith("__"))
+
+    def _is_simple_function(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+        body = self._body_without_docstring(node)
+        if len(body) > MAX_SIMPLE_STATEMENTS:
+            return False
+        return not any(isinstance(child, COMPLEX_NODES) for stmt in body for child in ast.walk(stmt))
+
+    def _body_without_docstring(
+        self, node: ast.FunctionDef | ast.AsyncFunctionDef
+    ) -> list[ast.stmt]:
+        body = list(node.body)
+        if (
+            body
+            and isinstance(body[0], ast.Expr)
+            and isinstance(body[0].value, ast.Constant)
+            and isinstance(body[0].value.value, str)
+        ):
+            return body[1:]
+        return body
+
+    def _collect_module_calls(
+        self, node: ast.Module
+    ) -> dict[str, list[tuple[ast.Call, ast.FunctionDef | ast.AsyncFunctionDef]]]:
+        calls: dict[str, list[tuple[ast.Call, ast.FunctionDef | ast.AsyncFunctionDef]]] = {}
+        for item in node.body:
+            if isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                for call in self._calls_inside(item):
+                    if isinstance(call.func, ast.Name):
+                        calls.setdefault(call.func.id, []).append((call, item))
+        return calls
+
+    def _collect_self_calls(
+        self, class_node: ast.ClassDef
+    ) -> dict[str, list[tuple[ast.Call, ast.FunctionDef | ast.AsyncFunctionDef]]]:
+        calls: dict[str, list[tuple[ast.Call, ast.FunctionDef | ast.AsyncFunctionDef]]] = {}
+        for item in class_node.body:
+            if isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                for call in self._calls_inside(item):
+                    if self._is_self_attr_call(call):
+                        calls.setdefault(call.func.attr, []).append((call, item))
+        return calls
+
+    def _calls_inside(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> list[ast.Call]:
+        return [child for stmt in self._body_without_docstring(node) for child in ast.walk(stmt) if isinstance(child, ast.Call)]
+
+    def _is_self_attr_call(self, node: ast.Call) -> bool:
+        return (
+            isinstance(node.func, ast.Attribute)
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id in {"self", "cls"}
+        )

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,6 +77,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Clone Determystic
+        run: git clone --depth 1 https://github.com/piercefreeman/deterministic.git ../deterministic
+
       - uses: ./.github/actions/setup-python-rust
         with:
           python-version: ${{ matrix.python-version }}

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,9 @@ DOCS_WEBSITE_NAME := docs_website
 SCRIPTS_DIR := .github
 SCRIPTS_NAME := scripts
 
+DETERMYSTIC_LOCAL_PACKAGE ?= $(abspath ../deterministic)
+DETERMYSTIC_VALIDATE ?= $(if $(wildcard $(DETERMYSTIC_LOCAL_PACKAGE)/pyproject.toml),uv run --with-editable $(DETERMYSTIC_LOCAL_PACKAGE) determystic validate,uv run --with determystic determystic validate)
+
 # Ignore these directories in the local filesystem if they exist
 .PHONY: lint test
 
@@ -64,6 +67,8 @@ lint-scripts:
 # Lint validation - CI to fail on any errors
 lint-validation-lib:
 	$(call lint-validation-common,$(LIB_DIR),$(LIB_NAME))
+	@echo "\n=== Running Determystic validation for $(LIB_NAME) ==="
+	@(cd $(LIB_DIR) && $(DETERMYSTIC_VALIDATE))
 	$(call lint-rust,$(LIB_DIR))
 lint-validation-create-mountaineer-app:
 	$(call lint-validation-common,$(CREATE_MOUNTAINEER_APP_DIR),$(CREATE_MOUNTAINEER_APP_NAME))

--- a/mountaineer/__tests__/client_builder/file_generators/test_globals.py
+++ b/mountaineer/__tests__/client_builder/file_generators/test_globals.py
@@ -97,32 +97,62 @@ def controller_wrappers(controller_parser: ControllerParser) -> list[ControllerW
     ]
 
 
+@pytest.fixture
+def controller_generator(
+    managed_path: ManagedViewPath,
+    controller_wrappers: List[ControllerWrapper],
+) -> GlobalControllerGenerator:
+    return GlobalControllerGenerator(
+        managed_path=managed_path, controller_wrappers=controller_wrappers
+    )
+
+
+@pytest.fixture
+def parsed_controllers(
+    controller_parser: ControllerParser, managed_path: ManagedViewPath
+) -> List[ParsedController]:
+    (managed_path / "child").mkdir()
+    (managed_path / "layout").mkdir()
+
+    return [
+        ParsedController(
+            wrapper=controller_parser.parse_controller(ChildController),
+            view_path=ManagedViewPath(managed_path / "child"),
+            is_layout=False,
+        ),
+        ParsedController(
+            wrapper=controller_parser.parse_controller(LayoutController),
+            view_path=ManagedViewPath(managed_path / "layout"),
+            is_layout=True,
+        ),
+    ]
+
+
+@pytest.fixture
+def link_generator(
+    managed_path: ManagedViewPath, parsed_controllers: List[ParsedController]
+) -> GlobalLinkGenerator:
+    return GlobalLinkGenerator(
+        managed_path=managed_path, parsed_controllers=parsed_controllers
+    )
+
+
 # Tests
 class TestGlobalControllerGenerator:
-    @pytest.fixture
-    def generator(
-        self,
-        managed_path: ManagedViewPath,
-        controller_wrappers: List[ControllerWrapper],
-    ) -> GlobalControllerGenerator:
-        return GlobalControllerGenerator(
-            managed_path=managed_path, controller_wrappers=controller_wrappers
-        )
-
     def test_model_enum_graph_resolution(
-        self, generator: GlobalControllerGenerator
+        self, controller_generator: GlobalControllerGenerator
     ) -> None:
         """Test that models and enums are sorted correctly"""
         # Get embedded types
         controllers = ControllerWrapper.get_all_embedded_controllers(
-            generator.controller_wrappers
+            controller_generator.controller_wrappers
         )
         embedded = ControllerWrapper.get_all_embedded_types(
             controllers, include_superclasses=True
         )
 
         # Sort them
-        sorted_items = generator._build_model_enum_graph(
+        sorted_items = controller_generator._build_model_enum_graph(
             embedded.models, embedded.enums
         )
 
@@ -143,13 +173,13 @@ class TestGlobalControllerGenerator:
         assert main_model_idx < dependent_model_idx
 
     def test_controller_graph_resolution(
-        self, generator: GlobalControllerGenerator
+        self, controller_generator: GlobalControllerGenerator
     ) -> None:
         """Test that controllers are sorted correctly"""
         controllers = ControllerWrapper.get_all_embedded_controllers(
-            generator.controller_wrappers
+            controller_generator.controller_wrappers
         )
-        sorted_controllers = generator._build_controller_graph(controllers)
+        sorted_controllers = controller_generator._build_controller_graph(controllers)
 
         base_idx = self.get_item_order(sorted_controllers, "BaseController")
         child_idx = self.get_item_order(sorted_controllers, "ChildController")
@@ -157,9 +187,11 @@ class TestGlobalControllerGenerator:
         # Base should come before Child
         assert base_idx < child_idx
 
-    def test_script_generation(self, generator: GlobalControllerGenerator) -> None:
+    def test_script_generation(
+        self, controller_generator: GlobalControllerGenerator
+    ) -> None:
         """Test the complete script generation"""
-        blocks = generator.script()
+        blocks = controller_generator.script()
         content = "\n".join(block.content for block in blocks)
 
         # Verify models are generated
@@ -189,37 +221,9 @@ class TestGlobalControllerGenerator:
 
 
 class TestGlobalLinkGenerator:
-    @pytest.fixture
-    def parsed_controllers(
-        self, controller_parser: ControllerParser, managed_path: ManagedViewPath
-    ) -> List[ParsedController]:
-        (managed_path / "child").mkdir()
-        (managed_path / "layout").mkdir()
-
-        return [
-            ParsedController(
-                wrapper=controller_parser.parse_controller(ChildController),
-                view_path=ManagedViewPath(managed_path / "child"),
-                is_layout=False,
-            ),
-            ParsedController(
-                wrapper=controller_parser.parse_controller(LayoutController),
-                view_path=ManagedViewPath(managed_path / "layout"),
-                is_layout=True,
-            ),
-        ]
-
-    @pytest.fixture
-    def generator(
-        self, managed_path: ManagedViewPath, parsed_controllers: List[ParsedController]
-    ) -> GlobalLinkGenerator:
-        return GlobalLinkGenerator(
-            managed_path=managed_path, parsed_controllers=parsed_controllers
-        )
-
-    def test_script_generation(self, generator: GlobalLinkGenerator) -> None:
+    def test_script_generation(self, link_generator: GlobalLinkGenerator) -> None:
         """Test link aggregator generation"""
-        blocks = generator.script()
+        blocks = link_generator.script()
         content = "\n".join(block.content for block in blocks)
 
         # Verify imports

--- a/mountaineer/__tests__/client_builder/file_generators/test_locals.py
+++ b/mountaineer/__tests__/client_builder/file_generators/test_locals.py
@@ -115,38 +115,93 @@ def controller_wrapper(controller_parser: ControllerParser) -> ControllerWrapper
     return controller_parser.parse_controller(ExampleController)
 
 
+@pytest.fixture
+def base_generator(
+    managed_path: ManagedViewPath, global_root: ManagedViewPath
+) -> LocalGeneratorBase:
+    class ConcreteGeneratorBase(LocalGeneratorBase):
+        def script(self):
+            yield CodeBlock()
+
+    return ConcreteGeneratorBase(managed_path=managed_path, global_root=global_root)
+
+
+@pytest.fixture
+def link_generator(
+    managed_path: ManagedViewPath,
+    global_root: ManagedViewPath,
+    controller_wrapper: ControllerWrapper,
+) -> LocalLinkGenerator:
+    return LocalLinkGenerator(
+        controller=controller_wrapper,
+        managed_path=managed_path,
+        global_root=global_root,
+    )
+
+
+@pytest.fixture
+def action_generator(
+    managed_path: ManagedViewPath,
+    global_root: ManagedViewPath,
+    controller_wrapper: ControllerWrapper,
+) -> LocalActionGenerator:
+    return LocalActionGenerator(
+        controller=controller_wrapper,
+        managed_path=managed_path,
+        global_root=global_root,
+    )
+
+
+@pytest.fixture
+def model_generator(
+    managed_path: ManagedViewPath,
+    global_root: ManagedViewPath,
+    controller_wrapper: ControllerWrapper,
+) -> LocalModelGenerator:
+    return LocalModelGenerator(
+        controller=controller_wrapper,
+        managed_path=managed_path,
+        global_root=global_root,
+    )
+
+
+@pytest.fixture
+def server_generator(
+    managed_path: ManagedViewPath,
+    global_root: ManagedViewPath,
+    controller_wrapper: ControllerWrapper,
+) -> LocalUseServerGenerator:
+    return LocalUseServerGenerator(
+        controller=controller_wrapper,
+        managed_path=managed_path,
+        global_root=global_root,
+    )
+
+
+@pytest.fixture
+def index_generator(
+    managed_path: ManagedViewPath,
+    global_root: ManagedViewPath,
+    controller_wrapper: ControllerWrapper,
+) -> LocalIndexGenerator:
+    return LocalIndexGenerator(
+        controller=controller_wrapper,
+        managed_path=managed_path,
+        global_root=global_root,
+    )
+
+
 class TestLocalGeneratorBase:
-    @pytest.fixture
-    def generator(self, managed_path: ManagedViewPath, global_root: ManagedViewPath):
-        class ConcreteGeneratorBase(LocalGeneratorBase):
-            def script(self):
-                yield CodeBlock()
-
-        return ConcreteGeneratorBase(managed_path=managed_path, global_root=global_root)
-
-    def test_get_global_import_path(self, generator: LocalGeneratorBase) -> None:
-        result: str = generator.get_global_import_path("test.ts")
+    def test_get_global_import_path(self, base_generator: LocalGeneratorBase) -> None:
+        result: str = base_generator.get_global_import_path("test.ts")
         assert isinstance(result, str)
         assert "../" in result
         assert result.endswith("test")
 
 
 class TestLocalLinkGenerator:
-    @pytest.fixture
-    def generator(
-        self,
-        managed_path: ManagedViewPath,
-        global_root: ManagedViewPath,
-        controller_wrapper: ControllerWrapper,
-    ) -> Any:
-        return LocalLinkGenerator(
-            controller=controller_wrapper,
-            managed_path=managed_path,
-            global_root=global_root,
-        )
-
-    def test_script_generation(self, generator: LocalLinkGenerator) -> None:
-        result = list(generator.script())
+    def test_script_generation(self, link_generator: LocalLinkGenerator) -> None:
+        result = list(link_generator.script())
         assert len(result) > 0
         content = "\n".join(block.content for block in result)
         assert "import" in content
@@ -156,36 +211,27 @@ class TestLocalLinkGenerator:
         assert "enum_param" in content
 
     def test_get_link_implementation_with_parameters(
-        self, generator: LocalLinkGenerator
+        self, link_generator: LocalLinkGenerator
     ) -> None:
-        impl = generator._get_link_implementation(generator.controller)
+        impl = link_generator._get_link_implementation(link_generator.controller)
         assert "path_param" in impl
         assert "query_param?" in impl  # Optional parameter
         assert "enum_param?" in impl  # Optional parameter
         assert "/test" in impl
 
-    def test_get_imports(self, generator: LocalLinkGenerator) -> None:
-        imports = list(generator._get_imports(generator.controller))
+    def test_get_imports(self, link_generator: LocalLinkGenerator) -> None:
+        imports = list(link_generator._get_imports(link_generator.controller))
         assert any("../api" in block.content for block in imports)
         assert any("../controllers" in block.content for block in imports)
 
 
 class TestLocalActionGenerator:
-    @pytest.fixture
-    def generator(
-        self,
-        managed_path: ManagedViewPath,
-        global_root: ManagedViewPath,
-        controller_wrapper: ControllerWrapper,
-    ) -> Any:
-        return LocalActionGenerator(
-            controller=controller_wrapper,
-            managed_path=managed_path,
-            global_root=global_root,
+    def test_generate_controller_actions(
+        self, action_generator: LocalActionGenerator
+    ) -> None:
+        actions = list(
+            action_generator._generate_controller_actions(action_generator.controller)
         )
-
-    def test_generate_controller_actions(self, generator: LocalActionGenerator) -> None:
-        actions = list(generator._generate_controller_actions(generator.controller))
         assert len(actions) == 4  # base_action, get_data, update_data, upload_file
         action_names: set[str] = {
             action
@@ -194,8 +240,10 @@ class TestLocalActionGenerator:
         }
         assert len(action_names) == 4
 
-    def test_get_dependent_imports(self, generator: LocalActionGenerator) -> None:
-        deps = generator._get_dependent_imports(generator.controller)
+    def test_get_dependent_imports(
+        self, action_generator: LocalActionGenerator
+    ) -> None:
+        deps = action_generator._get_dependent_imports(action_generator.controller)
 
         # Response wrapped models
         assert deps == {
@@ -208,9 +256,9 @@ class TestLocalActionGenerator:
         }
 
     def test_exception_payload_imports_are_type_only(
-        self, generator: LocalActionGenerator
+        self, action_generator: LocalActionGenerator
     ) -> None:
-        content = "\n".join(block.content for block in generator.script())
+        content = "\n".join(block.content for block in action_generator.script())
 
         assert "import { __request, FetchErrorBase }" in content
         assert (
@@ -228,21 +276,8 @@ class TestLocalActionGenerator:
 
 
 class TestLocalModelGenerator:
-    @pytest.fixture
-    def generator(
-        self,
-        managed_path: ManagedViewPath,
-        global_root: ManagedViewPath,
-        controller_wrapper: ControllerWrapper,
-    ) -> Any:
-        return LocalModelGenerator(
-            controller=controller_wrapper,
-            managed_path=managed_path,
-            global_root=global_root,
-        )
-
-    def test_script_generation(self, generator: LocalModelGenerator) -> None:
-        result: List[Any] = list(generator.script())
+    def test_script_generation(self, model_generator: LocalModelGenerator) -> None:
+        result: List[Any] = list(model_generator.script())
         assert len(result) > 0
         content: str = "\n".join(block.content for block in result)
 
@@ -256,23 +291,10 @@ class TestLocalModelGenerator:
 
 
 class TestLocalUseServerGenerator:
-    @pytest.fixture
-    def generator(
-        self,
-        managed_path: ManagedViewPath,
-        global_root: ManagedViewPath,
-        controller_wrapper: ControllerWrapper,
-    ) -> Any:
-        return LocalUseServerGenerator(
-            controller=controller_wrapper,
-            managed_path=managed_path,
-            global_root=global_root,
-        )
-
     def test_script_generation_with_render(
-        self, generator: LocalUseServerGenerator
+        self, server_generator: LocalUseServerGenerator
     ) -> None:
-        result: List[Any] = list(generator.script())
+        result: List[Any] = list(server_generator.script())
         content: str = "\n".join(block.content for block in result)
         assert "useServer" in content
         assert "ServerState" in content
@@ -289,28 +311,15 @@ class TestLocalUseServerGenerator:
 
 
 class TestLocalIndexGenerator:
-    @pytest.fixture
-    def generator(
-        self,
-        managed_path: ManagedViewPath,
-        global_root: ManagedViewPath,
-        controller_wrapper: ControllerWrapper,
-    ) -> Any:
-        return LocalIndexGenerator(
-            controller=controller_wrapper,
-            managed_path=managed_path,
-            global_root=global_root,
-        )
-
     def test_script_generation(
-        self, generator: LocalIndexGenerator, managed_path: ManagedViewPath
+        self, index_generator: LocalIndexGenerator, managed_path: ManagedViewPath
     ) -> None:
         (managed_path.parent / "actions.ts").write_text(
             "export const action = () => {}"
         )
         (managed_path.parent / "models.ts").write_text("export type Model = {}")
 
-        result: List[Any] = list(generator.script())
+        result: List[Any] = list(index_generator.script())
         assert len(result) > 0
         content: str = "\n".join(block.content for block in result)
         assert "export * from './actions'" in content

--- a/mountaineer/__tests__/client_builder/test_aliases.py
+++ b/mountaineer/__tests__/client_builder/test_aliases.py
@@ -18,15 +18,17 @@ from mountaineer.controller import ControllerBase
 T = TypeVar("T")
 
 
+@pytest.fixture
+def parser() -> ControllerParser:
+    return ControllerParser()
+
+
+@pytest.fixture
+def alias_manager() -> AliasManager:
+    return AliasManager()
+
+
 class TestAliasManager:
-    @pytest.fixture
-    def parser(self) -> ControllerParser:
-        return ControllerParser()
-
-    @pytest.fixture
-    def alias_manager(self) -> AliasManager:
-        return AliasManager()
-
     def test_basic_name_normalization(
         self, parser: ControllerParser, alias_manager: AliasManager
     ) -> None:

--- a/mountaineer/__tests__/client_builder/test_parser.py
+++ b/mountaineer/__tests__/client_builder/test_parser.py
@@ -38,6 +38,24 @@ T = TypeVar("T")
 S = TypeVar("S")
 
 
+@pytest.fixture
+def parser():
+    parser = ControllerParser()
+    app_controller = AppController(view_root=Path())
+    app_controller.register(ExampleController())
+    return parser
+
+
+@pytest.fixture
+def base_model_wrapper(parser: ControllerParser):
+    return parser._parse_model(ExampleModelBase)
+
+
+@pytest.fixture
+def test_controller_wrapper(parser: ControllerParser):
+    return parser.parse_controller(ExampleController)
+
+
 # Core test enum
 class ExampleEnum(Enum):
     A = "a"
@@ -161,21 +179,6 @@ class SpecialTypesController(ControllerBase):
 
 # Tests
 class TestControllerParser:
-    @pytest.fixture
-    def parser(self):
-        parser = ControllerParser()
-        app_controller = AppController(view_root=Path())
-        app_controller.register(ExampleController())
-        return parser
-
-    @pytest.fixture
-    def base_model_wrapper(self, parser: ControllerParser):
-        return parser._parse_model(ExampleModelBase)
-
-    @pytest.fixture
-    def test_controller_wrapper(self, parser: ControllerParser):
-        return parser.parse_controller(ExampleController)
-
     def test_parse_enum(self, parser: ControllerParser):
         wrapper = parser._parse_enum(ExampleEnum)
         assert isinstance(wrapper, EnumWrapper)
@@ -327,10 +330,6 @@ class TestControllerParser:
 
 
 class TestInheritanceHandling:
-    @pytest.fixture
-    def parser(self):
-        return ControllerParser()
-
     def test_basic_inheritance(self, parser: ControllerParser):
         wrapper = parser._parse_model(BaseInheritanceModel)
         assert len(wrapper.superclasses) == 1
@@ -345,10 +344,6 @@ class TestInheritanceHandling:
 
 
 class TestGenericHandling:
-    @pytest.fixture
-    def parser(self):
-        return ControllerParser()
-
     def test_basic_generic(self, parser: ControllerParser):
         wrapper = parser._parse_model(GenericTestModel[str])
         assert len(wrapper.value_models) == 2
@@ -371,13 +366,6 @@ class TestGenericHandling:
 
 
 class TestControllerWrapperFeatures:
-    @pytest.fixture
-    def parser(self):
-        parser = ControllerParser()
-        app_controller = AppController(view_root=Path())
-        app_controller.register(ExampleController())
-        return parser
-
     def test_all_actions_collection(self, parser: ControllerParser):
         wrapper = parser.parse_controller(ExampleController)
         action_names = {action.name for action in wrapper.all_actions}
@@ -421,10 +409,6 @@ class TestControllerWrapperFeatures:
 
 
 class TestIsolatedModelCreation:
-    @pytest.fixture
-    def parser(self):
-        return ControllerParser()
-
     def test_standard_model_isolation(self, parser: ControllerParser):
         class ParentModel(BaseModel):
             parent_field: str
@@ -527,13 +511,6 @@ class TestIsolatedModelCreation:
 
 
 class TestActionWrapper:
-    @pytest.fixture
-    def parser(self):
-        parser = ControllerParser()
-        app_controller = AppController(view_root=Path())
-        app_controller.register(ExampleController())
-        return parser
-
     @pytest.mark.parametrize(
         "params, headers, request_body, expected_has_required",
         [

--- a/mountaineer/__tests__/conftest.py
+++ b/mountaineer/__tests__/conftest.py
@@ -36,6 +36,18 @@ def clear_config_cache():
     unregister_config()
 
 
+@pytest.fixture(autouse=True)
+def cleanup_main_thread_event_loop():
+    yield
+    _cleanup_main_thread_event_loop()
+
+
+@pytest.fixture(scope="session", autouse=True)
+def cleanup_main_thread_event_loop_session():
+    yield
+    _cleanup_main_thread_event_loop()
+
+
 def _cleanup_main_thread_event_loop() -> None:
     """
     pytest-asyncio on Python 3.10 may leave the main thread's default loop attached to the
@@ -61,15 +73,3 @@ def _cleanup_main_thread_event_loop() -> None:
         event_loop.close()
 
     asyncio.set_event_loop(None)
-
-
-@pytest.fixture(autouse=True)
-def cleanup_main_thread_event_loop():
-    yield
-    _cleanup_main_thread_event_loop()
-
-
-@pytest.fixture(scope="session", autouse=True)
-def cleanup_main_thread_event_loop_session():
-    yield
-    _cleanup_main_thread_event_loop()

--- a/mountaineer/__tests__/development/conftest.py
+++ b/mountaineer/__tests__/development/conftest.py
@@ -14,43 +14,6 @@ from mountaineer.__tests__.fixtures import get_fixture_path
 AppPackageType = tuple[str, Path, Path]
 
 
-def create_package_json(views_path: Path) -> None:
-    """
-    Create a package.json file with necessary React dependencies.
-
-    """
-    package_json = {
-        "name": "test-package",
-        "version": "1.0.0",
-        "description": "Test package for mountaineer",
-        "main": "index.js",
-        "scripts": {"test": 'echo "Error: no test specified" && exit 1'},
-        "dependencies": {"react": "^18.2.0", "react-dom": "^18.2.0"},
-        "devDependencies": {
-            "@types/react": "^18.2.0",
-            "@types/react-dom": "^18.2.0",
-            "typescript": "^5.0.0",
-        },
-    }
-
-    with open(views_path / "package.json", "w") as f:
-        json_dump(package_json, f, indent=2)
-
-
-def setup_npm_environment(package_path: Path) -> None:
-    """
-    Install npm dependencies in the package directory.
-
-    """
-    subprocess.run(
-        ["npm", "install"],
-        cwd=package_path,
-        check=True,
-        capture_output=True,
-        text=True,
-    )
-
-
 @pytest.fixture(scope="module")
 def simple_package_dependencies():
     """
@@ -141,3 +104,40 @@ def app_package(isolated_package_dir: tuple[Path, str]) -> AppPackageType:
     (views_dir / "test_controller" / "page.tsx").write_text("")
 
     return package_name, package_path, controller_file
+
+
+def create_package_json(views_path: Path) -> None:
+    """
+    Create a package.json file with necessary React dependencies.
+
+    """
+    package_json = {
+        "name": "test-package",
+        "version": "1.0.0",
+        "description": "Test package for mountaineer",
+        "main": "index.js",
+        "scripts": {"test": 'echo "Error: no test specified" && exit 1'},
+        "dependencies": {"react": "^18.2.0", "react-dom": "^18.2.0"},
+        "devDependencies": {
+            "@types/react": "^18.2.0",
+            "@types/react-dom": "^18.2.0",
+            "typescript": "^5.0.0",
+        },
+    }
+
+    with open(views_path / "package.json", "w") as f:
+        json_dump(package_json, f, indent=2)
+
+
+def setup_npm_environment(package_path: Path) -> None:
+    """
+    Install npm dependencies in the package directory.
+
+    """
+    subprocess.run(
+        ["npm", "install"],
+        cwd=package_path,
+        check=True,
+        capture_output=True,
+        text=True,
+    )

--- a/mountaineer/__tests__/test_cache.py
+++ b/mountaineer/__tests__/test_cache.py
@@ -14,14 +14,14 @@ from mountaineer.cache import AsyncLoopObjectCache, extended_lru_cache
 #
 
 
-@extended_lru_cache(maxsize=100)
-def get_random_data(param: int):
-    return random()
-
-
 @pytest.fixture(autouse=True)
 def reset_cache():
     get_random_data._cache.clear()  # type: ignore
+
+
+@extended_lru_cache(maxsize=100)
+def get_random_data(param: int):
+    return random()
 
 
 def test_extended_lru_cache():

--- a/mountaineer/__tests__/test_static.py
+++ b/mountaineer/__tests__/test_static.py
@@ -8,6 +8,30 @@ from mountaineer.logging import LOGGER
 from mountaineer.static import get_static_path
 
 
+@pytest.fixture(scope="session")
+def setup_test_environment(tmp_path_factory: pytest.TempPathFactory):
+    temp_dir = tmp_path_factory.mktemp("test_environment")
+    harness_path = get_static_path(".")
+
+    # Copy all files from harness directory to temp directory
+    for item in os.listdir(harness_path):
+        s = os.path.join(harness_path, item)
+        d = os.path.join(temp_dir, item)
+        if os.path.isdir(s):
+            copytree(s, d)
+        else:
+            copy2(s, d)
+
+    # The harness with package.json lives within one nested directory
+    temp_dir = temp_dir / "harness"
+
+    try:
+        run_command("npm install", cwd=str(temp_dir))
+        yield temp_dir
+    finally:
+        LOGGER.info(f"Test environment cleaned up at {temp_dir}")
+
+
 def run_command(command: str, cwd: str) -> tuple[str, str]:
     try:
         # Use subprocess.Popen to capture output in real-time
@@ -34,30 +58,6 @@ def run_command(command: str, cwd: str) -> tuple[str, str]:
         LOGGER.error(f"Error executing command: {command}")
         LOGGER.error(f"Error output:\n{e.stderr}")
         raise
-
-
-@pytest.fixture(scope="session")
-def setup_test_environment(tmp_path_factory: pytest.TempPathFactory):
-    temp_dir = tmp_path_factory.mktemp("test_environment")
-    harness_path = get_static_path(".")
-
-    # Copy all files from harness directory to temp directory
-    for item in os.listdir(harness_path):
-        s = os.path.join(harness_path, item)
-        d = os.path.join(temp_dir, item)
-        if os.path.isdir(s):
-            copytree(s, d)
-        else:
-            copy2(s, d)
-
-    # The harness with package.json lives within one nested directory
-    temp_dir = temp_dir / "harness"
-
-    try:
-        run_command("npm install", cwd=str(temp_dir))
-        yield temp_dir
-    finally:
-        LOGGER.info(f"Test environment cleaned up at {temp_dir}")
 
 
 def test_static_frontend(setup_test_environment: str):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,9 @@ select = ["E4", "E7", "E9", "F", "I001", "T201"]
 [tool.ruff.lint.isort]
 combine-as-imports = true
 
+[tool.determystic]
+paths_include = ["mountaineer"]
+
 [tool.pytest.ini_options]
 markers = ["integration_tests: run longer-running integration tests"]
 # Default pytest runs shouldn't execute the integration tests


### PR DESCRIPTION
Mountaineer should enforce its Python conventions deterministically and keep them blocking in CI.

- add Determystic rules and behavioral tests for fixture placement, future annotations, and trivial single-use helpers
- move existing fixtures into module-level fixture blocks, resolving all 26 violations found in the Mountaineer source scan
- clone Determystic in the lint job and run validation through the existing Makefile CI target

Validated with all 29 rule tests, 85 affected pytest tests, Ruff, Ty, rustfmt, and Clippy.