### PR TITLE
Refactor error class definitions to global module

### DIFF
--- a/mountaineer/__tests__/client_builder/test_generated_client_integration.py
+++ b/mountaineer/__tests__/client_builder/test_generated_client_integration.py
@@ -80,6 +80,10 @@ class DetailController(ControllerBase):
             metadata=Metadata(title=f"Detail: {item_id}"),
         )
 
+    @passthrough
+    def get_detail_message(self) -> GetMessageResponse:
+        return GetMessageResponse(message="detail")
+
 
 @pytest.mark.integration_tests
 def test_generated_use_server_roundtrip(tmp_path: Path):

--- a/mountaineer/__tests__/fixtures/generated_client_project/__tests__/generated_client_roundtrip_test.ts
+++ b/mountaineer/__tests__/fixtures/generated_client_project/__tests__/generated_client_roundtrip_test.ts
@@ -3,7 +3,12 @@ import React, { act } from "react";
 import { createRoot } from "react-dom/client";
 import { JSDOM } from "jsdom";
 
-import { useServer } from "../app/home/.mountaineer";
+import { RequestValidationError } from "../.mountaineer";
+import { RequestValidationError as DetailRequestValidationError } from "../app/detail/.mountaineer";
+import {
+  RequestValidationError as HomeRequestValidationError,
+  useServer,
+} from "../app/home/.mountaineer";
 
 const baseUrl = process.env.MOUNTAINEER_BASE_URL!;
 const serverData = JSON.parse(process.env.MOUNTAINEER_SERVER_DATA_JSON!);
@@ -43,6 +48,9 @@ afterAll(() => {
 
 describe("generated useServer integration", () => {
   it("round trips sideeffects and keeps callbacks stable across rerenders", async () => {
+    expect(HomeRequestValidationError).toBe(RequestValidationError);
+    expect(DetailRequestValidationError).toBe(RequestValidationError);
+
     let latestState: any;
 
     function Probe() {
@@ -65,6 +73,14 @@ describe("generated useServer integration", () => {
     expect(
       initialState.linkGenerator.detailController({ item_id: "generated-link" }),
     ).toBe("/detail/generated-link");
+
+    await expect(
+      initialState.increment_count({
+        requestBody: {
+          count: "invalid",
+        },
+      }),
+    ).rejects.toBeInstanceOf(RequestValidationError);
 
     await act(async () => {
       const passthrough = await initialState.get_message();

--- a/src/client_builder/typescript/actions.rs
+++ b/src/client_builder/typescript/actions.rs
@@ -1,5 +1,5 @@
 use super::super::{
-    manifest::{Action, SchemaComponent, View},
+    manifest::{Action, ComponentKind, Envelope, SchemaComponent, View},
     Result,
 };
 use super::schema::{
@@ -9,6 +9,27 @@ use super::support::{destructured, import_path, shorthand_object, sorted};
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
+pub(super) fn global_exceptions(envelope: &Envelope) -> Vec<String> {
+    let mut exceptions = envelope
+        .components
+        .iter()
+        .filter(|component| component.kind == ComponentKind::Exception)
+        .collect::<Vec<_>>();
+    exceptions.sort_by_key(|component| &component.global_name);
+    if exceptions.is_empty() {
+        return Vec::new();
+    }
+
+    let mut blocks = vec!["import { FetchErrorBase } from './api';".into()];
+    blocks.extend(exceptions.into_iter().map(|component| {
+        format!(
+            "export class {} extends FetchErrorBase<import('./controllers').{}> {{}}",
+            component.global_name, component.global_name
+        )
+    }));
+    blocks
+}
+
 pub(super) fn local_actions(
     view: &View,
     global_root: &Path,
@@ -16,6 +37,7 @@ pub(super) fn local_actions(
 ) -> Result<Vec<String>> {
     let current = view.managed_dir.join("actions.ts");
     let api = import_path(&current, &global_root.join("api.ts"))?;
+    let exceptions = import_path(&current, &global_root.join("exceptions.ts"))?;
     let controllers = import_path(&current, &global_root.join("controllers.ts"))?;
     let mut dependencies = HashSet::new();
     let mut exception_names = HashSet::new();
@@ -31,9 +53,7 @@ pub(super) fn local_actions(
         }
         exception_names.extend(action.exceptions.iter().map(String::as_str));
     }
-    let mut imports = vec![format!(
-        "import {{ __request, FetchErrorBase }} from '{api}';"
-    )];
+    let mut imports = vec![format!("import {{ __request }} from '{api}';")];
     if !dependencies.is_empty() {
         imports.push(format!(
             "import type {{ {} }} from '{controllers}';",
@@ -41,19 +61,24 @@ pub(super) fn local_actions(
         ));
     }
 
-    let mut definitions = Vec::new();
-    for name in sorted(exception_names) {
-        let component = components
-            .get(name)
-            .ok_or_else(|| format!("Unknown exception component {name}"))?;
-        let base = format!("{}Base", component.local_name);
+    let exception_names = sorted(exception_names);
+    let mut exception_exports = Vec::new();
+    if !exception_names.is_empty() {
+        let mut exception_imports = Vec::new();
+        for name in exception_names {
+            let component = components
+                .get(name)
+                .ok_or_else(|| format!("Unknown exception component {name}"))?;
+            exception_imports.push(if component.global_name == component.local_name {
+                component.global_name.clone()
+            } else {
+                format!("{} as {}", component.global_name, component.local_name)
+            });
+            exception_exports.push(component.local_name.clone());
+        }
         imports.push(format!(
-            "import type {{ {} as {base} }} from '{controllers}';",
-            component.global_name
-        ));
-        definitions.push(format!(
-            "export class {} extends FetchErrorBase<{base}> {{}}",
-            component.local_name
+            "import {{ {} }} from '{exceptions}';",
+            exception_imports.join(", ")
         ));
     }
 
@@ -61,7 +86,9 @@ pub(super) fn local_actions(
     for action in &view.actions {
         blocks.push(action_definition(action, view, components)?);
     }
-    blocks.extend(definitions);
+    if !exception_exports.is_empty() {
+        blocks.push(format!("export {{ {} }};", exception_exports.join(", ")));
+    }
     Ok(blocks)
 }
 

--- a/src/client_builder/typescript/mod.rs
+++ b/src/client_builder/typescript/mod.rs
@@ -6,12 +6,16 @@ mod support;
 mod use_server;
 
 use self::{
-    actions::local_actions,
+    actions::{global_exceptions, local_actions},
     controllers::{global_controllers, local_models},
     links::{global_links, local_links},
     use_server::local_use_server,
 };
-use super::{manifest::Envelope, output::OutputPlan, Result};
+use super::{
+    manifest::{ComponentKind, Envelope},
+    output::OutputPlan,
+    Result,
+};
 use std::collections::HashMap;
 
 pub(super) fn render(envelope: &Envelope) -> Result<OutputPlan> {
@@ -41,18 +45,32 @@ pub(super) fn render(envelope: &Envelope) -> Result<OutputPlan> {
         generated(&envelope.mountaineer_version, global_controllers(envelope)),
     )?;
     output.write(
+        envelope.global_root.join("exceptions.ts"),
+        generated(&envelope.mountaineer_version, global_exceptions(envelope)),
+    )?;
+    output.write(
         envelope.global_root.join("links.ts"),
         generated(&envelope.mountaineer_version, global_links(envelope)?),
     )?;
+    let mut root_exports = vec![
+        "export * from './api';\nexport * from './controllers';\nexport * from './links';".into(),
+    ];
+    let mut exception_names = envelope
+        .components
+        .iter()
+        .filter(|component| component.kind == ComponentKind::Exception)
+        .map(|component| component.global_name.as_str())
+        .collect::<Vec<_>>();
+    exception_names.sort_unstable();
+    if !exception_names.is_empty() {
+        root_exports.push(format!(
+            "export {{ {} }} from './exceptions';",
+            exception_names.join(", ")
+        ));
+    }
     output.write(
         envelope.global_root.join("index.ts"),
-        generated(
-            &envelope.mountaineer_version,
-            vec![
-                "export * from './api';\nexport * from './controllers';\nexport * from './links';"
-                    .into(),
-            ],
-        ),
+        generated(&envelope.mountaineer_version, root_exports),
     )?;
 
     for view in &envelope.views {


### PR DESCRIPTION
- What: Generate each client error class once in the root `.mountaineer` module while retaining view-level re-exports.
- Why: Shared constructors let code used by multiple `useServer` hooks reliably detect errors with `instanceof`.
- Issue: https://github.com/piercefreeman/mountaineer/issues/196