### PR TITLE
Proxy Vite development assets through app server

### DIFF
--- a/crates/lib/vite/assets/entrypoints.mjs
+++ b/crates/lib/vite/assets/entrypoints.mjs
@@ -35,18 +35,18 @@ export function mountaineerEntrypoints(entrypoints, target) {
   };
 }
 
-export function developmentClientSource(views, styles) {
+export function developmentClientSource(views, styles, base) {
   return `
-import "/@vite/client";
-import RefreshRuntime from "/@react-refresh";
+import "${base}@vite/client";
+import RefreshRuntime from "${base}@react-refresh";
 RefreshRuntime.injectIntoGlobalHook(window);
 window.$RefreshReg$ = () => {};
 window.$RefreshSig$ = () => (type) => type;
 window.__vite_plugin_react_preamble_installed__ = true;
 await Promise.all(${JSON.stringify(styles)}.map((source) => import(source)));
-const ReactModule = await import("/@id/react");
+const ReactModule = await import("${base}@id/react");
 const React = ReactModule.default ?? ReactModule;
-const ReactDOMModule = await import("/@id/react-dom/client");
+const ReactDOMModule = await import("${base}@id/react-dom/client");
 const { hydrateRoot } = ReactDOMModule.default ?? ReactDOMModule;
 const components = await Promise.all(
   ${JSON.stringify(views)}.map((source) => import(source)),

--- a/crates/lib/vite/assets/vite.config.mjs
+++ b/crates/lib/vite/assets/vite.config.mjs
@@ -29,6 +29,7 @@ const react = (
 
 const development =
   mountaineer.mode === "development" ? mountaineer : undefined;
+const developmentBase = development?.base;
 const clientBuild =
   mountaineer.mode === "build_client" ? mountaineer : undefined;
 const ssrBuild = mountaineer.mode === "build_ssr" ? mountaineer : undefined;
@@ -49,7 +50,7 @@ const styleEntries = Object.fromEntries(
 export default defineConfig({
   root: mountaineer.frontend_root,
   appType: "custom",
-  base: "./",
+  base: developmentBase ?? "./",
   clearScreen: false,
   resolve: {
     alias: [
@@ -89,7 +90,7 @@ export default defineConfig({
             name: "mountaineer:development",
             configureServer(server) {
               server.middlewares.use(
-                "/@mountaineer/client",
+                `${developmentBase}@mountaineer/client`,
                 (request, response) => {
                   const params = new URL(
                     request.url ?? "",
@@ -97,10 +98,16 @@ export default defineConfig({
                   ).searchParams;
                   const views = params
                     .getAll("view")
-                    .map((view) => `/@fs/${view.replaceAll("\\", "/")}`);
+                    .map(
+                      (view) =>
+                        `${developmentBase}@fs/${view.replaceAll("\\", "/")}`,
+                    );
                   const styles = params
                     .getAll("style")
-                    .map((style) => `/@fs/${style.replaceAll("\\", "/")}`);
+                    .map(
+                      (style) =>
+                        `${developmentBase}@fs/${style.replaceAll("\\", "/")}`,
+                    );
                   if (views.length === 0) {
                     response.statusCode = 400;
                     response.end("Missing Mountaineer view");
@@ -108,7 +115,9 @@ export default defineConfig({
                   }
 
                   response.setHeader("Content-Type", "text/javascript");
-                  response.end(developmentClientSource(views, styles));
+                  response.end(
+                    developmentClientSource(views, styles, developmentBase),
+                  );
                 },
               );
 
@@ -130,15 +139,9 @@ export default defineConfig({
   ],
   server: development
     ? {
-        host: development.host,
+        host: "127.0.0.1",
         port: development.port,
         strictPort: true,
-        cors: true,
-        origin: `http://${development.public_host}:${development.port}`,
-        hmr: {
-          host: development.public_host,
-          port: development.port,
-        },
         watch: {
           ignored: ["**/.mountaineer/**", "**/.mountaineer-vite/**"],
         },

--- a/crates/lib/vite/src/lib.rs
+++ b/crates/lib/vite/src/lib.rs
@@ -59,8 +59,8 @@ pub struct DevelopmentConfig {
     /// Root directory containing the application's frontend source.
     pub frontend_root: PathBuf,
 
-    /// Host interface Vite should listen on.
-    pub host: String,
+    /// Browser-visible path prefix routed to Vite by the public development server.
+    pub base: String,
 }
 
 /// One named Mountaineer page and its ordered layout hierarchy.
@@ -145,7 +145,7 @@ pub struct StyleBuildConfig {
 pub struct DevelopmentServer {
     child: Child,
     _directory: TempDir,
-    origin: String,
+    address: SocketAddr,
     backend_signal: PathBuf,
 }
 
@@ -157,11 +157,7 @@ impl DevelopmentServer {
         let javascript_runtime = javascript_runtime().await?;
         let directory = tempfile::tempdir()?;
         let port = reserve_loopback_port()?;
-        let public_host = match config.host.as_str() {
-            "0.0.0.0" | "::" => "127.0.0.1",
-            host => host,
-        };
-        let origin = format!("http://{public_host}:{port}");
+        let address = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port);
         let backend_signal = directory.path().join("backend-generation");
         fs::write(&backend_signal, b"1")?;
         write_config(
@@ -170,8 +166,7 @@ impl DevelopmentServer {
                 frontend_root: &frontend_root,
                 toolchain_package_json: toolchain_root.join("package.json"),
                 mode: Mode::Development {
-                    host: &config.host,
-                    public_host,
+                    base: &config.base,
                     port,
                     backend_signal: &backend_signal,
                 },
@@ -189,7 +184,6 @@ impl DevelopmentServer {
         .stderr(Stdio::inherit())
         .kill_on_drop(true)
         .spawn()?;
-        let address = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port);
         let ready = tokio::select! {
             result = wait_until_ready(address, Duration::from_secs(15)) => result,
             status = child.wait() => {
@@ -208,14 +202,14 @@ impl DevelopmentServer {
         Ok(Self {
             child,
             _directory: directory,
-            origin,
+            address,
             backend_signal,
         })
     }
 
-    /// Browser-visible origin of the running Vite server.
-    pub fn origin(&self) -> &str {
-        &self.origin
+    /// Loopback address of the running Vite server.
+    pub fn address(&self) -> SocketAddr {
+        self.address
     }
 
     /// Invalidates Vite's backend-dependent modules and reloads connected browsers.
@@ -381,8 +375,7 @@ struct Config<'a> {
 #[serde(tag = "mode", rename_all = "snake_case")]
 enum Mode<'a> {
     Development {
-        host: &'a str,
-        public_host: &'a str,
+        base: &'a str,
         port: u16,
         backend_signal: &'a Path,
     },

--- a/mountaineer/__tests__/test_cli.py
+++ b/mountaineer/__tests__/test_cli.py
@@ -2,6 +2,7 @@ import asyncio
 import os
 import re
 import signal
+from html import unescape
 from os import environ
 from pathlib import Path
 from random import uniform
@@ -107,6 +108,57 @@ async def check_server_ready(port: int, timeout: int = 20):
     return False, status_code
 
 
+async def check_development_frontend(port: int):
+    public_host = f"dev.mountaineer.test:{port}"
+    async with httpx.AsyncClient(base_url=f"http://127.0.0.1:{port}") as client:
+        response = await client.get("/", headers={"Host": public_host})
+        assert response.status_code == 200
+
+        asset_paths = [
+            unescape(path)
+            for _, path in re.findall(r"(?:src|href)=(['\"])(.*?)\1", response.text)
+            if path.startswith("/__mountaineer__/")
+        ]
+        assert asset_paths
+
+        client_path = next(
+            path for path in asset_paths if "/@mountaineer/client?" in path
+        )
+        client_response = await client.get(client_path, headers={"Host": public_host})
+        assert client_response.status_code == 200
+
+        module_paths = set(
+            re.findall(r'"(/__mountaineer__/[^\"]+)"', client_response.text)
+        )
+        assert module_paths
+        for path in module_paths:
+            module_response = await client.get(path, headers={"Host": public_host})
+            assert module_response.status_code == 200, path
+
+    reader, writer = await asyncio.open_connection("127.0.0.1", port)
+    try:
+        writer.write(
+            (
+                "GET /__mountaineer__/ HTTP/1.1\r\n"
+                f"Host: {public_host}\r\n"
+                "Upgrade: websocket\r\n"
+                "Connection: Upgrade\r\n"
+                "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
+                "Sec-WebSocket-Version: 13\r\n"
+                "Sec-WebSocket-Protocol: vite-hmr\r\n"
+                "\r\n"
+            ).encode()
+        )
+        await writer.drain()
+        response_headers = await asyncio.wait_for(
+            reader.readuntil(b"\r\n\r\n"), timeout=5
+        )
+        assert response_headers.startswith(b"HTTP/1.1 101 Switching Protocols\r\n")
+    finally:
+        writer.close()
+        await writer.wait_closed()
+
+
 @pytest.mark.integration_tests
 @pytest.mark.asyncio
 async def test_runserver_with_user_modifications(tmp_ci_webapp: Path):
@@ -129,7 +181,7 @@ async def test_runserver_with_user_modifications(tmp_ci_webapp: Path):
 
     # The project's runserver command delegates to the native development server.
     server_process = Popen(
-        ["uv", "run", "runserver", "--port", str(port)],
+        ["uv", "run", "runserver", "--host", "0.0.0.0", "--port", str(port)],
         cwd=tmp_ci_webapp,
         env=uv_env,
     )
@@ -138,6 +190,7 @@ async def test_runserver_with_user_modifications(tmp_ci_webapp: Path):
     try:
         is_ready, status_code = await check_server_ready(port)
         assert is_ready, f"Server did not become ready (last status: {status_code})"
+        await check_development_frontend(port)
 
         for _ in range(5):
             with open(test_file_path, "a") as f:

--- a/src/cli/development/mod.rs
+++ b/src/cli/development/mod.rs
@@ -3,7 +3,7 @@ mod proxy;
 
 use self::{
     hot_reload::{discover_imports, ActiveWorker, PythonHotReload},
-    proxy::{reserve_loopback_port, serve_proxy, wait_until_ready},
+    proxy::{reserve_loopback_port, serve_proxy, wait_until_ready, VITE_PROXY_PREFIX},
 };
 use super::{
     config::{write_payload, LaunchConfig, RuntimeMode, ServerConfig},
@@ -65,7 +65,7 @@ pub(super) async fn run(args: &[String], python: String) -> Result<()> {
     let payload_dir = tempfile::tempdir()?;
     let mut vite = ViteDevServer::spawn(ViteConfig {
         frontend_root: config.frontend_root.clone(),
-        host: config.host.clone(),
+        base: VITE_PROXY_PREFIX.to_string(),
     })
     .await?;
     let mut generation = 1;
@@ -77,7 +77,7 @@ pub(super) async fn run(args: &[String], python: String) -> Result<()> {
         &payload_dir,
         &mut hot_reload,
         generation,
-        vite.origin(),
+        VITE_PROXY_PREFIX.trim_end_matches('/'),
         true,
     )
     .await?;
@@ -90,7 +90,7 @@ pub(super) async fn run(args: &[String], python: String) -> Result<()> {
         debounce: Duration::from_millis(debounce_ms),
     })?;
 
-    let mut proxy_task = tokio::spawn(serve_proxy(listener, active_target.clone()));
+    let mut proxy_task = tokio::spawn(serve_proxy(listener, active_target.clone(), vite.address()));
     finish_startup_spinner();
     status(
         Tone::Accent,
@@ -166,7 +166,7 @@ pub(super) async fn run(args: &[String], python: String) -> Result<()> {
                             &payload_dir,
                             &mut hot_reload,
                             generation,
-                            vite.origin(),
+                            VITE_PROXY_PREFIX.trim_end_matches('/'),
                             refresh_imports,
                         ).await {
                             Ok((candidate, target)) => {
@@ -219,7 +219,7 @@ pub(super) async fn run(args: &[String], python: String) -> Result<()> {
                             &payload_dir,
                             &mut candidate_strategy,
                             generation,
-                            vite.origin(),
+                            VITE_PROXY_PREFIX.trim_end_matches('/'),
                             true,
                         ).await {
                             Ok((candidate, target)) => {

--- a/src/cli/development/proxy.rs
+++ b/src/cli/development/proxy.rs
@@ -9,11 +9,13 @@ use std::{
     time::Duration,
 };
 use tokio::{
-    io::{copy_bidirectional, AsyncWriteExt},
+    io::{copy_bidirectional, AsyncReadExt, AsyncWriteExt},
     net::{TcpListener, TcpStream},
     sync::RwLock,
     time::{sleep, Instant},
 };
+
+pub(super) const VITE_PROXY_PREFIX: &str = "/__mountaineer__/";
 
 pub(super) async fn wait_until_ready(address: SocketAddr, wait: Duration) -> Result<()> {
     let deadline = Instant::now() + wait;
@@ -33,31 +35,108 @@ pub(super) async fn wait_until_ready(address: SocketAddr, wait: Duration) -> Res
 pub(super) async fn serve_proxy(
     listener: TcpListener,
     active_target: Arc<RwLock<Option<SocketAddr>>>,
+    vite_target: SocketAddr,
 ) -> Result<()> {
     loop {
-        let (mut inbound, _) = listener.accept().await?;
-        let target = *active_target.read().await;
+        let (inbound, _) = listener.accept().await?;
+        let active_target = active_target.clone();
         tokio::spawn(async move {
-            let Some(target) = target else {
-                let _ = inbound
-                    .write_all(
-                        b"HTTP/1.1 503 Service Unavailable\r\nContent-Length: 23\r\n\r\nBackend is starting up.",
-                    )
-                    .await;
-                return;
-            };
-            match TcpStream::connect(target).await {
-                Ok(mut outbound) => {
-                    let _ = copy_bidirectional(&mut inbound, &mut outbound).await;
-                }
-                Err(error) => status(
+            if let Err(error) = proxy_connection(inbound, active_target, vite_target).await {
+                status(
                     Tone::Warning,
                     "Warning",
-                    format!("backend proxy connection failed: {error}"),
-                ),
+                    format!("development proxy connection failed: {error}"),
+                );
             }
         });
     }
+}
+
+async fn proxy_connection(
+    mut inbound: TcpStream,
+    active_target: Arc<RwLock<Option<SocketAddr>>>,
+    vite_target: SocketAddr,
+) -> std::io::Result<()> {
+    let mut request = Vec::with_capacity(1024);
+    let mut chunk = [0_u8; 1024];
+    while !request.windows(4).any(|window| window == b"\r\n\r\n") && request.len() < 65536 {
+        let read = inbound.read(&mut chunk).await?;
+        if read == 0 {
+            return Ok(());
+        }
+        request.extend_from_slice(&chunk[..read]);
+    }
+
+    let vite_request = is_vite_request(&request);
+    let target = if vite_request {
+        Some(vite_target)
+    } else {
+        *active_target.read().await
+    };
+    let Some(target) = target else {
+        inbound
+            .write_all(
+                b"HTTP/1.1 503 Service Unavailable\r\nContent-Length: 23\r\n\r\nBackend is starting up.",
+            )
+            .await?;
+        return Ok(());
+    };
+
+    let mut outbound = TcpStream::connect(target).await?;
+    if vite_request {
+        rewrite_host(&mut request, vite_target);
+    }
+    if !is_websocket_upgrade(&request) {
+        close_after_response(&mut request);
+    }
+    outbound.write_all(&request).await?;
+    copy_bidirectional(&mut inbound, &mut outbound).await?;
+    Ok(())
+}
+
+fn rewrite_host(request: &mut Vec<u8>, host: SocketAddr) {
+    let Some(host_start) = request
+        .windows(b"\r\nhost:".len())
+        .position(|window| window.eq_ignore_ascii_case(b"\r\nhost:"))
+        .map(|position| position + 2)
+    else {
+        return;
+    };
+    let Some(host_end) = request[host_start..]
+        .windows(2)
+        .position(|window| window == b"\r\n")
+        .map(|position| host_start + position)
+    else {
+        return;
+    };
+    request.splice(host_start..host_end, format!("Host: {host}").bytes());
+}
+
+fn is_websocket_upgrade(request: &[u8]) -> bool {
+    std::str::from_utf8(request)
+        .is_ok_and(|request| request.to_ascii_lowercase().contains("upgrade: websocket"))
+}
+
+fn close_after_response(request: &mut Vec<u8>) {
+    if let Some(headers_end) = request.windows(4).position(|window| window == b"\r\n\r\n") {
+        request.splice(
+            headers_end..headers_end,
+            b"\r\nConnection: close".iter().copied(),
+        );
+    }
+}
+
+fn is_vite_request(request: &[u8]) -> bool {
+    let Some(line_end) = request.iter().position(|byte| *byte == b'\n') else {
+        return false;
+    };
+    let Ok(request_line) = std::str::from_utf8(&request[..line_end]) else {
+        return false;
+    };
+    request_line
+        .split_ascii_whitespace()
+        .nth(1)
+        .is_some_and(|path| path.starts_with(VITE_PROXY_PREFIX))
 }
 
 pub(super) fn reserve_loopback_port() -> Result<u16> {


### PR DESCRIPTION
Development pages previously referenced Vite on a separate random port. Those assets and the HMR WebSocket were unreachable when the app ran behind Docker, SSH port forwarding, a tunnel, or a custom hostname.

This routes Vite modules, styles, and HMR traffic through `/__mountaineer__/` on the public development server. Vite now listens only on loopback, and proxied Vite requests use its internal host so public hostnames remain accepted.