### PR TITLE
Avoid rewriting unchanged generated files

### DIFF
--- a/src/client_builder/mod.rs
+++ b/src/client_builder/mod.rs
@@ -16,7 +16,7 @@ pub fn build(payload: &str) -> Result<()> {
 mod tests {
     use super::*;
     use serde_json::{json, Value};
-    use std::fs;
+    use std::{fs, thread, time::Duration};
 
     fn controller(name: &str) -> Value {
         json!({
@@ -70,6 +70,32 @@ mod tests {
         assert_eq!(
             fs::read_to_string(global_root.join("api.ts")).unwrap(),
             "existing"
+        );
+    }
+
+    #[test]
+    fn identical_build_does_not_rewrite_generated_files() {
+        let directory = tempfile::tempdir().unwrap();
+        let global_root = directory.path().join(".mountaineer");
+        let payload = json!({
+            "schema_version": 1,
+            "mountaineer_version": "test",
+            "global_root": global_root,
+            "components": [],
+            "controllers": [],
+            "views": [],
+        });
+
+        build(&payload.to_string()).unwrap();
+        let generated = global_root.join("api.ts");
+        let first_modified = fs::metadata(&generated).unwrap().modified().unwrap();
+        thread::sleep(Duration::from_millis(20));
+
+        build(&payload.to_string()).unwrap();
+
+        assert_eq!(
+            fs::metadata(generated).unwrap().modified().unwrap(),
+            first_modified
         );
     }
 

--- a/src/client_builder/output.rs
+++ b/src/client_builder/output.rs
@@ -44,6 +44,12 @@ impl OutputPlan {
     pub(super) fn commit(self) -> Result<()> {
         let mut staged = Vec::with_capacity(self.writes.len());
         for generated in self.writes {
+            match fs::read(&generated.path) {
+                Ok(existing) if existing == generated.contents.as_bytes() => continue,
+                Ok(_) => {}
+                Err(error) if error.kind() == ErrorKind::NotFound => {}
+                Err(error) => return Err(error.into()),
+            }
             let parent = generated.path.parent().ok_or_else(|| {
                 format!("Generated path has no parent: {}", generated.path.display())
             })?;

--- a/src/client_builder/output.rs
+++ b/src/client_builder/output.rs
@@ -44,6 +44,8 @@ impl OutputPlan {
     pub(super) fn commit(self) -> Result<()> {
         let mut staged = Vec::with_capacity(self.writes.len());
         for generated in self.writes {
+            // Replacing byte-identical .mountaineer files emits source-change events that can
+            // loop regeneration and remount the frontend, losing UI state such as open modals.
             match fs::read(&generated.path) {
                 Ok(existing) if existing == generated.contents.as_bytes() => continue,
                 Ok(_) => {}


### PR DESCRIPTION
## Summary

- skip byte-identical generated outputs during commit
- prevent generated `.mountaineer` writes from retriggering development watchers
- add a regression test proving identical public builds preserve generated files

## Testing

- `cargo fmt --check`
- `cargo test --workspace`